### PR TITLE
Convert to AdoptOpenJDK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM adoptopenjdk:latest
 
 LABEL org.opencontainers.image.authors="Geoff Bourne <itzgeoff@gmail.com>"
 


### PR DESCRIPTION
This changes the base image to the one from AdoptOpenJDK's latest JDK (they don't provide a tag for 'JRE-latest'). AdoptOpenJDK is currently at 15.x, which includes Shenandoah GC and other improvements, and is based on Ubuntu images just like the 'multiarch' image is.

I'll issue some PRs for other changes that actually make use of the new features shortly.