### PR TITLE
Allow to enable the whitelist without modifying the whitelist file

### DIFF
--- a/README.md
+++ b/README.md
@@ -790,10 +790,11 @@ To whitelist players for your Minecraft server, pass the Minecraft usernames sep
 
 If the `WHITELIST` environment variable is not used, any user can join your Minecraft server if it's publicly accessible.
 
-> NOTE: When `WHITELIST` is used the server property `white-list` will automatically get set to `true`.
+> NOTE: When `WHITELIST` is used the server properties `white-list` and `whitelist` will automatically get set to `true`.
 
 > By default, the players in `WHITELIST` are **added** to the final `whitelist.json` file by the Minecraft server. If you set `OVERRIDE_WHITELIST` to "true" then the `whitelist.json` file will be recreated on each server startup.
 
+Alternatively, you can set `WHITELIST=true` or `WHITELIST=false` to set the server properties `white-list` and `whitelist` without modifying the whitelist file. In this case the whitelist is solely managed using the `whitelist add` and `whitelist remove` commands.
 ### Op/Administrator Players
 
 To add more "op" (aka adminstrator) users to your Minecraft server, pass the Minecraft usernames separated by commas via the `OPS` environment variable, such as

--- a/README.md
+++ b/README.md
@@ -794,7 +794,7 @@ If the `WHITELIST` environment variable is not used, any user can join your Mine
 
 > By default, the players in `WHITELIST` are **added** to the final `whitelist.json` file by the Minecraft server. If you set `OVERRIDE_WHITELIST` to "true" then the `whitelist.json` file will be recreated on each server startup.
 
-Alternatively, you can set `WHITELIST=true` or `WHITELIST=false` to set the server properties `white-list` and `whitelist` without modifying the whitelist file. In this case the whitelist is solely managed using the `whitelist add` and `whitelist remove` commands.
+Alternatively, you can set `ENABLE_WHITELIST=true` to only set the server properties `white-list` and `whitelist` without modifying the whitelist file. In this case the whitelist is solely managed using the `whitelist add` and `whitelist remove` commands.
 ### Op/Administrator Players
 
 To add more "op" (aka adminstrator) users to your Minecraft server, pass the Minecraft usernames separated by commas via the `OPS` environment variable, such as
@@ -1049,6 +1049,7 @@ Allows users to use flight on your server while in Survival mode, if they have a
 | PREVENT_PROXY_CONNECTIONS         | prevent-proxy-connections         |
 | USE_NATIVE_TRANSPORT              | use-native-transport              |
 | ENFORCE_WHITELIST                 | enforce-whitelist                 |
+| ENABLE_WHITELIST                  | white-list and whitelist          |
 
 ## Miscellaneous Options
 

--- a/start-finalSetupServerProperties
+++ b/start-finalSetupServerProperties
@@ -27,7 +27,7 @@ function setServerProp {
 }
 
 function customizeServerProps {
-  if [ -n "$WHITELIST" ]; then
+  if [ -n "$WHITELIST" && "$WHITELIST" != "false" ]; then
     log "Creating whitelist"
     setServerProp "whitelist" "true"
     setServerProp "white-list" "true"

--- a/start-finalSetupServerProperties
+++ b/start-finalSetupServerProperties
@@ -27,7 +27,7 @@ function setServerProp {
 }
 
 function customizeServerProps {
-  if [ -n "$WHITELIST" && "$WHITELIST" != "false" ]; then
+  if [ -n "$WHITELIST" ] || isTrue ${ENABLE_WHITELIST:-false}; then
     log "Creating whitelist"
     setServerProp "whitelist" "true"
     setServerProp "white-list" "true"

--- a/start-minecraftFinalSetup
+++ b/start-minecraftFinalSetup
@@ -13,7 +13,7 @@ if isTrue "${OVERRIDE_OPS}"; then
   rm -f /data/ops.json
 fi
 
-if [ -n "$WHITELIST" && "$WHITELIST" != "true" && "$WHITELIST" != "false" ]; then
+if [ -n "$WHITELIST" ]; then
   log "Updating whitelist"
   rm -f /data/white-list.txt.converted
   echo $WHITELIST | awk -v RS=, '{print}' > /data/white-list.txt

--- a/start-minecraftFinalSetup
+++ b/start-minecraftFinalSetup
@@ -13,7 +13,7 @@ if isTrue "${OVERRIDE_OPS}"; then
   rm -f /data/ops.json
 fi
 
-if [ -n "$WHITELIST" ]; then
+if [ -n "$WHITELIST" && "$WHITELIST" != "true" && "$WHITELIST" != "false" ]; then
   log "Updating whitelist"
   rm -f /data/white-list.txt.converted
   echo $WHITELIST | awk -v RS=, '{print}' > /data/white-list.txt


### PR DESCRIPTION
Currently there is no way to just enable the whitelist without adding a player to the whitelist file.
This change allows to set `WHITELIST=true` to set the server properties accordingly without modifying the whitelist file.
Players can then be added / removed from the whitelist using the `whitelist add` and `whitelist remove` commands.
For convenience `WHITELIST=false` will now disable the whitelist and has the same behaviour like `WHITELIST=` (empty string).

Signed-off-by: Pascal Sthamer <sthamer.pascal@gmail.com>