### PR TITLE
Short hotfix until version helper function is done

### DIFF
--- a/start-deployBukkitSpigot
+++ b/start-deployBukkitSpigot
@@ -20,7 +20,16 @@ function buildSpigotFromSource {
     cat /data/spigot_build.log
     exit 1
   fi
-  mv craftbukkit-*.jar /data/${SERVER}
+  if [  $VANILLA_VERSION != "1.15.2" -a \
+        $VANILLA_VERSION != "1.15.1" -a \
+        $VANILLA_VERSION != "1.15" -a \
+        $VANILLA_VERSION != "1.14.4" -a \
+        $VANILLA_VERSION != "1.14.3" -a \
+        $VANILLA_VERSION != "1.14.2" -a \
+        $VANILLA_VERSION != "1.14.1" -a \
+        $VANILLA_VERSION != "1.14" ]
+    mv craftbukkit-*.jar /data/${SERVER}
+  fi
   log "Cleaning up"
   rm -rf /data/temp
   cd /data

--- a/start-deployBukkitSpigot
+++ b/start-deployBukkitSpigot
@@ -27,7 +27,7 @@ function buildSpigotFromSource {
         $VANILLA_VERSION != "1.14.3" -a \
         $VANILLA_VERSION != "1.14.2" -a \
         $VANILLA_VERSION != "1.14.1" -a \
-        $VANILLA_VERSION != "1.14" ]
+        $VANILLA_VERSION != "1.14" ]; then
     mv craftbukkit-*.jar /data/${SERVER}
   fi
   log "Cleaning up"


### PR DESCRIPTION
This hotfix helps with the different behaviour of BuildTools.jar in 1.14 and above. It's a bit sketchy, but without it, this docker is unusable with Spigot 1.14 or newer right now.