### PR TITLE
Better handle CurseForge manifest.json

### DIFF
--- a/start-finalSetup02Modpack
+++ b/start-finalSetup02Modpack
@@ -78,10 +78,18 @@ done
 fi
 
 if [[ "$MANIFEST" ]]; then
-EFFECTIVE_MANIFEST_URL=$(curl -Ls -o /dev/null -w %{url_effective} $MANIFEST)
-case "X$EFFECTIVE_MANIFEST_URL" in
+    if [[ -e "$MANIFEST" ]]; then
+        EFFECTIVE_MANIFEST_FILE=$MANIFEST
+    elif isURL "$MANIFEST"; then
+        EFFECTIVE_MANIFEST_FILE=/tmp/manifest.json
+        curl -Ls -o $EFFECTIVE_MANIFEST_FILE "$MANIFEST"
+    else
+        echo "MANIFEST='$MANIFEST' is not a valid manifest url or location"
+    fi
+
+case "X$EFFECTIVE_MANIFEST_FILE" in
   X*.json)
-    if [ -f "${EFFECTIVE_MANIFEST_URL}" ]; then
+    if [ -f "${EFFECTIVE_MANIFEST_FILE}" ]; then
       MOD_DIR=${FTB_BASE_DIR:-/data}/mods
       if [ ! -d "$MOD_DIR" ]
       then
@@ -89,7 +97,7 @@ case "X$EFFECTIVE_MANIFEST_URL" in
         mkdir -p "$MOD_DIR"
       fi
       echo "Starting manifest download..."
-      cat "${EFFECTIVE_MANIFEST_URL}" | jq -r '.files[] | (.projectID|tostring) + " " + (.fileID|tostring)'| while read -r p f
+      cat "${EFFECTIVE_MANIFEST_FILE}" | jq -r '.files[] | (.projectID|tostring) + " " + (.fileID|tostring)'| while read -r p f
       do
         if [ ! -f $MOD_DIR/${p}_${f}.jar ]
         then

--- a/start-finalSetup02Modpack
+++ b/start-finalSetup02Modpack
@@ -82,9 +82,11 @@ if [[ "$MANIFEST" ]]; then
         EFFECTIVE_MANIFEST_FILE=$MANIFEST
     elif isURL "$MANIFEST"; then
         EFFECTIVE_MANIFEST_FILE=/tmp/manifest.json
-        curl -Ls -o $EFFECTIVE_MANIFEST_FILE "$MANIFEST"
+        EFFECTIVE_MANIFEST_URL=$(curl -Ls -o /dev/null -w %{url_effective} $MANIFEST)
+        curl -Ls -o $EFFECTIVE_MANIFEST_FILE "$EFFECTIVE_MANIFEST_URL"
     else
         echo "MANIFEST='$MANIFEST' is not a valid manifest url or location"
+        exit 2
     fi
 
 case "X$EFFECTIVE_MANIFEST_FILE" in

--- a/start-utils
+++ b/start-utils
@@ -3,7 +3,7 @@
 function isURL {
   local value=$1
 
-  if [[ ${value:0:8} == "https://" || ${value:0:7} = "http://" ]]; then
+  if [[ ${value:0:8} == "https://" || ${value:0:7} == "http://" ]]; then
     return 0
   else
     return 1


### PR DESCRIPTION
Pull request to address issue #413 

Feel free to push back if you don't like the changes. 

* In my changes, I renamed the MANIFEST_URL variable to be MANIFEST_FILE for the block of code that handles the manifest file.
* I first check if the supplied ENV variable MANIFEST is an existing file, and use that.
* Next check is if the supplied MANIFEST is a url.  If so, use curl to download remote manifest.json file and save to /tmp, and use that file for MANIFEST_FILE.
* Last "check" is the else - to catch if it wasn't an existing file and not a URL.  I display a message but chose not to exit/fail because I didn't know if that would break anything else.  It could probably use an exit between lines 87-88.

I also fixed what I believe is a bug in the start-utils isURL function since my changes are using that function.