### PR TITLE
Support local paths for modpacks / mods

### DIFF
--- a/README.md
+++ b/README.md
@@ -1123,7 +1123,7 @@ The world will only be downloaded or copied if it doesn't exist already. Set `FO
 
 ### Downloadable mod/plugin pack for Forge, Bukkit, and Spigot Servers
 
-Like the `WORLD` option above, you can specify the URL of a "mod pack"
+Like the `WORLD` option above, you can specify the URL or path of a "mod pack"
 to download and install into `mods` for Forge or `plugins` for Bukkit/Spigot.
 To use this option pass the environment variable `MODPACK`, such as
 
@@ -1133,7 +1133,7 @@ To use this option pass the environment variable `MODPACK`, such as
 top level of the zip archive. Make sure the jars are compatible with the
 particular `TYPE` of server you are running.
 
-You may also download individual mods using the `MODS` environment variable and supplying the URL
+You may also download individual mods using the `MODS` environment variable and supplying the URL or path
 to the jar files. Multiple mods/plugins should be comma separated.
 
     docker run -d -e MODS=https://www.example.com/mods/mod1.jar,https://www.example.com/mods/mod2.jar ...

--- a/start-finalSetupModpack
+++ b/start-finalSetupModpack
@@ -36,24 +36,25 @@ if [[ "$MODPACK" ]]; then
       log "ERROR: failed to download from $downloadUrl"
       exit 2
     fi
-
-    if [ "$TYPE" = "SPIGOT" ]; then
-      mkdir -p /data/plugins
-      if ! unzip -o -d /data/plugins /tmp/modpack.zip; then
-        log "ERROR: failed to unzip the modpack from $downloadUrl"
-      fi
-    else
-      mkdir -p /data/mods
-      if ! unzip -o -d /data/mods /tmp/modpack.zip; then
-        log "ERROR: failed to unzip the modpack from $downloadUrl"
-      fi
-    fi
-    rm -f /tmp/modpack.zip
-
+  elif [[ "$MODPACK" =~ .*\.zip ]]; then
+    cp $MODPACK /tmp/modpack.zip
   else
-    log "ERROR Invalid URL given for MODPACK: $MODPACK"
+    log "ERROR Invalid URL or Path given for MODPACK: $MODPACK"
     exit 1
   fi
+
+  if [ "$TYPE" = "SPIGOT" ]; then
+    mkdir -p /data/plugins
+    if ! unzip -o -d /data/plugins /tmp/modpack.zip; then
+      log "ERROR: failed to unzip the modpack from $downloadUrl"
+    fi
+  else
+    mkdir -p /data/mods
+    if ! unzip -o -d /data/mods /tmp/modpack.zip; then
+      log "ERROR: failed to unzip the modpack from $downloadUrl"
+    fi
+  fi
+  rm -f /tmp/modpack.zip
 fi
 
 # If supplied with a URL for a plugin download it.
@@ -87,8 +88,12 @@ if [[ "$MODS" ]]; then
           exit 2
         fi
       fi
+    elif [[ "$i" =~ .*\.jar ]]; then
+      log "Copying plugin located at $i ..."
+      out_file=$(basename "$i")
+      cp "$i" "${out_dir}/$out_file"
     else
-      log "ERROR Invalid URL given in MODS: $i"
+      log "ERROR Invalid URL or Path given in MODS: $i"
       exit 2
     fi
   done

--- a/start-finalSetupModpack
+++ b/start-finalSetupModpack
@@ -37,7 +37,10 @@ if [[ "$MODPACK" ]]; then
       exit 2
     fi
   elif [[ "$MODPACK" =~ .*\.zip ]]; then
-    cp $MODPACK /tmp/modpack.zip
+    if ! cp $MODPACK /tmp/modpack.zip; then
+      log "ERROR: failed to copy from $MODPACK"
+      exit 2
+    fi
   else
     log "ERROR Invalid URL or Path given for MODPACK: $MODPACK"
     exit 1
@@ -91,7 +94,10 @@ if [[ "$MODS" ]]; then
     elif [[ "$i" =~ .*\.jar ]]; then
       log "Copying plugin located at $i ..."
       out_file=$(basename "$i")
-      cp "$i" "${out_dir}/$out_file"
+      if ! cp "$i" "${out_dir}/$out_file"; then
+        log "ERROR: failed to copy from $i into $out_dir"
+        exit 2
+      fi
     else
       log "ERROR Invalid URL or Path given in MODS: $i"
       exit 2


### PR DESCRIPTION
I noticed while testing some things with this image that local paths were available for using Worlds, but not for Mods or Modpacks.
I spent a little bit of time trying to implement this in my own branch, and think it would be useful upstream.

I understand that the usecase can also be served through utilising volumes, however having similar functionality for these environment variables may aid usability.
I'm also unsure whether the checking of paths is sufficient - this will check whether a path ends in the correct extension right now, but not much more - although we do also check whether the command succeeds.