### PR TITLE
Add ttf-dejavu to package list

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,8 @@ RUN apk add --no-cache -U \
   rsync \
   nano \
   sudo \
-  knock
+  knock \
+  ttf-dejavu
 
 RUN addgroup -g 1000 minecraft \
   && adduser -Ss /bin/false -u 1000 -G minecraft -h /home/minecraft minecraft \


### PR DESCRIPTION
Some Spigot plugins (namely BannerBoard and InteractiveBoard that I've tested) use the Java2D graphics library to render in-game maps from images, text, etc. server side. Unfortunately Java2D will crash if it can't find at least one system font when it calls sun.java2d.HeadlessGraphicsEnvironment.getAvailableFontFamilyNames() causing any plugin that uses this API to fail to load.

This isn't a problem on most systems as almost every distro's openJRE package marks fontconfig or dejavu as a dependency to prevent issues like this, however openJDK's alpine images don't for some reason (presumably  because you wouldn't normally need font access in a headless environment except for extreme edge cases).

This change simply adds ttf-dejavu to the APK list which solves this issue for both of these plugins (and presumably others that exist that use this method).