### PR TITLE
fix bad find statement

### DIFF
--- a/start-deployCF
+++ b/start-deployCF
@@ -91,7 +91,9 @@ if ! isTrue ${USE_MODPACK_START_SCRIPT:-true}; then
     echo "${FTB_SERVER_MOD}" > $installMarker
   fi
 
-  export SERVER=$(find ${FTB_BASE_DIR} -type f \( -path "*/libraries/*" -o -path "*/mods/*" \) -prune -o -name "forge*.jar" -not -name "forge*installer.jar" -print)
+  # change from */mods/* to /mods/* as leading * makes things fail
+  # and add maxdepth 2
+  export SERVER=$(find ${FTB_BASE_DIR} -type f \( -path "/libraries/*" -o -path "/mods/*" \) -prune -o -name "forge*.jar" -not -name "forge*installer.jar" -maxdepth 2 -print)
   if [[ -z "${SERVER}" || ! -f "${SERVER}" ]]; then
     log "ERROR unable to locate installed forge server jar"
     isDebugging && find ${FTB_BASE_DIR} -name "forge*.jar"

--- a/start-deployCF
+++ b/start-deployCF
@@ -85,7 +85,8 @@ if ! isTrue ${USE_MODPACK_START_SCRIPT:-true}; then
       fi
 
       log "Installing forge server"
-      (cd $(dirname "${forgeInstallerJar}"); java -jar $(basename "${forgeInstallerJar}") --installServer)
+      dirOfInstaller=$(dirname "${forgeInstallerJar}")
+      (cd "${dirOfInstaller}"; java -jar $(basename "${forgeInstallerJar}") --installServer)
     fi
 
     echo "${FTB_SERVER_MOD}" > $installMarker
@@ -184,7 +185,7 @@ if [[ $(find ${FTB_BASE_DIR} $entryScriptExpr | wc -l) = 0 ]]; then
 
     # Allow up to 2 levels since some modpacks have a top-level directory named
     # for the modpack
-    forgeJar=$(find ${FTB_BASE_DIR} -maxdepth 2 -name 'forge*.jar' -a -not -name 'forge*installer')
+    forgeJar=$(find ${FTB_BASE_DIR} -type f \( -path "/libraries/*" -o -path "/mods/*" \) -prune -o -name "forge*.jar" -not -name "forge*installer.jar" -maxdepth 2 -print)
     if [[ "$forgeJar" ]]; then
       export FTB_BASE_DIR=$(dirname "${forgeJar}")
       log "No entry script found, so building one for ${forgeJar}"

--- a/start-deployCF
+++ b/start-deployCF
@@ -91,8 +91,6 @@ if ! isTrue ${USE_MODPACK_START_SCRIPT:-true}; then
     echo "${FTB_SERVER_MOD}" > $installMarker
   fi
 
-  # change from */mods/* to /mods/* as leading * makes things fail
-  # and add maxdepth 2
   export SERVER=$(find ${FTB_BASE_DIR} -type f \( -path "/libraries/*" -o -path "/mods/*" \) -prune -o -name "forge*.jar" -not -name "forge*installer.jar" -maxdepth 2 -print)
   if [[ -z "${SERVER}" || ! -f "${SERVER}" ]]; then
     log "ERROR unable to locate installed forge server jar"


### PR DESCRIPTION
After working w/ a CurseForge mod, I tracked down a bug in the find statement that when the forge server is in */FeedTheBeast/mods/forge-<version>.jar, the find statement to locate it won't actually work due to the path */mods/*. Removed the leading * (also from the * in front of libraries) and added in a maxdepth (forge installer will also make a copy in /libraries/net/minecraftforge/forge/<version>/).

