### PR TITLE
fix duplicate projects subpath

### DIFF
--- a/start-finalSetup02Modpack
+++ b/start-finalSetup02Modpack
@@ -89,7 +89,7 @@ case "X$EFFECTIVE_MANIFEST_URL" in
       do
         if [ ! -f $MOD_DIR/${p}_${f}.jar ]
         then
-          redirect_url="$(curl -Ls -o /dev/null -w %{url_effective} ${CURSE_URL_BASE}/projects/${p})"
+          redirect_url="$(curl -Ls -o /dev/null -w %{url_effective} ${CURSE_URL_BASE}/${p})"
           url="$redirect_url/download/${f}/file"
           echo Downloading curseforge mod $url
           #  Manifest usually doesn't have mod names. Using id should be fine, tho


### PR DESCRIPTION
`CURSE_URL_BASE` already had `/projects` appended to it, missed it by mistake. Originally wrote `redirect_url` assuming `CURSE_URL_BASE` was `https://minecraft.curseforge.com`