### PR TITLE
Adds EULA to the 'quickstart' command in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ latest snapshot. See the _Versions_ section below for more information.
 
 To simply use the latest stable version, run
 
-    docker run -d -p 25565:25565 --name mc itzg/minecraft-server -e EULA=TRUE
+    docker run -d -p 25565:25565 --name mc -e EULA=TRUE itzg/minecraft-server
 
 where the standard server port, 25565, will be exposed on your host machine.
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ latest snapshot. See the _Versions_ section below for more information.
 
 To simply use the latest stable version, run
 
-    docker run -d -p 25565:25565 --name mc itzg/minecraft-server
+    docker run -d -p 25565:25565 --name mc itzg/minecraft-server -e EULA=TRUE
 
 where the standard server port, 25565, will be exposed on your host machine.
 
@@ -35,6 +35,7 @@ With that you can easily view the logs, stop, or re-start the container:
     docker stop mc
 
     docker start mc
+*Be sure to always include `-e EULA=TRUE` in your commands, as Mojang/Microsoft now requires EULA acceptance.*
 
 ## Looking for a Bedrock Dedicated Server
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ With that you can easily view the logs, stop, or re-start the container:
     docker stop mc
 
     docker start mc
-*Be sure to always include `-e EULA=TRUE` in your commands, as Mojang/Microsoft now requires EULA acceptance.*
+*Be sure to always include `-e EULA=TRUE` in your commands, as Mojang/Microsoft requires EULA acceptance.*
 
 ## Looking for a Bedrock Dedicated Server
 


### PR DESCRIPTION
most people will start with the quickstart command, which won't work anymore now that EULA is required.  Modified the sample quickstart to include the new minimum params.