### PR TITLE
Allow specify paper build  and don't use legacy gamemode and difficulty

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ up:
 This is the easiest way if you are using an ephemeral `/data` filesystem,
 or downloading a world with the `WORLD` option.
 
-There are two additional volumes that can be mounted; `/mods` and `/config`.  
+There are two additional volumes that can be mounted; `/mods` and `/config`.
 Any files in either of these filesystems will be copied over to the main
 `/data` filesystem before starting Minecraft.
 
@@ -374,7 +374,7 @@ up:
 This is the easiest way if you are using an ephemeral `/data` filesystem,
 or downloading a world with the `WORLD` option.
 
-There is one additional volume that can be mounted; `/plugins`.  
+There is one additional volume that can be mounted; `/plugins`.
 Any files in this filesystem will be copied over to the main
 `/data/plugins` filesystem before starting Minecraft.
 
@@ -385,6 +385,9 @@ in either persistent volumes or a downloadable archive.
 ## Running a PaperSpigot server
 
 Enable PaperSpigot server mode by adding a `-e TYPE=PAPER -e VERSION=1.9.4` to your command-line.
+
+By default the container will run the latest build of [Paper server](https://papermc.io/downloads)
+but you can also choose to run a specific build with `-e PAPERBUILD=205`.
 
     docker run -d -v /path/on/host:/data \
         -e TYPE=PAPER -e VERSION=1.9.4 \
@@ -436,7 +439,7 @@ up:
 This is the easiest way if you are using an ephemeral `/data` filesystem,
 or downloading a world with the `WORLD` option.
 
-There is one additional volume that can be mounted; `/plugins`.  
+There is one additional volume that can be mounted; `/plugins`.
 Any files in this filesystem will be copied over to the main
 `/data/plugins` filesystem before starting Minecraft.
 
@@ -451,8 +454,8 @@ but note the following additional steps needed...
 
 You need to specify a modpack to run, using the `FTB_SERVER_MOD` or `CF_SERVER_MOD` environment
 variable. An FTB/CurseForge server modpack is available together with its respective
-client modpack on https://www.feed-the-beast.com under "Additional Files." Similar you can
-locate the modpacks for CurseForge at https://www.curseforge.com/minecraft/modpacks .
+client modpack on <https://www.feed-the-beast.com> under "Additional Files." Similar you can
+locate the modpacks for CurseForge at <https://www.curseforge.com/minecraft/modpacks> .
 
 Now you can add a `-e FTB_SERVER_MOD=name_of_modpack.zip` to your command-line.
 
@@ -490,7 +493,7 @@ To use these packs you will need to:
 - Specify the manifest location with env var `MANIFEST=/data/FeedTheBeast/manifest`
 - Pick a relevant ServerStart.sh and potentially settings.cfg and put them in `/data/FeedTheBeast`
 
-An example of the latter would be to use https://github.com/AllTheMods/Server-Scripts
+An example of the latter would be to use <https://github.com/AllTheMods/Server-Scripts>
 There, you'll find that all you have to do is put `ServerStart.sh` and `settings.cfg` into
 `/data/FeedTheBeast`, taking care to update `settings.cfg` to specify your desired version
 of minecraft and forge. You can do this in the cli with something like:
@@ -588,7 +591,7 @@ up:
 This is the easiest way if you are using an ephemeral `/data` filesystem,
 or downloading a world with the `WORLD` option.
 
-There are two additional volumes that can be mounted; `/mods` and `/config`.  
+There are two additional volumes that can be mounted; `/mods` and `/config`.
 Any files in either of these filesystems will be copied over to the main
 `/data` filesystem before starting Minecraft.
 
@@ -987,7 +990,7 @@ Allows users to use flight on your server while in Survival mode, if they have a
 
     -e ALLOW_FLIGHT=TRUE|FALSE
 
-### Other server property mappings:
+### Other server property mappings
 
 Environment Variable | Server Property
 ---------------------|-----------------

--- a/start-deployPaper
+++ b/start-deployPaper
@@ -3,9 +3,10 @@
 . /start-utils
 
 export SERVER=paper_server-${VANILLA_VERSION}.jar
+PAPERBUILD=${PAPERBUILD:-LATEST}
 if [ ! -f "$SERVER" ] || [ -n "$FORCE_REDOWNLOAD" ]; then
-    downloadUrl=${PAPER_DOWNLOAD_URL:-https://papermc.io/api/v1/paper/${VANILLA_VERSION}/latest/download}
-    log "Downloading Paper $VANILLA_VERSION from $downloadUrl ..."
+    downloadUrl=${PAPER_DOWNLOAD_URL:-https://papermc.io/api/v1/paper/${VANILLA_VERSION}/${PAPERBUILD}/download}
+    log "Downloading Paper $VANILLA_VERSION (build $PAPERBUILD) from $downloadUrl ..."
     curl -fsSL -o "$SERVER" "$downloadUrl"
     if [ ! -f "$SERVER" ]; then
       log "ERROR: failed to download from $downloadUrl (status=$?)"

--- a/start-deployPaper
+++ b/start-deployPaper
@@ -2,8 +2,9 @@
 
 . /start-utils
 
-export SERVER=paper_server-${VANILLA_VERSION}.jar
 PAPERBUILD=${PAPERBUILD:-LATEST}
+export SERVER=paper_server-${VANILLA_VERSION}-${PAPERBUILD}.jar
+
 if [ ! -f "$SERVER" ] || [ -n "$FORCE_REDOWNLOAD" ]; then
     downloadUrl=${PAPER_DOWNLOAD_URL:-https://papermc.io/api/v1/paper/${VANILLA_VERSION}/${PAPERBUILD}/download}
     log "Downloading Paper $VANILLA_VERSION (build $PAPERBUILD) from $downloadUrl ..."

--- a/start-finalSetup04ServerProperties
+++ b/start-finalSetup04ServerProperties
@@ -81,16 +81,32 @@ function customizeServerProps {
   if [ -n "$DIFFICULTY" ]; then
     case $DIFFICULTY in
       peaceful|0)
-        DIFFICULTY=0
+        if versionLessThan 1.13; then
+          DIFFICULTY=0
+        else
+          DIFFICULTY=peaceful
+        fi
         ;;
       easy|1)
-        DIFFICULTY=1
+        if versionLessThan 1.13; then
+          DIFFICULTY=1
+        else
+          DIFFICULTY=easy
+        fi
         ;;
       normal|2)
-        DIFFICULTY=2
+        if versionLessThan 1.13; then
+          DIFFICULTY=2
+        else
+          DIFFICULTY=normal
+        fi
         ;;
       hard|3)
-        DIFFICULTY=3
+        if versionLessThan 1.13; then
+          DIFFICULTY=3
+        else
+          DIFFICULTY=hard
+        fi
         ;;
       *)
         log "DIFFICULTY must be peaceful, easy, normal, or hard."
