### PR TITLE
fix: don't echo double backslashes to server.properties

### DIFF
--- a/start-finalSetupServerProperties
+++ b/start-finalSetupServerProperties
@@ -19,7 +19,7 @@ function setServerProp {
       sed -i "/^${prop}\s*=/ c ${prop}=${var//\\/\\\\}" "$SERVER_PROPERTIES"
     else
       log "Adding ${prop} with '${var}' in ${SERVER_PROPERTIES}"
-      echo "${prop}=${var//\\/\\\\}" >> "$SERVER_PROPERTIES"
+      echo "${prop}=${var}" >> "$SERVER_PROPERTIES"
     fi
   else
     isDebugging && log "Skip setting ${prop}"


### PR DESCRIPTION
Using `sed`, we need to escape backslashes, but with `echo` we can just use the variable as-is.
Closes #949