### PR TITLE
Updated worldDest to use FTB_DIR

### DIFF
--- a/start-finalSetup01World
+++ b/start-finalSetup01World
@@ -5,7 +5,7 @@ set -e
 isDebugging && set -x
 
 if [ $TYPE = "FEED-THE-BEAST" ]; then
-  worldDest=$FTB_BASE_DIR/$LEVEL
+  worldDest=$FTB_DIR/$LEVEL
 else
   worldDest=/data/$LEVEL
 fi


### PR DESCRIPTION
FTB modpacks that have a top-level directory named for the modpack will result in extracted and cloned world data landing in the wrong location. This is fixed by extracting FTB worlds to FTB_DIR which is set during start-deployFTB.