### PR TITLE
Escaped backslashes when setting server property value

### DIFF
--- a/start-finalSetupServerProperties
+++ b/start-finalSetupServerProperties
@@ -13,7 +13,7 @@ function setServerProp {
         var=${var,,} ;;
     esac
     log "Setting ${prop} to '${var}' in ${SERVER_PROPERTIES}"
-    sed -i "/^${prop}\s*=/ c ${prop}=${var/\\/\\\\}" "$SERVER_PROPERTIES"
+    sed -i "/^${prop}\s*=/ c ${prop}=${var//\\/\\\\}" "$SERVER_PROPERTIES"
   else
     log "Skip setting ${prop}"
   fi

--- a/start-finalSetupServerProperties
+++ b/start-finalSetupServerProperties
@@ -13,7 +13,7 @@ function setServerProp {
         var=${var,,} ;;
     esac
     log "Setting ${prop} to '${var}' in ${SERVER_PROPERTIES}"
-    sed -i "/^${prop}\s*=/ c ${prop}=${var}" "$SERVER_PROPERTIES"
+    sed -i "/^${prop}\s*=/ c ${prop}=${var/\\/\\\\}" "$SERVER_PROPERTIES"
   else
     log "Skip setting ${prop}"
   fi


### PR DESCRIPTION
@P4sca1 I was going to suggest this change, but was just as easy to make the change and PR it.

Fixes #446