### PR TITLE
Workaround: Change default RELEASE of Yatopia

### DIFF
--- a/start-deployYatopia
+++ b/start-deployYatopia
@@ -6,7 +6,7 @@ IFS=$'\n\t'
 isDebugging && set -x
 
 : ${VANILLA_VERSION:?}
-: ${RELEASE:=stable}
+: ${RELEASE:=latest}
 : ${FORCE_REDOWNLOAD:=false}
 
 requireEnum RELEASE stable latest


### PR DESCRIPTION
api.yatopiamc.org/v2/stableBuild API has been broken for a couple of months (see https://github.com/YatopiaMC/Yatopia/issues/488 ) and it looks like it won't be fixed soon. Thus, changed the default RELEASE value from stable to latest, so that Yatopia can still be easily set up without explicitly specifying a RELEASE env.