### PR TITLE
fix/681

### DIFF
--- a/start-deployPaper
+++ b/start-deployPaper
@@ -56,6 +56,10 @@ else
     zarg=(-z "$SERVER")
   fi
 
+  log "Removing old PaperMC versions ..."
+  paperJarSearchString=${SERVER/$build/[0-9]*}
+  find . -name "$paperJarSearchString" ! -name "$SERVER" -delete -print
+
   log "Downloading PaperMC $VANILLA_VERSION (build $build) ..."
   curl -fsSL -o "$SERVER" "${zarg[@]}" \
     "https://papermc.io/api/v2/projects/paper/versions/${VANILLA_VERSION}/builds/${build}/downloads/${SERVER}" \

--- a/start-deployPaper
+++ b/start-deployPaper
@@ -28,7 +28,7 @@ else
           VANILLA_VERSION=$(echo "$versions" | jq -r '.versions[-1]')
           log "WARN: using ${VANILLA_VERSION} since that's the latest provided by PaperMC"
           # re-execute the current script with the newly computed version
-          exec $0 "$@"
+          exec "$0" "$@"
       fi
       log "ERROR: ${VANILLA_VERSION} is not published by PaperMC"
       log "       Set VERSION to one of the following: "
@@ -71,4 +71,4 @@ export TYPE=SPIGOT
 export SKIP_LOG4J_CONFIG=true
 
 # Continue to Final Setup
-exec ${SCRIPTS:-/}start-finalSetupWorld $@
+exec ${SCRIPTS:-/}start-finalSetupWorld "$@"


### PR DESCRIPTION
Remove all PaperMC jars that are not needed.

How it works:

- Use the filename to be downloaded/executed as starting point e.g. _SERVER=paper-1.16.4-392.jar_
- In this filename replace the build number with a wildcard for any build number e.g. _paperJarSearchString=paper-1.16.4-[0-9]*.jar_
- Find and delete all files matching the $paperJarSearchString except the one file named $SERVER
- Also print which files were deleted