### PR TITLE
Fixing AUTOPAUSE on Raspberry Pi 4s

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update \
     imagemagick \
     gosu \
     sudo \
+    net-tools \
     curl wget \
     jq \
     dos2unix \

--- a/files/autopause/autopause-daemon.sh
+++ b/files/autopause/autopause-daemon.sh
@@ -8,7 +8,7 @@ sudo /usr/sbin/knockd -c /tmp/knockd-config.cfg -d
 if [ $? -ne 0 ] ; then
   while :
   do
-    if [[ -n $(ps -o comm | grep java) ]] ; then
+    if [[ -n $(ps -ax -o comm | grep java) ]] ; then
       break
     fi
     sleep 0.1

--- a/files/autopause/autopause-daemon.sh
+++ b/files/autopause/autopause-daemon.sh
@@ -17,7 +17,7 @@ if [ $? -ne 0 ] ; then
   logAutopause "Possible cause: docker's host network mode."
   logAutopause "Recreate without host mode or disable autopause functionality."
   logAutopause "Stopping server."
-  killall -SIGTERM java
+  pkill -SIGTERM java
   exit 1
 fi
 

--- a/files/autopause/autopause-fcns.sh
+++ b/files/autopause/autopause-fcns.sh
@@ -5,11 +5,11 @@ current_uptime() {
 }
 
 java_running() {
-  [[ $( ps -a -o stat,comm | grep 'java' | awk '{ print $1 }') =~ ^S.*$ ]]
+  [[ $( ps -ax -o stat,comm | grep 'java' | awk '{ print $1 }') =~ ^S.*$ ]]
 }
 
 rcon_client_exists() {
-  [[ -n "$(ps -a -o comm | grep 'rcon-cli')" ]]
+  [[ -n "$(ps -ax -o comm | grep 'rcon-cli')" ]]
 }
 
 mc_server_listening() {

--- a/files/autopause/knockd-config.cfg
+++ b/files/autopause/knockd-config.cfg
@@ -3,10 +3,10 @@
 [unpauseMCServer-server]
  sequence = 25565
  seq_timeout = 1
- command = /sbin/su-exec minecraft:minecraft /autopause/resume.sh
+ command = /usr/sbin/gosu minecraft:minecraft /autopause/resume.sh
  tcpflags = syn
 [unpauseMCServer-rcon]
  sequence = 25575
  seq_timeout = 1
- command = /sbin/su-exec minecraft:minecraft /autopause/resume.sh
+ command = /usr/sbin/gosu minecraft:minecraft /autopause/resume.sh
  tcpflags = syn

--- a/files/autopause/pause.sh
+++ b/files/autopause/pause.sh
@@ -2,7 +2,7 @@
 
 . /start-utils
 
-if [[ $( ps -a -o stat,comm | grep 'java' | awk '{ print $1 }') =~ ^S.*$ ]] ; then
+if [[ $( ps -ax -o stat,comm | grep 'java' | awk '{ print $1 }') =~ ^S.*$ ]] ; then
   # save world
   rcon-cli save-all >/dev/null
 
@@ -17,5 +17,5 @@ if [[ $( ps -a -o stat,comm | grep 'java' | awk '{ print $1 }') =~ ^S.*$ ]] ; th
 
   # finally pause the process
   logAutopauseAction "Pausing Java process"
-  killall -q -STOP java
+  pkill -q -STOP java
 fi

--- a/files/autopause/pause.sh
+++ b/files/autopause/pause.sh
@@ -17,5 +17,5 @@ if [[ $( ps -ax -o stat,comm | grep 'java' | awk '{ print $1 }') =~ ^S.*$ ]] ; t
 
   # finally pause the process
   logAutopauseAction "Pausing Java process"
-  pkill -q -STOP java
+  pkill -STOP java
 fi

--- a/files/autopause/resume.sh
+++ b/files/autopause/resume.sh
@@ -2,7 +2,7 @@
 
 . /start-utils
 
-if [[ $( ps -a -o stat,comm | grep 'java' | awk '{ print $1 }') =~ ^T.*$ ]] ; then
+if [[ $( ps -ax -o stat,comm | grep 'java' | awk '{ print $1 }') =~ ^T.*$ ]] ; then
   logAutopauseAction "Knocked, resuming Java process"
   pkill -CONT java
 fi

--- a/files/autopause/resume.sh
+++ b/files/autopause/resume.sh
@@ -4,5 +4,5 @@
 
 if [[ $( ps -a -o stat,comm | grep 'java' | awk '{ print $1 }') =~ ^T.*$ ]] ; then
   logAutopauseAction "Knocked, resuming Java process"
-  pkill -q -CONT java
+  pkill -CONT java
 fi

--- a/files/autopause/resume.sh
+++ b/files/autopause/resume.sh
@@ -4,5 +4,5 @@
 
 if [[ $( ps -a -o stat,comm | grep 'java' | awk '{ print $1 }') =~ ^T.*$ ]] ; then
   logAutopauseAction "Knocked, resuming Java process"
-  killall -q -CONT java
+  pkill -q -CONT java
 fi

--- a/files/sudoers-mc
+++ b/files/sudoers-mc
@@ -1,2 +1,2 @@
-%minecraft ALL=(ALL) NOPASSWD:/usr/bin/killall
+%minecraft ALL=(ALL) NOPASSWD:/usr/bin/pkill
 %minecraft ALL=(ALL) NOPASSWD:/usr/sbin/knockd

--- a/health.sh
+++ b/health.sh
@@ -5,7 +5,7 @@
 if isTrue "${DISABLE_HEALTHCHECK}"; then
   echo "Healthcheck disabled"
   exit 0
-elif isTrue "${ENABLE_AUTOPAUSE}" && [[ "$( ps -a -o stat,comm | grep 'java' | awk '{ print $1 }')" =~ ^T.*$ ]]; then
+elif isTrue "${ENABLE_AUTOPAUSE}" && [[ "$( ps -ax -o stat,comm | grep 'java' | awk '{ print $1 }')" =~ ^T.*$ ]]; then
   echo "Java process suspended by Autopause function"
   exit 0
 else


### PR DESCRIPTION
Adding net-tools, replacing killall with pkill, and replacing ps -a with ps -ax