### PR TITLE
Fix minecraft shutdown

### DIFF
--- a/minecraft-server/Dockerfile
+++ b/minecraft-server/Dockerfile
@@ -18,7 +18,7 @@ VOLUME ['/data']
 ADD server.properties /tmp/server.properties
 WORKDIR /data
 
-CMD /start
+CMD [ "/start" ]
 
 ENV MOTD A Minecraft Server Powered by Docker
 ENV LEVEL world


### PR DESCRIPTION
Sorry, just one more for the day. This one fixes 'docker stop ...', which was improperly shutting down the server. With this change, you'll notice that minecraft now actually receives a shutdown signal and exit, rather than being killed (and losing data). 

Fix to allow signals to pass into the container, properly.
'docker stop ...' was resorting to SIGKILL to stop the container,
which results in data loss. This change switches CMD to 'exec' mode,
ensuring signals make their way to the java process so that things
shut down properly.
