### PR TITLE
Bump java version to 16 to support snapshot 21w19a onwards

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk11:alpine-jre
+FROM adoptopenjdk/openjdk16:alpine-jre
 
 LABEL org.opencontainers.image.authors="Geoff Bourne <itzgeoff@gmail.com>"
 


### PR DESCRIPTION
When I restarted my snapshot server this morning to get the latest 21w19a this morning I got this:

```
minecraft_1  | [init] Running as uid=1000 gid=1000 with /data as 'drwxrwxr-x    4 1000     1000          4096 May 12 14:26 /data'
minecraft_1  | [init] Resolved version given SNAPSHOT into 21w19a
minecraft_1  | [init] Resolving type given VANILLA
minecraft_1  | [init] server.properties already created, skipping
minecraft_1  | [init] Checking for JSON files.
minecraft_1  | [init] Setting initial memory to 16G and max to 16G
minecraft_1  | [init] Starting the Minecraft server...
minecraft_1  | Error: LinkageError occurred while loading main class net.minecraft.server.Main
minecraft_1  | 	java.lang.UnsupportedClassVersionError: net/minecraft/server/Main has been compiled by a more recent version of the Java Runtime (class file version 60.0), this version of the Java Runtime only recognizes class file versions up to 55.0
minecraft_1  | 2021-05-12T14:26:21.848Z	WARN	mc-server-runner	sub-process failed	{"exitCode": 1}
minecraft_1  | 2021-05-12T14:26:21.848Z	INFO	mc-server-runner	Done
minecraft_minecraft_1 exited with code 1
``` 

Bumping the base image to `adoptopenjdk/openjdk16:alpine-jre` fixed this issue.

It looks like this snapshot version, and likely the next major releases will require this more recent version: https://www.minecraft.net/en-us/article/minecraft-snapshot-21w19a

I realize that there may be some other places in this repository that may need testing for java 16, so please let me know if I've missed anything major.

Addresses https://github.com/itzg/docker-minecraft-server/issues/864