### PR TITLE
Revert "Fixed locating of CF modpack server jar when not using server script"

### DIFF
--- a/start-deployCF
+++ b/start-deployCF
@@ -60,8 +60,8 @@ if ! isTrue ${USE_MODPACK_START_SCRIPT:-true}; then
     mkdir -p ${FTB_BASE_DIR}
     unzip -o "${FTB_SERVER_MOD}" -d ${FTB_BASE_DIR} | awk '{printf "."} END {print ""}'
 
-    SERVER=$(find ${FTB_BASE_DIR} -type f -not -name "forge*installer.jar" -name "forge*.jar")
-    if [[ -z "$SERVER" ]]; then
+    serverJar=$(find ${FTB_BASE_DIR}  -path "*/libraries/*" -prune -type f -o  -not -name "forge*installer.jar" -name "forge*.jar")
+    if [[ -z "$serverJar" ]]; then
 
       if [ -f "${FTB_BASE_DIR}/settings.cfg" ]; then
         loadForgeVars "${FTB_BASE_DIR}/settings.cfg"
@@ -89,15 +89,14 @@ if ! isTrue ${USE_MODPACK_START_SCRIPT:-true}; then
     fi
 
     echo "${FTB_SERVER_MOD}" > $installMarker
-    SERVER=$(find ${FTB_BASE_DIR} -type f -not -name "forge*installer.jar" -name "forge*.jar")
   fi
 
+  export SERVER=$(find ${FTB_BASE_DIR}  -path "*/libraries/*" -prune -type f -o  -not -name "forge*installer.jar" -name "forge*.jar")
   if [[ -z "${SERVER}" || ! -f "${SERVER}" ]]; then
     log "ERROR unable to locate installed forge server jar"
     isDebugging && find ${FTB_BASE_DIR} -name "forge*.jar"
     exit 2
   fi
-  export SERVER
 
   export FTB_DIR=$(dirname "${SERVER}")
 


### PR DESCRIPTION
This reverts commit 65b3997e7276ca3d99978971877eb19429ec3dd5.

That commit prevents my modpack (which doesn't have its own start script — it's generated from gdlauncher) from starting, but I'm not exactly sure why it was committed so I'm just putting this up as a suggestion. 65b3997e7276ca3d99978971877eb19429ec3dd5 made it so that an installed server never sets `$SERVER`, causing the container to exit. Additionally, `libraries/` needs to be excluded since other files match in there.

Logs from before:

```
mc_1      | [init] Running as uid=1000 gid=1000 with /data as 'drwxrwxr-x    3 1000     1000             7 Apr 30 02:57 /data'
mc_1      | [init] Resolved version given 1.16.5 into 1.16.5
mc_1      | [init] Resolving type given CURSEFORGE
mc_1      | + : /data/FeedTheBeast
mc_1      | + export FTB_BASE_DIR
mc_1      | + legacyJavaFixerUrl=https://ftb.forgecdn.net/FTB2/maven/net/minecraftforge/lex/legacyjavafixer/1.0/legacyjavafixer-1.0.jar
mc_1      | + export TYPE=CURSEFORGE
mc_1      | + TYPE=CURSEFORGE
mc_1      | + FTB_SERVER_MOD=/modpacks/flippant_SERVER-0.7.0.zip
mc_1      | + log 'Looking for Feed-The-Beast / CurseForge server modpack.'
mc_1      | + echo '[init] Looking for Feed-The-Beast / CurseForge server modpack.'
mc_1      | + requireVar FTB_SERVER_MOD
mc_1      | [init] Looking for Feed-The-Beast / CurseForge server modpack.
mc_1      | + '[' '!' -v FTB_SERVER_MOD ']'
mc_1      | + '[' -z /modpacks/flippant_SERVER-0.7.0.zip ']'
mc_1      | + isTrue false
mc_1      | + local value=false
mc_1      | + result=
mc_1      | + case ${value} in
mc_1      | + result=1
mc_1      | + return 1
mc_1      | + '[' -f /modpacks/flippant_SERVER-0.7.0.zip ']'
mc_1      | + needsInstall=true
mc_1      | + installMarker=/data/.curseforge-installed
mc_1      | + '[' -f /data/.curseforge-installed ']'
mc_1      | ++ cat /data/.curseforge-installed
mc_1      | + '[' /modpacks/flippant_SERVER-0.7.0.zip '!=' /modpacks/flippant_SERVER-0.7.0.zip ']'
mc_1      | + needsInstall=false
mc_1      | + false
mc_1      | + [[ -z '' ]]
mc_1      | + log 'ERROR unable to locate installed forge server jar'
mc_1      | + echo '[init] ERROR unable to locate installed forge server jar'
mc_1      | [init] ERROR unable to locate installed forge server jar
mc_1      | + isDebugging
mc_1      | + isTrue true
mc_1      | + local value=true
mc_1      | + result=
mc_1      | + case ${value} in
mc_1      | + result=0
mc_1      | + return 0
mc_1      | + return 0
mc_1      | + find /data/FeedTheBeast -name 'forge*.jar'
mc_1      | /data/FeedTheBeast/forge-1.16.5-36.1.4.jar
mc_1      | /data/FeedTheBeast/libraries/net/minecraftforge/forgespi/3.2.0/forgespi-3.2.0.jar
mc_1      | /data/FeedTheBeast/libraries/net/minecraftforge/forge/1.16.5-36.1.4/forge-1.16.5-36.1.4-universal.jar
mc_1      | /data/FeedTheBeast/libraries/net/minecraftforge/forge/1.16.5-36.1.4/forge-1.16.5-36.1.4.jar
mc_1      | /data/FeedTheBeast/libraries/net/minecraftforge/forge/1.16.5-36.1.4/forge-1.16.5-36.1.4-server.jar
mc_1      | + exit 2
```

