### PR TITLE
fix(curseforge): automatically patch settings.sh file

### DIFF
--- a/start-minecraftFinalSetup
+++ b/start-minecraftFinalSetup
@@ -205,6 +205,14 @@ EOF
     sed -i "s/MAX_RAM=[^;]*/MAX_RAM=${MAX_MEMORY}/" "${FTB_DIR}/settings.cfg"
   fi
 
+  # patch CurseForge settings.sh file, if present
+  if [ -f "${FTB_DIR}/settings.sh" ]; then
+    sed -i "s/MIN_RAM=[^;]*/MIN_RAM=\"${INIT_MEMORY}\"/" "${FTB_DIR}/settings.sh"
+    sed -i "s/MAX_RAM=[^;]*/MAX_RAM=\"${MAX_MEMORY}\"/" "${FTB_DIR}/settings.sh"
+    ESCAPED_JVM_XX_OPTS=$(echo "$JVM_XX_OPTS" | sed -e 's/\//\\\//g')
+    sed -i "s/JAVA_PARAMETERS=[^;]*/JAVA_PARAMETERS=\"${ESCAPED_JVM_XX_OPTS//[$'\t\r\n']} ${JVM_OPTS} $expandedDOpts\"/" "${FTB_DIR}/settings.sh"
+  fi
+
   cd "${FTB_DIR}"
   log "Running FTB ${FTB_SERVER_START} in ${FTB_DIR} ..."
 


### PR DESCRIPTION
Pretty hacky way to do it, but it works _for now_.

Some weird things had to be done for the JVM args to work with the Aikar flags because they have newlines _and_ slashes (which would both cause issues with sed).