### PR TITLE
allow mods with "forge" in name for cf modpacks

### DIFF
--- a/start-deployCF
+++ b/start-deployCF
@@ -60,7 +60,7 @@ if ! isTrue ${USE_MODPACK_START_SCRIPT:-true}; then
     mkdir -p ${FTB_BASE_DIR}
     unzip -o "${FTB_SERVER_MOD}" -d ${FTB_BASE_DIR} | awk '{printf "."} END {print ""}'
 
-    serverJar=$(find ${FTB_BASE_DIR} -type f -path "*/libraries/*" -prune -o -name "forge*.jar" -not -name "forge*installer.jar" -print)
+    serverJar=$(find ${FTB_BASE_DIR} -type f \( -path "*/libraries/*" -o -path "*/mods/*" \) -prune -o -name "forge*.jar" -not -name "forge*installer.jar" -print)
     if [[ -z "$serverJar" ]]; then
 
       if [ -f "${FTB_BASE_DIR}/settings.cfg" ]; then
@@ -91,7 +91,7 @@ if ! isTrue ${USE_MODPACK_START_SCRIPT:-true}; then
     echo "${FTB_SERVER_MOD}" > $installMarker
   fi
 
-  export SERVER=$(find ${FTB_BASE_DIR} -type f -path "*/libraries/*" -prune -o -name "forge*.jar" -not -name "forge*installer.jar" -print)
+  export SERVER=$(find ${FTB_BASE_DIR} -type f \( -path "*/libraries/*" -o -path "*/mods/*" \) -prune -o -name "forge*.jar" -not -name "forge*installer.jar" -print)
   if [[ -z "${SERVER}" || ! -f "${SERVER}" ]]; then
     log "ERROR unable to locate installed forge server jar"
     isDebugging && find ${FTB_BASE_DIR} -name "forge*.jar"


