### PR TITLE
Added 'FORCE_WORLD_COPY' environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -947,6 +947,9 @@ read-only volume attachment to ensure the clone source remains pristine.
 docker run ... -v $HOME/worlds:/worlds:ro -e WORLD=/worlds/basic
 ```
 
+### Overwrite world on start
+The world will only be downloaded or copied if it doesn't exist already. Set `FORCE_WORLD_COPY=TRUE` to force overwrite the world on every server start.
+
 ### Downloadable mod/plugin pack for Forge, Bukkit, and Spigot Servers
 
 Like the `WORLD` option above, you can specify the URL of a "mod pack"

--- a/start-finalSetupWorld
+++ b/start-finalSetupWorld
@@ -10,7 +10,7 @@ else
   worldDest=/data/$LEVEL
 fi
 
-if [[ "$WORLD" ]] && [ ! -d "$worldDest" ]; then
+if [[ "$WORLD" ]] &&  isTrue "${FORCE_WORLD_COPY}" || [ ! -d "$worldDest" ]; then
   if isURL $WORLD; then
     curl -fsSL "$WORLD" -o /tmp/world.zip
     zipSrc=/tmp/world.zip
@@ -40,7 +40,7 @@ if [[ "$WORLD" ]] && [ ! -d "$worldDest" ]; then
     mv "$baseDir" "$worldDest"
   else
     log "Cloning world directory from $WORLD ..."
-    cp -r "$WORLD" "$worldDest"
+    rsync --recursive --delete "${WORLD%/}"/ "$worldDest"
   fi
 
   if [ "$TYPE" = "SPIGOT" ]; then

--- a/start-finalSetupWorld
+++ b/start-finalSetupWorld
@@ -37,7 +37,7 @@ if [[ "$WORLD" ]] &&  isTrue "${FORCE_WORLD_COPY}" || [ ! -d "$worldDest" ]; the
       log "ERROR invalid world content"
       exit 1
     fi
-    mv "$baseDir" "$worldDest"
+    rsync --remove-source-files --recursive --delete "$baseDir/" "$worldDest"
   else
     log "Cloning world directory from $WORLD ..."
     rsync --recursive --delete "${WORLD%/}"/ "$worldDest"


### PR DESCRIPTION
Setting `FORCE_WORLD_COPY=TRUE` will overwrite the world on server start.