### PR TITLE
ignore duplicate entries in the targets array of version.json

### DIFF
--- a/start-deployFTBA
+++ b/start-deployFTBA
@@ -48,8 +48,8 @@ else
 fi
 
 isDebugging && cat version.json
-forgeVersion=$(jq -r '.targets[] | select(.name == "forge") | .version' version.json)
-mcVersion=$(jq -r '.targets[] | select(.name == "minecraft") | .version' version.json)
+forgeVersion=$(jq -r '.targets|unique[] | select(.name == "forge") | .version' version.json)
+mcVersion=$(jq -r '.targets|unique[] | select(.name == "minecraft") | .version' version.json)
 
 variants=(
   forge-${mcVersion}-${forgeVersion}.jar


### PR DESCRIPTION
For some reason ftb-installer puts more than one entry into the targets
array for "forge" which screws up the filename we expect for the
installed server.  I saw this only with some modpaks and not others
(eg FTB_MODPACK_ID=23 this happens, but not FTB_MODPACK_ID=31)
