### PR TITLE
Refactored autopause setup into its own start-file

### DIFF
--- a/start-autopause
+++ b/start-autopause
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+. /start-utils
+
+log "Autopause functionality enabled"
+
+# update server port to listen to
+regseq="^\s*sequence\s*=\s*$SERVER_PORT\s*$"
+linenum=$(grep -nm1 sequence /autopause/knockd-config.cfg | cut -d : -f 1 | tail -n1)
+if ! [[ $(awk "NR==$linenum" /autopause/knockd-config.cfg) =~ $regseq ]]; then
+  sed -i "${linenum}s/sequence.*/sequence = $SERVER_PORT/" /autopause/knockd-config.cfg
+  log "Updated server port in knockd config"
+fi
+# update rcon port to listen to
+regseq="^\s*sequence\s*=\s*$RCON_PORT\s*$"
+linenum=$(grep -nm2 sequence /autopause/knockd-config.cfg | cut -d : -f 1 | tail -n1)
+if ! [[ $(awk "NR==$linenum" /autopause/knockd-config.cfg) =~ $regseq ]]; then
+  sed -i "${linenum}s/sequence.*/sequence = $RCON_PORT/" /autopause/knockd-config.cfg
+  log "Updated rcon port in knockd config"
+fi
+
+if ! [[ $AUTOPAUSE_PERIOD =~ ^[0-9]+$ ]]; then
+  AUTOPAUSE_PERIOD=10
+  export AUTOPAUSE_PERIOD
+  log "Warning: AUTOPAUSE_PERIOD is not numeric, set to 10 (seconds)"
+fi
+if [ "$AUTOPAUSE_PERIOD" -eq "0" ] ; then
+  AUTOPAUSE_PERIOD=10
+  export AUTOPAUSE_PERIOD
+  log "Warning: AUTOPAUSE_PERIOD must not be 0, set to 10 (seconds)"
+fi
+if ! [[ $AUTOPAUSE_TIMEOUT_KN =~ ^[0-9]+$ ]] ; then
+  AUTOPAUSE_TIMEOUT_KN=120
+  export AUTOPAUSE_TIMEOUT_KN
+  log "Warning: AUTOPAUSE_TIMEOUT_KN is not numeric, set to 120 (seconds)"
+fi
+if ! [[ $AUTOPAUSE_TIMEOUT_EST =~ ^[0-9]+$ ]] ; then
+  AUTOPAUSE_TIMEOUT_EST=3600
+  export AUTOPAUSE_TIMEOUT_EST
+  log "Warning: AUTOPAUSE_TIMEOUT_EST is not numeric, set to 3600 (seconds)"
+fi
+if ! [[ $AUTOPAUSE_TIMEOUT_INIT =~ ^[0-9]+$ ]] ; then
+  AUTOPAUSE_TIMEOUT_INIT=600
+  export AUTOPAUSE_TIMEOUT_INIT
+  log "Warning: AUTOPAUSE_TIMEOUT_INIT is not numeric, set to 600 (seconds)"
+fi
+
+if [[ -n $MAX_TICK_TIME ]] ; then
+  log "Warning: MAX_TICK_TIME is non-default, for autopause to work properly, this check should be disabled (-1 for versions >= 1.8.1)"
+else
+  if versionLessThan 1.8.1; then
+    # 10 years
+    MAX_TICK_TIME=315360000000
+  else
+    MAX_TICK_TIME=-1
+  fi
+  export MAX_TICK_TIME
+fi
+
+/autopause/autopause-daemon.sh &

--- a/start-configuration
+++ b/start-configuration
@@ -69,62 +69,7 @@ cd /data || exit 1
 export ORIGINAL_TYPE=${TYPE^^}
 
 if isTrue "${ENABLE_AUTOPAUSE}"; then
-  log "Autopause functionality enabled"
-
-  # update server port to listen to
-  regseq="^\s*sequence\s*=\s*$SERVER_PORT\s*$"
-  linenum=$(grep -nm1 sequence /autopause/knockd-config.cfg | cut -d : -f 1 | tail -n1)
-  if ! [[ $(awk "NR==$linenum" /autopause/knockd-config.cfg) =~ $regseq ]]; then
-    sed -i "${linenum}s/sequence.*/sequence = $SERVER_PORT/" /autopause/knockd-config.cfg
-    log "Updated server port in knockd config"
-  fi
-  # update rcon port to listen to
-  regseq="^\s*sequence\s*=\s*$RCON_PORT\s*$"
-  linenum=$(grep -nm2 sequence /autopause/knockd-config.cfg | cut -d : -f 1 | tail -n1)
-  if ! [[ $(awk "NR==$linenum" /autopause/knockd-config.cfg) =~ $regseq ]]; then
-    sed -i "${linenum}s/sequence.*/sequence = $RCON_PORT/" /autopause/knockd-config.cfg
-    log "Updated rcon port in knockd config"
-  fi
-
-  if ! [[ $AUTOPAUSE_PERIOD =~ ^[0-9]+$ ]]; then
-    AUTOPAUSE_PERIOD=10
-    export AUTOPAUSE_PERIOD
-    log "Warning: AUTOPAUSE_PERIOD is not numeric, set to 10 (seconds)"
-  fi
-  if [ "$AUTOPAUSE_PERIOD" -eq "0" ] ; then
-    AUTOPAUSE_PERIOD=10
-    export AUTOPAUSE_PERIOD
-    log "Warning: AUTOPAUSE_PERIOD must not be 0, set to 10 (seconds)"
-  fi
-  if ! [[ $AUTOPAUSE_TIMEOUT_KN =~ ^[0-9]+$ ]] ; then
-    AUTOPAUSE_TIMEOUT_KN=120
-    export AUTOPAUSE_TIMEOUT_KN
-    log "Warning: AUTOPAUSE_TIMEOUT_KN is not numeric, set to 120 (seconds)"
-  fi
-  if ! [[ $AUTOPAUSE_TIMEOUT_EST =~ ^[0-9]+$ ]] ; then
-    AUTOPAUSE_TIMEOUT_EST=3600
-    export AUTOPAUSE_TIMEOUT_EST
-    log "Warning: AUTOPAUSE_TIMEOUT_EST is not numeric, set to 3600 (seconds)"
-  fi
-  if ! [[ $AUTOPAUSE_TIMEOUT_INIT =~ ^[0-9]+$ ]] ; then
-    AUTOPAUSE_TIMEOUT_INIT=600
-    export AUTOPAUSE_TIMEOUT_INIT
-    log "Warning: AUTOPAUSE_TIMEOUT_INIT is not numeric, set to 600 (seconds)"
-  fi
-
-  if [[ -n $MAX_TICK_TIME ]] ; then
-    log "Warning: MAX_TICK_TIME is non-default, for autopause to work properly, this check should be disabled (-1 for versions >= 1.8.1)"
-  else
-    if versionLessThan 1.8.1; then
-      # 10 years
-      MAX_TICK_TIME=315360000000
-    else
-      MAX_TICK_TIME=-1
-    fi
-    export MAX_TICK_TIME
-  fi
-
-  /autopause/autopause-daemon.sh &
+  /start-autopause
 fi
 
 log "Resolving type given ${TYPE}"


### PR DESCRIPTION
@Oekn5w, looking again at `start-configuration` it seemed like it would be good to refactor the setup code for autopause into its own file to ease maintainability. Can you double check the refactoring for me?