### PR TITLE
fix: update Sky Factory version link

### DIFF
--- a/examples/modpacks/README.md
+++ b/examples/modpacks/README.md
@@ -1,3 +1,3 @@
 Place server [modpacks downloaded from CurseForge](https://www.curseforge.com/minecraft/modpacks) in this directory.
 
-The example [`docker-compose-curseforge.yml`](../docker-compose-curseforge.yml) references a modpack downloaded from <https://www.curseforge.com/minecraft/modpacks/skyfactory-4/files/2787018>.
+The example [`docker-compose-curseforge.yml`](../docker-compose-curseforge.yml) references a modpack downloaded from <https://www.curseforge.com/minecraft/modpacks/skyfactory-4/files/3012800>.


### PR DESCRIPTION
SF 4.1.0 doesn't work with the latest Forge anymore. 4.2.2 does.