### PR TITLE
Fix typo in example docker-compose

### DIFF
--- a/examples/docker-compose-simple.yml
+++ b/examples/docker-compose-simple.yml
@@ -9,4 +9,4 @@ services:
       EULA: "TRUE"
     volumes:
       # attach the relative directory 'data' to the container's /data path
-      ./data:/data
+      - ./data:/data


### PR DESCRIPTION
After copy pasting the docker-compose error occured:
ERROR: The Compose file './docker-compose.yml' is invalid because:
services.mc.volumes contains an invalid type, it should be an array

I've just add "-" and should work now.