### PR TITLE
Fix -version => -mcversion

### DIFF
--- a/start-deployFabric
+++ b/start-deployFabric
@@ -50,7 +50,7 @@ if [[ ! -e $installMarker ]]; then
   tries=3
   set +e
   while ((--tries >= 0)); do
-    java -jar $FABRIC_INSTALLER server -version $VANILLA_VERSION -downloadMinecraft
+    java -jar $FABRIC_INSTALLER server -mcversion $VANILLA_VERSION -downloadMinecraft
     if [[ $? == 0 ]]; then
       break
     fi


### PR DESCRIPTION
Fabric's installer uses `-mcversion` to specify the Minecraft version (https://fabricmc.net/wiki/install). The way the command is written right now it will always use the latest version of MC and ignore the `VERSION` specification.

See https://github.com/itzg/docker-minecraft-server/issues/351 for more discussion.