### PR TITLE
(improvement) Offsets healthcheck to T+1m

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,7 @@ RUN apk add --no-cache -U \
 
 RUN pip install mcstatus yq
 
-ARG HEALTHCHECK_DEFAULT_START=5m
-HEALTHCHECK --start-period=${HEALTHCHECK_DEFAULT_START} CMD mcstatus localhost:$SERVER_PORT ping
+HEALTHCHECK --start-period=5m CMD mcstatus localhost:$SERVER_PORT ping
 
 RUN addgroup -g 1000 minecraft \
   && adduser -Ss /bin/false -u 1000 -G minecraft -h /home/minecraft minecraft \

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN apk add --no-cache -U \
 
 RUN pip install mcstatus yq
 
-HEALTHCHECK CMD mcstatus localhost:$SERVER_PORT ping
+HEALTHCHECK --start-period=5m CMD mcstatus localhost:$SERVER_PORT ping
 
 RUN addgroup -g 1000 minecraft \
   && adduser -Ss /bin/false -u 1000 -G minecraft -h /home/minecraft minecraft \

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN apk add --no-cache -U \
 
 RUN pip install mcstatus yq
 
-HEALTHCHECK --start-period=5m CMD mcstatus localhost:$SERVER_PORT ping
+HEALTHCHECK --start-period=1m CMD mcstatus localhost:$SERVER_PORT ping
 
 RUN addgroup -g 1000 minecraft \
   && adduser -Ss /bin/false -u 1000 -G minecraft -h /home/minecraft minecraft \

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,8 @@ RUN apk add --no-cache -U \
 
 RUN pip install mcstatus yq
 
-HEALTHCHECK --start-period=5m CMD mcstatus localhost:$SERVER_PORT ping
+ARG HEALTHCHECK_DEFAULT_START=5m
+HEALTHCHECK --start-period=${HEALTHCHECK_DEFAULT_START} CMD mcstatus localhost:$SERVER_PORT ping
 
 RUN addgroup -g 1000 minecraft \
   && adduser -Ss /bin/false -u 1000 -G minecraft -h /home/minecraft minecraft \


### PR DESCRIPTION
Changes:
   - Added the `--start-period=5m` option to the docker healthcheck which offsets the mcstatus commands by 5 minutes to allow modpacks to complete downloading.