### PR TITLE
(bugfix) download pack only when checksum file does not exist

### DIFF
--- a/start-finalSetup02Modpack
+++ b/start-finalSetup02Modpack
@@ -14,6 +14,7 @@ if [ "$REMOVE_OLD_MODS" = "TRUE" ]; then
   else
     rm -rf /data/mods/*
   fi
+    rm -rf /data/.generic_pack.sum
 fi
 
 # If supplied with a URL for a modpack (simple zip of jars), download it and unpack
@@ -111,7 +112,7 @@ esac
 fi
 
 if [[ "${GENERIC_PACK}" ]]; then
-  if isURL "${GENERIC_PACK}"; then
+  if [ -f /data/.generic_pack.sum && isURL "${GENERIC_PACK}"]; then
     generic_pack_url=${GENERIC_PACK}
     GENERIC_PACK=/tmp/$(basename ${generic_pack_url})
     echo "Downloading generic pack from ${generic_pack_url} ..."


### PR DESCRIPTION
Changes:
   - added test for /data/.generic_pack.sum to exist before downloading the modpack (allows other methods to update the pack including removing this checksum file to update the modpack)
   - added removing /data/.generic_pack.sum automatically when Environment Variable `REMOVE_OLD_MODS` is set to 'TRUE'