### PR TITLE
Switch to AdoptOpenJDK's JRE image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk:15-jre
+FROM adoptopenjdk:latest
 
 LABEL org.opencontainers.image.authors="Geoff Bourne <itzgeoff@gmail.com>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk:latest
+FROM adoptopenjdk:15-jre
 
 LABEL org.opencontainers.image.authors="Geoff Bourne <itzgeoff@gmail.com>"
 

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ To use a different version of Java, please use a docker tag to run your Minecraf
 | openj9-11      | Uses Eclipse OpenJ9 JVM for Java 11         | Alpine Linux |
 | openj9-nightly | Uses Eclipse OpenJ9 JVM testing builds      | Alpine Linux |
 | multiarch      | Uses Java version 8 latest update           | Debian Linux |
-| multiarch-latest | Uses Java version 15 latest update        | Debian Linux |
+| multiarch-latest | Uses Java version 15 latest update        | Ubuntu Linux |
 
 For example, to use a Java version 13:
 
@@ -182,7 +182,7 @@ Keep in mind that some versions of Minecraft server can't work on the newest ver
 ## Healthcheck
 
 This image contains [mc-monitor](https://github.com/itzg/mc-monitor) and uses
-its `status` command to continually check on the container's. That can be observed
+its `status` command to continually check on the containers. That can be observed
 from the `STATUS` column of `docker ps`
 
 ```

--- a/start-minecraftFinalSetup
+++ b/start-minecraftFinalSetup
@@ -140,9 +140,8 @@ if isTrue "${USE_AIKAR_FLAGS}"; then
   -Daikars.new.flags=true
   "
 fi
-
 # Pre-allocate the memory so we don't waste cycles on alloc/dealloc.
-if isTrue "${USE_MPD_FLAGS}"; then
+if isTrue "${PRE_TOUCH_HEAP}"; then
   log "Preallocating JVM memory"
   JVM_XX_OPTS="${JVM_XX_OPTS}
   -XX:+UnlockExperimentalVMOptions
@@ -155,18 +154,20 @@ fi
 if ( grep -q "AnonHugePages" /proc/meminfo ); then
   log "Using Transparent Huge Pages (https://www.kernel.org/doc/Documentation/vm/transhuge.txt)"
   JVM_XX_OPTS="${JVM_XX_OPTS}
+  -XX:+UnlockExperimentalVMOptions
   -XX:+UseLargePages
   -XX:+UseTransparentHugePages
   "
 fi
 
-if isTrue "${USE_MPD_FLAGS}"; then
+if isTrue "${USE_SHENANDOAH_GC}"; then
   # Test if Java provides the Shenandoah GC, and use it if it is available. We also include some tuning options. It's backported to AdoptOpenJDK 8 and 11.
   # Shenandoah is much more modern and smarter than the G1GC, and needs fewer tuning parameters.
   # These settings only run GC when there's 10% free space left in the heap, and only run two GC threads.
   if ( java -XX:+UnlockExperimentalVMOptions -XX:+PrintFlagsFinal --version | grep -q "UseShenandoahGC" ); then
   log "Using Shenandoah GC (https://wiki.openjdk.java.net/display/shenandoah/Main)"
     JVM_XX_OPTS="${JVM_XX_OPTS}
+    -XX:+UnlockExperimentalVMOptions
     -XX:+UseShenandoahGC
     -XX:+DisableExplicitGC
     -XX:ShenandoahGCHeuristics=static

--- a/start-minecraftFinalSetup
+++ b/start-minecraftFinalSetup
@@ -141,16 +141,48 @@ if isTrue "${USE_AIKAR_FLAGS}"; then
   "
 fi
 
-if isTrue "${USE_LARGE_PAGES}"; then
+# Pre-allocate the memory so we don't waste cycles on alloc/dealloc.
+if isTrue "${USE_MPD_FLAGS}"; then
+  log "Preallocating JVM memory"
   JVM_XX_OPTS="${JVM_XX_OPTS}
-  -XX:+UseLargePagesInMetaspace
+  -XX:+UnlockExperimentalVMOptions
+  -XX:+AlwaysPreTouch
   "
 fi
 
+# Test if Transparent Huge Pages are available, and use them if they are.
+# --XX:UseLargePagesInMetaspace has been deprecated: https://bugs.openjdk.java.net/browse/JDK-8243161
+if ( grep -q "AnonHugePages" /proc/meminfo ); then
+  log "Using Transparent Huge Pages (https://www.kernel.org/doc/Documentation/vm/transhuge.txt)"
+  JVM_XX_OPTS="${JVM_XX_OPTS}
+  -XX:+UseLargePages
+  -XX:+UseTransparentHugePages
+  "
+fi
+
+if isTrue "${USE_MPD_FLAGS}"; then
+  # Test if Java provides the Shenandoah GC, and use it if it is available. We also include some tuning options. It's backported to AdoptOpenJDK 8 and 11.
+  # Shenandoah is much more modern and smarter than the G1GC, and needs fewer tuning parameters.
+  # These settings only run GC when there's 10% free space left in the heap, and only run two GC threads.
+  if ( java -XX:+UnlockExperimentalVMOptions -XX:+PrintFlagsFinal --version | grep -q "UseShenandoahGC" ); then
+  log "Using Shenandoah GC (https://wiki.openjdk.java.net/display/shenandoah/Main)"
+    JVM_XX_OPTS="${JVM_XX_OPTS}
+    -XX:+UseShenandoahGC
+    -XX:+DisableExplicitGC
+    -XX:ShenandoahGCHeuristics=static
+    -XX:ShenandoahMinFreeThreshold=10
+    -XX:ConcGCThreads=2
+    "
+  fi
+fi
+
 if isTrue "${DEBUG_MEMORY}"; then
-  log "Memory usage and availability (in MB)"
+  log "Enabled verbose memory and garbage collection logging."
   uname -a
   free -m
+  JVM_XX_OPTS="${JVM_XX_OPTS}
+  -Xlog:gc
+  "
 fi
 
 JVM_OPTS="-Xms${INIT_MEMORY} -Xmx${MAX_MEMORY} ${JVM_OPTS}"


### PR DESCRIPTION
Changes the base image from "the latest JDK" to "the latests JRE", which is more compact and specific.