### PR TITLE
Fixed "REPLACE_ENV_VARIABLES_EXCLUDE_PATHS" breaking cfg replacer when set

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ Specific files can be excluded by listing their name (without path) in the varia
 Paths can be excluded by listing them in the variable `REPLACE_ENV_VARIABLES_EXCLUDE_PATHS`. Path
 excludes are recursive. Here is an example:
 ```
-REPLACE_ENV_VARIABLES_EXCLUDE_PATHS="/data/plugins/Essentials/userdata/ /data/plugins/MyPlugin/"
+REPLACE_ENV_VARIABLES_EXCLUDE_PATHS="/data/plugins/Essentials/userdata /data/plugins/MyPlugin"
 ```
 
 Here is a full example where we want to replace values inside a `database.yml`.

--- a/start-finalSetupEnvVariables
+++ b/start-finalSetupEnvVariables
@@ -6,20 +6,21 @@
 
 if isTrue "${REPLACE_ENV_VARIABLES}"; then
   log "Replacing env variables in configs that match the prefix $ENV_VARIABLE_PREFIX..."
-  findExcludes=
 
   # File excludes
+  fileExcludes=
   for f in ${REPLACE_ENV_VARIABLES_EXCLUDES}; do
-    findExcludes="${findExcludes} -not -name $f"
+    fileExcludes="${fileExcludes} -not -name $f"
   done
 
   # Directory excludes (recursive)
   dirExcludes=$(join_by " -o -path " ${REPLACE_ENV_VARIABLES_EXCLUDE_PATHS})
   if [[ $dirExcludes ]]; then
-    findExcludes+=" -type d ( -path ${dirExcludes} ) -prune"
+    dirExcludes=" -type d ( -path ${dirExcludes} ) -prune -o"
   fi
 
-  isDebugging && echo "Using find exclusions: $findExcludes"
+  isDebugging && echo "Using find file exclusions: $fileExcludes"
+  isDebugging && echo "Using find directory exclusions: $dirExcludes"
 
   while IFS='=' read -r name value ; do
     # check if name of env variable matches the prefix
@@ -34,10 +35,12 @@ if isTrue "${REPLACE_ENV_VARIABLES}"; then
       fi
 
       log "Replacing $name with $value ..."
-      find /data/ -type f \
+      find /data/ \
+          $dirExcludes \
+          -type f \
           \( -name "*.yml" -or -name "*.yaml" -or -name "*.txt" -or -name "*.cfg" \
           -or -name "*.conf" -or -name "*.properties" \) \
-          $findExcludes \
+          $fileExcludes \
           -exec sed -i 's#${'"$name"'}#'"$value"'#g' {} \;
     fi
   done < <(env)


### PR DESCRIPTION
Turns out there were multiple issues with how we constructed the find command when using directory excludes. This led to the find command not replacing any configurations when `REPLACE_ENV_VARIABLES_EXCLUDE_PATHS` was set.

This is the configuration in which I got it working. Tested it locally with directories with 2000+ files. The speedup is really good :slightly_smiling_face:.
I'm not an expert on bash or the find command so please let me know if there are issues with the patch.