### PR TITLE
feat: improve REMOVE_OLD_MODS option

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,13 +301,13 @@ or downloading a world with the `WORLD` option.
 
 There are two additional volumes that can be mounted; `/mods` and `/config`.
 Any files in either of these filesystems will be copied over to the main
-`/data` filesystem before starting Minecraft. If you want old mods to be removed as the `/mods` content is updated, then add `-e REMOVE_OLD_MODS=TRUE`.
+`/data` filesystem before starting Minecraft. If you want old mods to be removed as the `/mods` content is updated, then add `-e REMOVE_OLD_MODS=TRUE`. If you are running a `BUKKIT` distribution this will affect all files inside the `plugins/` directory. You can fine tune the removal process by specifing the `REMOVE_OLD_MODS_INCLUDE` and `REMOVE_OLD_MODS_EXCLUDE` variables. By default everything will be removed. You can also specify the `REMOVE_OLD_MODS_DEPTH` (default 16) variable to only delete files up to a certain level.
+
+> For example: `-e REMOVE_OLD_MODS=TRUE -e REMOVE_OLD_MODS_INCLUDE="*.jar" -e REMOVE_OLD_MODS_DEPTH=1` will remove all old jar files that are directly inside the `plugins/` or `mods/` directory.
 
 This works well if you want to have a common set of modules in a separate
 location, but still have multiple worlds with different server requirements
 in either persistent volumes or a downloadable archive.
-
-
 
 ### Replacing variables inside configs
 

--- a/start-finalSetupModpack
+++ b/start-finalSetupModpack
@@ -11,12 +11,16 @@ fi
 CURSE_URL_BASE=${CURSE_URL_BASE:-https://minecraft.curseforge.com/projects}
 
 # Remove old mods/plugins
-if [ "$REMOVE_OLD_MODS" = "TRUE" ]; then
-  if [ "$TYPE" = "SPIGOT" ]; then
-    rm -rf /data/plugins/*
-  else
-    rm -rf /data/mods/*
-  fi
+if isTrue ${REMOVE_OLD_MODS}; then
+  remove_mods_dest="/data/mods"
+  case ${TYPE} in
+    SPIGOT|BUKKIT|PAPER)
+      remove_mods_dest="/data/plugins"
+      ;;
+  esac
+
+  log "Removing old mods in $remove_mods_dest..."
+  find $remove_mods_dest -mindepth 1 -maxdepth ${REMOVE_OLD_MODS_DEPTH:-16} -wholename "${REMOVE_OLD_MODS_INCLUDE:-*}" -not -wholename "${REMOVE_OLD_MODS_EXCLUDE}" -delete
 fi
 
 # If supplied with a URL for a modpack (simple zip of jars), download it and unpack

--- a/start-minecraftFinalSetup
+++ b/start-minecraftFinalSetup
@@ -54,9 +54,6 @@ done
 if [ -d /mods ]; then
   log "Copying any mods over..."
   mkdir -p /data/mods
-  if isTrue "${REMOVE_OLD_MODS}"; then
-    rsyncArgs=(--delete)
-  fi
   rsync -a --out-format="update:%f:Last Modified %M" "${rsyncArgs[@]}" --prune-empty-dirs --update /mods /data
 fi
 


### PR DESCRIPTION
A `REMOVE_OLD_MODS_INCLUDE`, `REMOVE_OLD_MODS_EXCLUDE` and `REMOVE_OLD_MODS_DEPTH` option can now be specified to filter the plugins or mods that should be deleted.

`REMOVE_OLD_MODS_INCLUDE` defaults to `*` which mirrors the current behauvior of deleting everything inside the `plugins` or `mods` directory.

Closes #662