### PR TITLE
Fix README: volumes should be in list

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ services:
       EULA: "TRUE"
     volumes:
       # attach the relative directory 'data' to the container's /data path
-      ./data:/data
+      - ./data:/data
 ```
 
 ## Versions


### PR DESCRIPTION
Fix the typo in the `README.md`, docker volumes in docker-compose yaml should be in the list format.