### PR DESCRIPTION
The deployCF script looks for `forge*.jar`, which can match mods with
"forge" in the name (e.g.
https://www.curseforge.com/minecraft/mc-mods/forgery). This change
allows the mod to work as-is without renaming it to
`forg_ery-1.2.3.jar`.

Here's how it didn't work before (both forge and forgery are found):

```
mc_1      | [init] Running as uid=1000 gid=1000 with /data as 'drwxrwxr-x    3 1000     1000             7 Apr 30 18:04 /data'
mc_1      | [init] Resolved version given 1.16.5 into 1.16.5
mc_1      | [init] Resolving type given CURSEFORGE
mc_1      | [init] **********************************************************************
mc_1      | [init] WARNING: The image tag itzg/minecraft-server:java8 is recommended
mc_1      | [init]          since some mods require Java 8
mc_1      | [init]          Exception traces reporting ClassCastException: class jdk.internal.loader.ClassLoaders$AppClassLoader
mc_1      | [init]          can be fixed with java8
mc_1      | [init] **********************************************************************
mc_1      | + : /data/FeedTheBeast
mc_1      | + export FTB_BASE_DIR
mc_1      | + legacyJavaFixerUrl=https://ftb.forgecdn.net/FTB2/maven/net/minecraftforge/lex/legacyjavafixer/1.0/legacyjavafixer-1.0.jar
mc_1      | + export TYPE=CURSEFORGE
mc_1      | + TYPE=CURSEFORGE
mc_1      | + FTB_SERVER_MOD=/modpacks/flippant_SERVER-0.7.0.zip
mc_1      | + log 'Looking for Feed-The-Beast / CurseForge server modpack.'
mc_1      | + echo '[init] Looking for Feed-The-Beast / CurseForge server modpack.'
mc_1      | [init] Looking for Feed-The-Beast / CurseForge server modpack.
mc_1      | + requireVar FTB_SERVER_MOD
mc_1      | + '[' '!' -v FTB_SERVER_MOD ']'
mc_1      | + '[' -z /modpacks/flippant_SERVER-0.7.0.zip ']'
mc_1      | + isTrue false
mc_1      | + local value=false
mc_1      | + result=
mc_1      | + case ${value} in
mc_1      | + result=1
mc_1      | + return 1
mc_1      | + '[' -f /modpacks/flippant_SERVER-0.7.0.zip ']'
mc_1      | + needsInstall=true
mc_1      | + installMarker=/data/.curseforge-installed
mc_1      | + '[' -f /data/.curseforge-installed ']'
mc_1      | ++ cat /data/.curseforge-installed
mc_1      | + '[' /modpacks/flippant_SERVER-0.7.0.zip '!=' /modpacks/flippant_SERVER-0.7.0.zip ']'
mc_1      | + needsInstall=false
mc_1      | + false
mc_1      | ++ find /data/FeedTheBeast -type f -path '*/libraries/*' -prune -o -name 'forge*.jar' -not -name 'forge*installer.jar' -print
mc_1      | + export 'SERVER=/data/FeedTheBeast/forge-1.16.5-36.1.4.jar
mc_1      | /data/FeedTheBeast/mods/forgery-1.3.4.jar'
mc_1      | + SERVER='/data/FeedTheBeast/forge-1.16.5-36.1.4.jar
mc_1      | /data/FeedTheBeast/mods/forgery-1.3.4.jar'
mc_1      | + [[ -z /data/FeedTheBeast/forge-1.16.5-36.1.4.jar
mc_1      | /data/FeedTheBeast/mods/forgery-1.3.4.jar ]]
mc_1      | + [[ ! -f /data/FeedTheBeast/forge-1.16.5-36.1.4.jar
mc_1      | /data/FeedTheBeast/mods/forgery-1.3.4.jar ]]
mc_1      | + log 'ERROR unable to locate installed forge server jar'
mc_1      | + echo '[init] ERROR unable to locate installed forge server jar'
mc_1      | [init] ERROR unable to locate installed forge server jar
mc_1      | + isDebugging
mc_1      | + isTrue true
mc_1      | + local value=true
mc_1      | + result=
mc_1      | + case ${value} in
mc_1      | + result=0
mc_1      | + return 0
mc_1      | + return 0
mc_1      | + find /data/FeedTheBeast -name 'forge*.jar'
mc_1      | /data/FeedTheBeast/forge-1.16.5-36.1.4.jar
mc_1      | /data/FeedTheBeast/libraries/net/minecraftforge/forgespi/3.2.0/forgespi-3.2.0.jar
mc_1      | /data/FeedTheBeast/libraries/net/minecraftforge/forge/1.16.5-36.1.4/forge-1.16.5-36.1.4-universal.jar
mc_1      | /data/FeedTheBeast/libraries/net/minecraftforge/forge/1.16.5-36.1.4/forge-1.16.5-36.1.4.jar
mc_1      | /data/FeedTheBeast/libraries/net/minecraftforge/forge/1.16.5-36.1.4/forge-1.16.5-36.1.4-server.jar
mc_1      | /data/FeedTheBeast/mods/forgery-1.3.4.jar
mc_1      | + exit 2
```

And here's a contrived example to show the issue more clearly (and the
result with this fix).

```
$ tree bar
bar
├── foo/
│   ├── libraries/
│   │   ├── libloader cached libs.txt
│   │   └── libloader mod state.obj
│   ├── baz
│   ├── forge-1.12.2-foo-installer.jar
│   └── forge-1.12.2-foo-universal.jar
└── mods/
    └── forgery-1.2.3.jar

3 directories, 6 files

$ find ./bar -path '*/libraries/*' -prune -o -type f -name 'forge*.jar' -not -name 'forge*installer.jar' -print
./bar/foo/forge-1.12.2-foo-universal.jar
./bar/mods/forgery-1.2.3.jar

$ find ./bar \( -path '*/libraries/*' -o -path '*/mods/*' \) -prune -o -type f -name 'f
orge*.jar' -not -name 'forge*installer.jar' -print
./bar/foo/forge-1.12.2-foo-universal.jar
```