With the revert, the server works. I'm guessing this will also resolve #846.

```
mc_1      | [init] Running as uid=1000 gid=1000 with /data as 'drwxrwxr-x    3 1000     1000             7 Apr 30 03:18 /data'
mc_1      | [init] Resolved version given 1.16.5 into 1.16.5
mc_1      | [init] Resolving type given CURSEFORGE
mc_1      | [init] **********************************************************************
mc_1      | [init] WARNING: The image tag itzg/minecraft-server:java8 is recommended
mc_1      | [init]          since some mods require Java 8
mc_1      | [init]          Exception traces reporting ClassCastException: class jdk.internal.loader.ClassLoaders$AppClassLoader
mc_1      | [init]          can be fixed with java8
mc_1      | [init] **********************************************************************
mc_1      | + : /data/FeedTheBeast
mc_1      | + export FTB_BASE_DIR
mc_1      | + legacyJavaFixerUrl=https://ftb.forgecdn.net/FTB2/maven/net/minecraftforge/lex/legacyjavafixer/1.0/legacyjavafixer-1.0.jar
mc_1      | + export TYPE=CURSEFORGE
mc_1      | + TYPE=CURSEFORGE
mc_1      | + FTB_SERVER_MOD=/modpacks/flippant_SERVER-0.7.0.zip
mc_1      | + log 'Looking for Feed-The-Beast / CurseForge server modpack.'
mc_1      | + echo '[init] Looking for Feed-The-Beast / CurseForge server modpack.'
mc_1      | [init] Looking for Feed-The-Beast / CurseForge server modpack.
mc_1      | + requireVar FTB_SERVER_MOD
mc_1      | + '[' '!' -v FTB_SERVER_MOD ']'
mc_1      | + '[' -z /modpacks/flippant_SERVER-0.7.0.zip ']'
mc_1      | + isTrue false
mc_1      | + local value=false
mc_1      | + result=
mc_1      | + case ${value} in
mc_1      | + result=1
mc_1      | + return 1
mc_1      | + '[' -f /modpacks/flippant_SERVER-0.7.0.zip ']'
mc_1      | + needsInstall=true
mc_1      | + installMarker=/data/.curseforge-installed
mc_1      | + '[' -f /data/.curseforge-installed ']'
mc_1      | ++ cat /data/.curseforge-installed
mc_1      | + '[' /modpacks/flippant_SERVER-0.7.0.zip '!=' /modpacks/flippant_SERVER-0.7.0.zip ']'
mc_1      | + needsInstall=false
mc_1      | + false
mc_1      | ++ find /data/FeedTheBeast -path '*/libraries/*' -prune -type f -o -not -name 'forge*installer.jar' -name 'forge*.jar'
mc_1      | + export SERVER=/data/FeedTheBeast/forge-1.16.5-36.1.4.jar
mc_1      | + SERVER=/data/FeedTheBeast/forge-1.16.5-36.1.4.jar
mc_1      | + [[ -z /data/FeedTheBeast/forge-1.16.5-36.1.4.jar ]]
mc_1      | + [[ ! -f /data/FeedTheBeast/forge-1.16.5-36.1.4.jar ]]
mc_1      | ++ dirname /data/FeedTheBeast/forge-1.16.5-36.1.4.jar
mc_1      | + export FTB_DIR=/data/FeedTheBeast
mc_1      | + FTB_DIR=/data/FeedTheBeast
mc_1      | + exec /start-finalSetupWorld
```

Things continue normally from here.