### PR TITLE
IPv6 support for autopause

### DIFF
--- a/files/autopause/autopause-fcns.sh
+++ b/files/autopause/autopause-fcns.sh
@@ -13,7 +13,7 @@ rcon_client_exists() {
 }
 
 mc_server_listening() {
-  [[ -n $(netstat -tln | grep "0.0.0.0:$SERVER_PORT" | grep LISTEN) ]]
+  [[ -n $(netstat -tln | grep -e "0.0.0.0:$SERVER_PORT" -e ":::$SERVER_PORT" | grep LISTEN) ]]
 }
 
 java_clients_connected() {
@@ -29,7 +29,7 @@ java_clients_connected() {
   # remember, that the host network mode does not work with autopause because of the knockd utility
   for (( i=0; i<${#connections[@]}; i++ ))
   do
-    if [[ ! $(echo "${connections[$i]}" | awk '{print $5}') =~ ^\s*127\.0\.0\.1:.*$ ]] ; then
+    if [[ ! $(echo "${connections[$i]}" | awk '{print $5}') =~ ^localhost$|^127(?:\.[0-9]+){0,2}\.[0-9]+$|^(?:0*\:)*?:?0*1$ ]] ; then
       # not localhost
       return 0
     fi


### PR DESCRIPTION
The AutoPause Feature currently only supports IPv4, this PR fixes just that. Tested and working as expected on a GCP Server. The regex for matching loopback addresses was taken from [Stackoverflow](https://stackoverflow.com/a/8426365/6500551), seems to work just fine, but I also manually checked some edge cases