### PR TITLE
Allow to modify server-ip in server.properties

### DIFF
--- a/start-finalSetup04ServerProperties
+++ b/start-finalSetup04ServerProperties
@@ -43,6 +43,7 @@ function customizeServerProps {
   fi
 
   setServerProp "server-name" "$SERVER_NAME"
+  setServerProp "server-ip" "$SERVER_IP"
   setServerProp "server-port" "$SERVER_PORT"
   setServerProp "motd" "$MOTD"
   setServerProp "allow-nether" "$ALLOW_NETHER"


### PR DESCRIPTION
Needed when your machine has multiple ip adresses assigned and you want to host your server on only one ip instead of allocating all available ips.