### PR TITLE
Support Java versions above 11 for Airplane

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ By default, the container will download the latest version of the "vanilla" [Min
       * [Enabling Autopause](#enabling-autopause)
    * [Running on RaspberryPi](#running-on-raspberrypi)
 
-<!-- Added by: runner, at: Mon Jun  7 01:38:43 UTC 2021 -->
+<!-- Added by: runner, at: Tue Jun  8 23:49:30 UTC 2021 -->
 
 <!--te-->
 

--- a/README.md
+++ b/README.md
@@ -452,8 +452,6 @@ An [Airplane](https://github.com/TECHNOVE/Airplane) server, which is a fork of T
 
 > **NOTE** only `VERSION=LATEST` is supported
 
-> **NOTE** only Java 8 and 11 are supported
-
 Extra variables:
 - `FORCE_REDOWNLOAD=false` : set to true to force the located server jar to be re-downloaded
 - `USE_FLARE_FLAGS=false` : set to true to add appropriate flags for the [Flare](https://blog.airplane.gg/flare) profiler

--- a/start-deployAirplane
+++ b/start-deployAirplane
@@ -7,9 +7,10 @@ isDebugging && set -x
 
 JAVA_VER=$(java -version 2>&1 | head -1 | cut -d'"' -f2 | sed '/^1\./s///' | cut -d'.' -f1)
 
-if [ "${JAVA_VER}" != "8" ] && [ "${JAVA_VER}" != "11" ]; then
-  log "ERROR: Airplane server type only supports Java versions 8 and 11"
-  exit 1
+if [ "${JAVA_VER}" = "8" ]; then
+  JDK=8
+else
+  JDK=11
 fi
 
 if [ "${VERSION}" != "LATEST" ]; then
@@ -17,10 +18,10 @@ if [ "${VERSION}" != "LATEST" ]; then
   exit 1
 fi
 
-export SERVER=airplane-${VANILLA_VERSION}-jdk${JAVA_VER}.jar
+export SERVER=airplane-${VANILLA_VERSION}-jdk${JDK}.jar
 
 if [ ! -f "$SERVER" ] || isTrue "$FORCE_REDOWNLOAD"; then
-    downloadUrl="https://dl.airplane.gg/latest/Airplane-JDK${JAVA_VER}/launcher-airplane.jar"
+    downloadUrl="https://dl.airplane.gg/latest/Airplane-JDK${JDK}/launcher-airplane.jar"
     log "Downloading Airplane from $downloadUrl ..."
     curl -fsSL -o "$SERVER" "$downloadUrl"
     if [ ! -f "$SERVER" ]; then


### PR DESCRIPTION
This PR enables the use of Airplane on Java versions above 11, in anticipation of 1.17.