### PR TITLE
docker-versions-create init

### DIFF
--- a/docker-versions-create.sh
+++ b/docker-versions-create.sh
@@ -1,119 +1,77 @@
 #!/bin/bash
 #set -x
-# Use this array to build different versions of the docker container
-version_array=('openjdk:8u212-jre-alpine' \
-  'adoptopenjdk/openjdk8-openj9:alpine' \
-  'adoptopenjdk/openjdk8:alpine-jre' \
-  'adoptopenjdk/openjdk8:alpine-jre-nightly')
-# This variable will determine what build would be the default one (without version)
-defailt_version='openjdk:8u212-jre-alpine'
+# Use this variable to indicate a list of branches that docker hub is watching
+branches_list=('openj9' 'another_name')
 
-function ShowHelp {
-  cat <<EOF
-This script will create and push new docker images to docker hub.
-It will also create a new git branch on github. Please consider merging new brunch with master if you are satisfied with changes.
-To add or remove different version from the build - edit this file and add\remove version from 'version_array'
-By default, it will skip recreation of image if Dockerfile for this image was found in ./versions dir
-
-Usage:
-  docker-versions-create.sh [--help, --ask]
-  --help: shows this massage
-  --ask:  don't skip image recreation and ask if recreation is required for each version.
-EOF
-  exit 0
+function TrapExit {
+  echo "Checking out back in master"
+  git checkout master
 }
 
-function DockerBuild {
-  local container_version docker_file tag_version
-  container_version="$1"
-  docker_file="$2"
-  tag_version=$(echo "$container_version" | tr '/:' '-')
-  cp ./Dockerfile ./versions/"$docker_file"
-  sed -e "s|^FROM.*\$|FROM $container_version|" -i ./versions/"$docker_file"
-  if [[ "$container_version" == "$defailt_version" ]]; then
-    # skipping version tag creation
-    docker build -f ./versions/"$docker_file" -t itzg/minecraft-server .
+trap TrapExit EXIT SIGTERM
+
+test -d ./.git || { echo ".git folder was not found. Please start this script from root directory of the project!";
+  exit 1; }
+
+# Making sure we are in master
+git checkout master
+#Updating git branch list. Cause the branch may be created from diff place
+# Are tags in use? if not - remove --tags
+git fetch --all --tags || { \
+  echo "Can't fetch changes from the remote. Permissions?"; \
+  exit 1; }
+# Updating current master from remote. Cause repo could be changed
+git merge origin/master || { echo "Can't update local master from remote repo!"; \
+  exit 1; }
+
+git_branches=$(git branch -a)
+
+for branch in "${branches_list[@]}"; do
+  if [[ "$git_branches" != *"$branch" ]]; then
+    echo "Can't update $branch because I can't find it in the list of branches."
+    exit 1
   else
-    docker build -f ./versions/"$docker_file" -t itzg/minecraft-server:"$tag_version" .
-  fi
-}
+    echo "Branch $branch found. Working with it."
+    git checkout "$branch" || { echo "Can't checkout into the branch. Don't know the cause."; \
+      exit 1; }
+    proceed='False'
+    while [[ "$proceed" == "False" ]]; do
+      if git merge master; then
+        proceed="True"
+        echo "Branch $branch updated to current master successfully"
+        # pushing changes to remote for this branch
+        git commit -m "Auto merge branch with master" -a
+        # push may fail if remote doesn't have this branch yet. In this case - sending branch
+        git push || git push -u origin "$branch" || { echo "Can't push changes to the origin."; exit 1; }
+      else
+        cat<<EOL
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+Master merge in the branch $branch encountered an error!
+You may try to fix the error and merge again. (Commit changes)
+Or skip this branch merge completely.
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+EOL
+        printf "Should we try again? (y):"
+        read answer
+        if [[ "$answer" == '' ]] || [[ "$answer" == 'y' ]] || [[ "$answer" == 'Y' ]]; then
+          # If you use non-local editor or files are changed in repo
+          cat <<EOL
 
-function GitBranch {
-  local container_version docker_file tag_version
-  container_version="$1"
-  docker_file="$2"
-  tag_version=$(echo "$container_version" | tr '/:' '-')
-  # Recreating git branch if exists
-  if [[ $(git branch -l) == *"$tag_version"* ]]; then
-    git checkout master
-    git branch -D "$tag_version"
-    git push -d origin "$tag_version"
-  fi
-  git checkout -b "$tag_version" || exit 1
-  git add ./versions/*
-  git commit -m "Version $container_version added"
-  git push --set-upstream origin "$tag_version"
-}
+The following commands may encounter an error!
+This is completely fine if the changes were made locally and remote branch doesn't know about them.
 
-function DockerPush {
-  local container_version docker_file tag_version
-  container_version="$1"
-  docker_file="$2"
-  tag_version=$(echo "$container_version" | tr '/:' '-')
-  if [[ "$container_version" == "$defailt_version" ]]; then
-    docker push itzg/minecraft-server
-  else
-    docker push itzg/minecraft-server:"$tag_version"
+EOL
+          # Updating branch from remote before trying again
+          git checkout master
+          git fetch --all
+          git pull -a
+          git checkout "$branch"
+          continue
+        else
+          break
+        fi
+      fi
+    done
   fi
-}
 
-#Some checks
-if [[ $# -gt 2 ]]; then
-  echo "This script recieves only one argument"
-  ShowHelp
-elif [[ $# -eq 1 ]]; then
-  case "$1" in
-    '--help' )
-      ShowHelp;;
-    '--ask' )
-      REBUILD_ASK='True';;
-  esac
-fi
-test -e ./Dockerfile || \
-  { echo "Can't find Dockerfile."; \
-  exit 1; }
-test -d ./versions || \
-  mkdir ./versions || \
-  { echo "Can't create directory to store different versions. Please check directory permissions!"; \
-  exit 1; }
-touch ./versions/.test || \
-  { echo "Can't create files inside versions. Please check directory permissions!"; \
-  exit 1; }
-rm -f ./versions/.test
-
-# Working with versions
-for version in "${version_array[@]}"; do
-  echo "Working with $version"
-  version_file_name=$(echo "$version" | tr '/:' '-')
-  version_file_name="Dockerfile-$version_file_name"
-  if [[ -e ./versions/"$version_file_name" ]] && [[ "$REBUILD_ASK" != 'True' ]]; then
-    echo "Version '$version' was found. Skipping"
-    continue
-  elif [[ -e ./versions/"$version_file_name" ]] && [[ "$REBUILD_ASK" == 'True' ]]; then
-    echo "Version '$version' was found. Should we recreate it? [y]"
-    read answer
-    if [[ "$answer" == 'y' ]]; then
-      rm -f ./versions/"$version_file_name"
-      DockerBuild "$version" "$version_file_name" || exit 1
-      GitBranch "$version" "$version_file_name"  || exit 1
-      DockerPush "$version" "$version_file_name" || exit 1
-    else
-      continue
-    fi
-  elif [[ ! -e ./versions/"$version_file_name" ]]; then
-    echo "Version '$version' was not found. Creating"
-    DockerBuild "$version" "$version_file_name" || exit 1
-    GitBranch "$version" "$version_file_name" || exit 1
-    DockerPush "$version" "$version_file_name" || exit 1
-  fi
 done

--- a/docker-versions-create.sh
+++ b/docker-versions-create.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #set -x
 # Use this variable to indicate a list of branches that docker hub is watching
-branches_list=('openj9' 'another_name')
+branches_list=('openj9' 'openj9-nightly')
 
 function TrapExit {
   echo "Checking out back in master"
@@ -15,13 +15,7 @@ test -d ./.git || { echo ".git folder was not found. Please start this script fr
 
 # Making sure we are in master
 git checkout master
-#Updating git branch list. Cause the branch may be created from diff place
-# Are tags in use? if not - remove --tags
-git fetch --all --tags || { \
-  echo "Can't fetch changes from the remote. Permissions?"; \
-  exit 1; }
-# Updating current master from remote. Cause repo could be changed
-git merge origin/master || { echo "Can't update local master from remote repo!"; \
+git pull --all || { echo "Can't pull the repo!"; \
   exit 1; }
 
 git_branches=$(git branch -a)

--- a/docker-versions-create.sh
+++ b/docker-versions-create.sh
@@ -27,7 +27,7 @@ git merge origin/master || { echo "Can't update local master from remote repo!";
 git_branches=$(git branch -a)
 
 for branch in "${branches_list[@]}"; do
-  if [[ "$git_branches" != *"$branch" ]]; then
+  if [[ "$git_branches" != *"$branch"* ]]; then
     echo "Can't update $branch because I can't find it in the list of branches."
     exit 1
   else

--- a/docker-versions-create.sh
+++ b/docker-versions-create.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+#set -x
+# Use this array to build different versions of the docker container
+version_array=('openjdk:8u212-jre-alpine' \
+  'adoptopenjdk/openjdk8-openj9:alpine' \
+  'adoptopenjdk/openjdk8:alpine-jre' \
+  'adoptopenjdk/openjdk8:alpine-jre-nightly')
+# This variable will determine what build would be the default one (without version)
+defailt_version='openjdk:8u212-jre-alpine'
+
+function ShowHelp {
+  cat <<EOF
+This script will create and push new docker images to docker hub.
+It will also create a new git branch on github. Please consider merging new brunch with master if you are satisfied with changes.
+To add or remove different version from the build - edit this file and add\remove version from 'version_array'
+By default, it will skip recreation of image if Dockerfile for this image was found in ./versions dir
+
+Usage:
+  docker-versions-create.sh [--help, --ask]
+  --help: shows this massage
+  --ask:  don't skip image recreation and ask if recreation is required for each version.
+EOF
+  exit 0
+}
+
+function DockerBuild {
+  local container_version docker_file tag_version
+  container_version="$1"
+  docker_file="$2"
+  tag_version=$(echo "$container_version" | tr '/:' '-')
+  cp ./Dockerfile ./versions/"$docker_file"
+  sed -e "s|^FROM.*\$|FROM $container_version|" -i ./versions/"$docker_file"
+  if [[ "$container_version" == "$defailt_version" ]]; then
+    # skipping version tag creation
+    docker build -f ./versions/"$docker_file" -t itzg/minecraft-server .
+  else
+    docker build -f ./versions/"$docker_file" -t itzg/minecraft-server:"$tag_version" .
+  fi
+}
+
+function GitBranch {
+  local container_version docker_file tag_version
+  container_version="$1"
+  docker_file="$2"
+  tag_version=$(echo "$container_version" | tr '/:' '-')
+  # Recreating git branch if exists
+  if [[ $(git branch -l) == *"$tag_version"* ]]; then
+    git checkout master
+    git branch -D "$tag_version"
+    git push -d origin "$tag_version"
+  fi
+  git checkout -b "$tag_version" || exit 1
+  git add ./versions/*
+  git commit -m "Version $container_version added"
+  git push --set-upstream origin "$tag_version"
+}
+
+function DockerPush {
+  local container_version docker_file tag_version
+  container_version="$1"
+  docker_file="$2"
+  tag_version=$(echo "$container_version" | tr '/:' '-')
+  if [[ "$container_version" == "$defailt_version" ]]; then
+    docker push itzg/minecraft-server
+  else
+    docker push itzg/minecraft-server:"$tag_version"
+  fi
+}
+
+#Some checks
+if [[ $# -gt 2 ]]; then
+  echo "This script recieves only one argument"
+  ShowHelp
+elif [[ $# -eq 1 ]]; then
+  case "$1" in
+    '--help' )
+      ShowHelp;;
+    '--ask' )
+      REBUILD_ASK='True';;
+  esac
+fi
+test -e ./Dockerfile || \
+  { echo "Can't find Dockerfile."; \
+  exit 1; }
+test -d ./versions || \
+  mkdir ./versions || \
+  { echo "Can't create directory to store different versions. Please check directory permissions!"; \
+  exit 1; }
+touch ./versions/.test || \
+  { echo "Can't create files inside versions. Please check directory permissions!"; \
+  exit 1; }
+rm -f ./versions/.test
+
+# Working with versions
+for version in "${version_array[@]}"; do
+  echo "Working with $version"
+  version_file_name=$(echo "$version" | tr '/:' '-')
+  version_file_name="Dockerfile-$version_file_name"
+  if [[ -e ./versions/"$version_file_name" ]] && [[ "$REBUILD_ASK" != 'True' ]]; then
+    echo "Version '$version' was found. Skipping"
+    continue
+  elif [[ -e ./versions/"$version_file_name" ]] && [[ "$REBUILD_ASK" == 'True' ]]; then
+    echo "Version '$version' was found. Should we recreate it? [y]"
+    read answer
+    if [[ "$answer" == 'y' ]]; then
+      rm -f ./versions/"$version_file_name"
+      DockerBuild "$version" "$version_file_name" || exit 1
+      GitBranch "$version" "$version_file_name"  || exit 1
+      DockerPush "$version" "$version_file_name" || exit 1
+    else
+      continue
+    fi
+  elif [[ ! -e ./versions/"$version_file_name" ]]; then
+    echo "Version '$version' was not found. Creating"
+    DockerBuild "$version" "$version_file_name" || exit 1
+    GitBranch "$version" "$version_file_name" || exit 1
+    DockerPush "$version" "$version_file_name" || exit 1
+  fi
+done


### PR DESCRIPTION
I've created a small sh script to simplify docker container creation with version.
Hope it will speedup [#360 ](https://github.com/itzg/docker-minecraft-server/issues/360) issue resolution. 
I've tested it to the point of actual pushes. As I don't know the environment configuration of your workstation - I assume the script to be changed to work in your environment. 
Upon completion you need to do some manual steps:
1. Merge github branch that the script created
2. Update docker hub description and add new version with link to a dockerfile that was created by this script. 