### PR TITLE
feat: add COPY_CONFIG_DEST option

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,10 @@ This works well if you want to have a common set of modules in a separate
 location, but still have multiple worlds with different server requirements
 in either persistent volumes or a downloadable archive.
 
+You can specify the destination of the configs that are located inside the `/config` mount by setting the `COPY_CONFIG_DEST` variable. The configs are copied recursivly to the `/data/config` directory by default. If a file was updated directly inside the `/data/*` directoy and is newer than the file in the `/config/*` mount it will not be overriden.
+
+> For example: `-v ./config:/config -e COPY_CONFIG_DEST=/data` will allow you to copy over your `bukkit.yml` and so on directly into the server directory.
+
 ### Replacing variables inside configs
 
 Sometimes you have mods or plugins that require configuration information that is only available at runtime.

--- a/start-minecraftFinalSetup
+++ b/start-minecraftFinalSetup
@@ -2,6 +2,8 @@
 
 . ${SCRIPTS:-/}start-utils
 
+: ${COPY_CONFIG_DEST:="/data/config"}
+
 if [ -n "$OPS" ]; then
   log "Setting/adding ops"
   rm -rf /data/ops.txt.converted
@@ -57,14 +59,11 @@ if [ -d /mods ]; then
   rsync -a --out-format="update:%f:Last Modified %M" "${rsyncArgs[@]}" --prune-empty-dirs --update /mods /data
 fi
 
-[ -d /data/config ] || mkdir /data/config
-for c in /config/*
-do
-  if [ -f "$c" ]; then
-    log Copying configuration $(basename "$c")
-    cp -rf "$c" /data/config
-  fi
-done
+if [ -d /config ]; then
+  log "Copying any configs from /config to $COPY_CONFIG_DEST"
+  mkdir -p $COPY_CONFIG_DEST
+  rsync -a --out-format="update:%f:Last Modified %M" "${rsyncArgs[@]}" --prune-empty-dirs --update /config/ $COPY_CONFIG_DEST
+fi
 
 EXTRA_ARGS=""
 # Optional disable console


### PR DESCRIPTION
A new `COPY_CONFIG_DEST` option now allows you to specifcy where the files in `/config` should be copied to.
Defaults to `/data/config` to mirror the old behaviour.

Closes feat: copy server configs into server dir (analogue to bungee) #664