### PR TITLE
Use -prune for "REPLACE_ENV_VARIABLES_EXCLUDE_PATHS" feature.

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,13 @@ There are some limitations to what characters you can use.
 Variables will be replaced in files with the following extensions:
 `.yml`, `.yaml`, `.txt`, `.cfg`, `.conf`, `.properties`.
 
-Specific files can be excluded by listing their name (without path) in the variable `REPLACE_ENV_VARIABLES_EXCLUDES`. Paths can be excluded by listing them in the variable `REPLACE_ENV_VARIABLES_EXCLUDE_PATHS`.
+Specific files can be excluded by listing their name (without path) in the variable `REPLACE_ENV_VARIABLES_EXCLUDES`.
+
+Paths can be excluded by listing them in the variable `REPLACE_ENV_VARIABLES_EXCLUDE_PATHS`. Path
+excludes are recursive. Here is an example:
+```
+REPLACE_ENV_VARIABLES_EXCLUDE_PATHS="/data/plugins/Essentials/userdata/ /data/plugins/MyPlugin/"
+```
 
 Here is a full example where we want to replace values inside a `database.yml`.
 

--- a/start-finalSetupEnvVariables
+++ b/start-finalSetupEnvVariables
@@ -6,15 +6,20 @@
 
 if isTrue "${REPLACE_ENV_VARIABLES}"; then
   log "Replacing env variables in configs that match the prefix $ENV_VARIABLE_PREFIX..."
-
   findExcludes=
+
+  # File excludes
   for f in ${REPLACE_ENV_VARIABLES_EXCLUDES}; do
     findExcludes="${findExcludes} -not -name $f"
   done
-  for p in ${REPLACE_ENV_VARIABLES_EXCLUDE_PATHS}; do
-    findExcludes="${findExcludes} -not -path \"*$p*\""
-  done
-  isDebugging && echo "Using find exclusion: $findExcludes"
+
+  # Directory excludes (recursive)
+  dirExcludes=$(join_by " -o -path " ${REPLACE_ENV_VARIABLES_EXCLUDE_PATHS})
+  if [[ $dirExcludes ]]; then
+    findExcludes+=" -type d ( -path ${dirExcludes} ) -prune"
+  fi
+
+  isDebugging && echo "Using find exclusions: $findExcludes"
 
   while IFS='=' read -r name value ; do
     # check if name of env variable matches the prefix

--- a/start-utils
+++ b/start-utils
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+function join_by { local d=$1; shift; echo -n "$1"; shift; printf "%s" "${@/#/$d}"; }
+
 function isURL {
   local value=$1
 


### PR DESCRIPTION
Using the -prune option to exclude paths in "find" should be a lot more efficient than -not since it prevents find from traversing excluded directories / files.