### PR TITLE
Fixed JVM_XX_OPTS for FTB servers

### DIFF
--- a/start-minecraftFinalSetup
+++ b/start-minecraftFinalSetup
@@ -102,7 +102,7 @@ if [[ ${TYPE} == "FEED-THE-BEAST" ]]; then
     cat > "${FTB_DIR}/settings-local.sh" <<EOF
 export MIN_RAM="${INIT_MEMORY}"
 export MAX_RAM="${MAX_MEMORY}"
-export JAVA_PARAMETERS="-Xms${INIT_MEMORY} $expandedDOpts"
+export JAVA_PARAMETERS="${JVM_XX_OPTS} -Xms${INIT_MEMORY} ${JVM_OPTS} $expandedDOpts"
 EOF
 
     # patch CurseForge cfg file, if present


### PR DESCRIPTION
Creation of settings-local.sh for FTB instances does not propagate JVM_XX_OPTS and JVM_OPTS into the file, leading to those instances ignoring those parameters.  This fix adds those to the exported JAVA_PARAMETERS env var, which should have the desired effect.