### PR TITLE
Move server-icon.png to FTB_DIR if exists

### DIFF
--- a/start-minecraftFinalSetup
+++ b/start-minecraftFinalSetup
@@ -190,6 +190,10 @@ elif [[ ${TYPE} == "FEED-THE-BEAST" ]]; then
       cp -f /data/white-list.txt ${FTB_DIR}/
     fi
 
+    if [ ! -e "${FTB_DIR}/server-icon.png" -a -e /data/server-icon.png ]; then
+      cp -f /data/server-icon.png ${FTB_DIR}/
+    fi
+
     cp -f /data/eula.txt "${FTB_DIR}/"
 
     cat > "${FTB_DIR}/settings-local.sh" <<EOF


### PR DESCRIPTION
server-icon.png does not correctly get copied to the FTB directory when using FTB/CurseForge modpacks