### PR TITLE
Remove distro-provided JRE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ LABEL org.opencontainers.image.authors="Geoff Bourne <itzgeoff@gmail.com>"
 RUN apt-get update \
   && DEBIAN_FRONTEND=noninteractive \
   apt-get install -y \
-    openjdk-8-jre-headless \
     imagemagick \
     gosu \
     curl wget \


### PR DESCRIPTION
We don't need Java 8 from Ubuntu, we have 15 from AdoptOpenJDK.