### PR TITLE
upgrade base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8u212-jre-alpine
+FROM openjdk:8u252-jre-alpine
 
 LABEL maintainer "itzg"
 


### PR DESCRIPTION
This should fix aarch64, see https://github.com/itzg/docker-minecraft-server/issues/316#issuecomment-631755949 and the comment before it.

As of yet untested, but a version bump is probably in order anyways.