### PR TITLE
Add `resource-pack-sha1` to server.properties

### DIFF
--- a/server.properties
+++ b/server.properties
@@ -22,6 +22,7 @@ snooper-enabled=true
 texture-pack=
 online-mode=true
 resource-pack=
+resource-pack-sha1=
 pvp=true
 difficulty=1
 enable-command-block=true


### PR DESCRIPTION
The `sed` command in
https://github.com/itzg/docker-minecraft-server/blob/master/start-finalSetup04ServerProperties#L16
does nothing if the line is not already in the file.

> [09:14:03] [Server thread/WARN]: You specified a resource pack without providing a sha1 hash. Pack will be updated on the client only if you change the name of the pack.