@@ -104,19 +120,33 @@ function customizeServerProps {
     log "Setting mode"
     MODE_LC=$( echo $MODE | tr '[:upper:]' '[:lower:]' )
     case $MODE_LC in
-      0|1|2|3)
+      su*|0)
+        if versionLessThan 1.13; then
+          MODE=0
+        else
+          MODE=survival
+        fi
         ;;
-      su*)
-        MODE=0
+      c*|1)
+        if versionLessThan 1.13; then
+          MODE=1
+        else
+          MODE=creative
+        fi
         ;;
-      c*)
-        MODE=1
+      a*|2)
+        if versionLessThan 1.13; then
+          MODE=2
+        else
+          MODE=adventure
+        fi
         ;;
-      a*)
-        MODE=2
-        ;;
-      sp*)
-        MODE=3
+      sp*|3)
+        if versionLessThan 1.13; then
+          MODE=3
+        else
+          MODE=spectator
+        fi
         ;;
       *)
         log "ERROR: Invalid game mode: $MODE"


### PR DESCRIPTION
Hello,
This PR add environnent variable `PAPERBUILD` (default to `latest`) to specify wich paper build want download.
This PR also remove legacy usage of numeric `gamemode` and `difficulty`. From 1.14 this is legacy (source: https://minecraft.gamepedia.com/Java_Edition_18w48a)

Thanks