### PR TITLE
Move to new Airplane download system

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,15 +450,17 @@ An [Airplane](https://github.com/TECHNOVE/Airplane) server, which is a fork of T
 
     -e TYPE=AIRPLANE
 
-> **NOTE** only `VERSION=LATEST` is supported
+> **NOTE** the `VERSION` variable is used to select an Airplane branch to download from. The available options are "LATEST" "1.16" "1.17" and "PURPUR"
+> **NOTE** The 1.17 branch is currently in beta. Use at your own risk!
 
 Extra variables:
+- `ARIPLANE_BUILD=lastSuccessfulBuild` : set a specific Airplane build to use
 - `FORCE_REDOWNLOAD=false` : set to true to force the located server jar to be re-downloaded
 - `USE_FLARE_FLAGS=false` : set to true to add appropriate flags for the [Flare](https://blog.airplane.gg/flare) profiler
 
 ### Running a Purpur server
 
-A [Purpur](https://purpur.pl3x.net/) server, which is "a drop-in replacement for Paper servers designed for configurability, new fun and exciting gameplay features, and high performance built on top of Tuinity.".
+A [Purpur](https://purpur.pl3x.net/) server, which is "a drop-in replacement for Paper servers designed for configurability, new fun and exciting gameplay features, and high performance built on top of Tuinity."
 
     -e TYPE=PURPUR
 

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ By default, the container will download the latest version of the "vanilla" [Min
       * [Enabling Autopause](#enabling-autopause)
    * [Running on RaspberryPi](#running-on-raspberrypi)
 
-<!-- Added by: runner, at: Tue Jun 22 23:39:21 UTC 2021 -->
+<!-- Added by: runner, at: Wed Jun 23 01:36:53 UTC 2021 -->
 
 <!--te-->
 

--- a/README.md
+++ b/README.md
@@ -455,7 +455,7 @@ An [Airplane](https://github.com/TECHNOVE/Airplane) server, which is a fork of T
 > NOTE: The 1.17 branch is currently in beta. Use at your own risk!
 
 Extra variables:
-- `ARIPLANE_BUILD=lastSuccessfulBuild` : set a specific Airplane build to use
+- `AIRPLANE_BUILD=lastSuccessfulBuild` : set a specific Airplane build to use
 - `FORCE_REDOWNLOAD=false` : set to true to force the located server jar to be re-downloaded
 - `USE_FLARE_FLAGS=false` : set to true to add appropriate flags for the [Flare](https://blog.airplane.gg/flare) profiler
 

--- a/README.md
+++ b/README.md
@@ -450,8 +450,9 @@ An [Airplane](https://github.com/TECHNOVE/Airplane) server, which is a fork of T
 
     -e TYPE=AIRPLANE
 
-> **NOTE** the `VERSION` variable is used to select an Airplane branch to download from. The available options are "LATEST" "1.16" "1.17" and "PURPUR"
-> **NOTE** The 1.17 branch is currently in beta. Use at your own risk!
+> NOTE: The `VERSION` variable is used to select an Airplane branch to download from. The available options are "LATEST" "1.16" "1.17" and "PURPUR"
+
+> NOTE: The 1.17 branch is currently in beta. Use at your own risk!
 
 Extra variables:
 - `ARIPLANE_BUILD=lastSuccessfulBuild` : set a specific Airplane build to use

--- a/start-deployAirplane
+++ b/start-deployAirplane
@@ -5,23 +5,30 @@ IFS=$'\n\t'
 . ${SCRIPTS:-/}start-utils
 isDebugging && set -x
 
-JAVA_VER=$(java -version 2>&1 | head -1 | cut -d'"' -f2 | sed '/^1\./s///' | cut -d'.' -f1)
-
-if [ "${JAVA_VER}" = "8" ]; then
-  JDK=8
-else
-  JDK=11
-fi
-
-if [ "${VERSION}" != "LATEST" ]; then
-  log "ERROR: Airplane server type only supports VERSION=LATEST"
+if [ "${VERSION}" != "LATEST" ] && [ "${VERSION}" != "1.16" ] && [ "${VERSION}" != "1.17" ] && [ "${VERSION}" != "PURPUR" ]; then
+  log "ERROR: Airplane server type only supports VERSION=LATEST, VERSION=1.17, VERSION=1.16 or VERSION=PURPUR. Note that these are branches, not x.0 versions."
   exit 1
 fi
 
-export SERVER=airplane-${VANILLA_VERSION}-jdk${JDK}.jar
+: ${AIRPLANE_BUILD:=lastSuccessfulBuild}
+
+if [ "${VERSION}" = "LATEST" ] || [ "${VERSION}" = "1.16" ]; then
+  AIRPLANE_BRANCH="1.16"
+fi
+
+if [ "${VERSION}" = "1.17" ]; then
+  AIRPLANE_BRANCH="1.17"
+  log "Airplane 1.17 is in beta. Use at your own risk!"
+fi
+
+if [ "${VERSION}" = "PURPUR" ]; then
+  AIRPLANE_BRANCH="PURPUR-1.16"
+fi
+
+export SERVER=airplane-${AIRPLANE_BRANCH}-${AIRPLANE_BUILD}.jar
 
 if [ ! -f "$SERVER" ] || isTrue "$FORCE_REDOWNLOAD"; then
-    downloadUrl="https://dl.airplane.gg/latest/Airplane-JDK${JDK}/launcher-airplane.jar"
+    downloadUrl="https://ci.tivy.ca/job/Airplane-${AIRPLANE_BRANCH}/${AIRPLANE_BUILD}/artifact/launcher-airplane.jar"
     log "Downloading Airplane from $downloadUrl ..."
     curl -fsSL -o "$SERVER" "$downloadUrl"
     if [ ! -f "$SERVER" ]; then

--- a/start-deployAirplane
+++ b/start-deployAirplane
@@ -6,7 +6,7 @@ IFS=$'\n\t'
 isDebugging && set -x
 
 if [ "${VERSION}" != "LATEST" ] && [ "${VERSION}" != "1.16" ] && [ "${VERSION}" != "1.17" ] && [ "${VERSION}" != "PURPUR" ]; then
-  log "ERROR: Airplane server type only supports VERSION=LATEST, VERSION=1.17, VERSION=1.16 or VERSION=PURPUR. Note that these are branches, not x.0 versions."
+  log "ERROR: Airplane server type only supports VERSION=LATEST, VERSION=1.16, VERSION=1.17 or VERSION=PURPUR. Note that these are branches, not #.#.# versions."
   exit 1
 fi
 


### PR DESCRIPTION
This PR reflects Airplane's move to their new Jenkins-based download system. It also enables support for 1.17, as well as the new Airplane+Purpur branch.