### PR TITLE
Only write EULA when it's set to `TRUE`

### DIFF
--- a/start-configuration
+++ b/start-configuration
@@ -6,14 +6,7 @@ shopt -s nullglob
 export HOME=/data
 
 if [ ! -e /data/eula.txt ]; then
-  if [ "$EULA" != "" ]; then
-    echo "# Generated via Docker on $(date)" > eula.txt
-    echo "eula=$EULA" >> eula.txt
-    if [ $? != 0 ]; then
-      echo "ERROR: unable to write eula to /data. Please make sure attached directory is writable by uid=${UID}"
-      exit 2
-    fi
-  else
+  if [ "$EULA" != "TRUE" ]; then
     echo ""
     echo "Please accept the Minecraft EULA at"
     echo "  https://account.mojang.com/documents/minecraft_eula"
@@ -22,7 +15,15 @@ if [ ! -e /data/eula.txt ]; then
     echo ""
     exit 1
   fi
+
+  echo "# Generated via Docker on $(date)" > eula.txt
+  echo "eula=$EULA" >> eula.txt
+  if [ $? != 0 ]; then
+    echo "ERROR: unable to write eula to /data. Please make sure attached directory is writable by uid=${UID}"
+    exit 2
+  fi
 fi
+
 
 echo "Running as uid=$(id -u) gid=$(id -g) with /data as '$(ls -lnd /data)'"
 

--- a/start-configuration
+++ b/start-configuration
@@ -6,6 +6,7 @@ shopt -s nullglob
 export HOME=/data
 
 if [ ! -e /data/eula.txt ]; then
+  EULA="${EULA^^}"
   if [ "$EULA" != "TRUE" ]; then
     echo ""
     echo "Please accept the Minecraft EULA at"


### PR DESCRIPTION
### Issue

When you for example set the `EULA` environment variable to `true` (instead of uppercase `TRUE`) the `eula.txt` is written with a wrong value and the server won't start. After that, it is not possible to change the value using the `EULA` environment variable and you would have to change the file manually, which might be a little complicated for some users when they use docker volumes instead of bind mounts.

### Fix

This pull request fixes this by checking the value to be `TRUE` (uppercase) before writing the `eula.txt` file. For any other value, the request to set the value using `-e EULA=TRUE` is displayed.