### PR TITLE
Replacing killall with pkill and ps -a to ps -ax

### DIFF
--- a/files/autopause/autopause-daemon.sh
+++ b/files/autopause/autopause-daemon.sh
@@ -17,7 +17,7 @@ if [ $? -ne 0 ] ; then
   logAutopause "Possible cause: docker's host network mode."
   logAutopause "Recreate without host mode or disable autopause functionality."
   logAutopause "Stopping server."
-  killall -SIGTERM java
+  pkill -SIGTERM java
   exit 1
 fi
 

--- a/files/autopause/pause.sh
+++ b/files/autopause/pause.sh
@@ -2,7 +2,7 @@
 
 . /start-utils
 
-if [[ $( ps -a -o stat,comm | grep 'java' | awk '{ print $1 }') =~ ^S.*$ ]] ; then
+if [[ $( ps -ax -o stat,comm | grep 'java' | awk '{ print $1 }') =~ ^S.*$ ]] ; then
   # save world
   rcon-cli save-all >/dev/null
 
@@ -17,5 +17,5 @@ if [[ $( ps -a -o stat,comm | grep 'java' | awk '{ print $1 }') =~ ^S.*$ ]] ; th
 
   # finally pause the process
   logAutopauseAction "Pausing Java process"
-  killall -q -STOP java
+  pkill -q -STOP java
 fi

--- a/files/autopause/resume.sh
+++ b/files/autopause/resume.sh
@@ -4,5 +4,5 @@
 
 if [[ $( ps -a -o stat,comm | grep 'java' | awk '{ print $1 }') =~ ^T.*$ ]] ; then
   logAutopauseAction "Knocked, resuming Java process"
-  killall -q -CONT java
+  pkill -q -CONT java
 fi


### PR DESCRIPTION
Fixes #699 

Replacing killall with pkill.  Pkill is able to find the java process to stop it properly.

Replacing ps -a with ps -ax.  ps -ax is able to find the java process to enter the if loop.