### PR TITLE
Support FTP servers for file downloads

### DIFF
--- a/start-finalSetupModpack
+++ b/start-finalSetupModpack
@@ -24,12 +24,12 @@ if [[ "$MODPACK" ]]; then
       downloadUrl=$(curl -Ls -o /dev/null -w %{effective_url} $MODPACK)
       if ! [[ $downloadUrl == *.zip ]]; then
         log "ERROR Invalid URL given for MODPACK: $downloadUrl resolved from $MODPACK"
-        log "      Must be HTTP or HTTPS and a ZIP file"
+        log "      Must be HTTP, HTTPS or FTP and a ZIP file"
         exit 1
       fi
     fi
 
-    log "Downloading mod/plugin pack via HTTP"
+    log "Downloading mod/plugin pack"
     log "  from $downloadUrl ..."
     if ! curl -sSL -o /tmp/modpack.zip "$downloadUrl"; then
       log "ERROR: failed to download from $downloadUrl"

--- a/start-utils
+++ b/start-utils
@@ -11,7 +11,7 @@ function join_by() {
 function isURL() {
   local value=$1
 
-  if [[ ${value:0:8} == "https://" || ${value:0:7} == "http://" ]]; then
+  if [[ ${value:0:8} == "https://" || ${value:0:7} == "http://" || ${value:0:6} == "ftp://" ]]; then
     return 0
   else
     return 1


### PR DESCRIPTION
Since `curl` can natively download files from FTP servers, given a `ftp://` URL, support those URLs. Closes #849
