### PR TITLE
Update Airplane branches for 1.17 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,9 +450,7 @@ An [Airplane](https://github.com/TECHNOVE/Airplane) server, which is a fork of T
 
     -e TYPE=AIRPLANE
 
-> NOTE: The `VERSION` variable is used to select an Airplane branch to download from. The available options are "LATEST" "1.16" "1.17" and "PURPUR"
-
-> NOTE: The 1.17 branch is currently in beta, and is not yet sufficiently stable for production use. Use at your own risk!
+> NOTE: The `VERSION` variable is used to select an Airplane branch to download from. The available options are "LATEST" "1.17" "1.16" "PURPUR" and "PURPUR-1.16"
 
 Extra variables:
 - `AIRPLANE_BUILD=lastSuccessfulBuild` : set a specific Airplane build to use

--- a/start-deployAirplane
+++ b/start-deployAirplane
@@ -5,28 +5,26 @@ IFS=$'\n\t'
 . ${SCRIPTS:-/}start-utils
 isDebugging && set -x
 
-if [ "${VERSION}" != "LATEST" ] && [ "${VERSION}" != "1.16" ] && [ "${VERSION}" != "1.17" ] && [ "${VERSION}" != "PURPUR" ]; then
-  log "ERROR: Airplane server type only supports VERSION=LATEST, VERSION=1.16, VERSION=1.17 or VERSION=PURPUR. Note that these are branches, not #.#.# versions."
+if [ "${VERSION}" != "LATEST" ] && [ "${VERSION}" != "1.16" ] && [ "${VERSION}" != "1.17" ] && [ "${VERSION}" != "PURPUR" ] && [ "${VERSION}" != "PURPUR-1.16" ] ; then
+  log "ERROR: Airplane server type only supports VERSION=LATEST, VERSION=1.17, VERSION=1.16, VERSION=PURPUR or VERSION=PURPUR-1.16. Note that these are branches, not #.#.# versions."
   exit 1
 fi
 
 : ${AIRPLANE_BUILD:=lastSuccessfulBuild}
 
-if [ "${VERSION}" = "LATEST" ] || [ "${VERSION}" = "1.16" ]; then
+if  [ "${VERSION}" = "LATEST" ] || [ "${VERSION}" = "1.17" ]; then
+  AIRPLANE_BRANCH="1.17"
+fi
+
+if [ "${VERSION}" = "1.16" ]; then
   AIRPLANE_BRANCH="1.16"
 fi
 
-if [ "${VERSION}" = "1.17" ]; then
-  AIRPLANE_BRANCH="1.17"
-  log "AIRPLANE 1.17 IS IN BETA, AND IS NOT YET PRODUCTION-READY. USE AT YOUR OWN RISK!!!"
-fi
-
-if [ "${VERSION}" = "1.17.1" ]; then
-  AIRPLANE_BRANCH="1.17.1"
-  log "AIRPLANE 1.17.1 IS IN BETA, AND IS NOT YET PRODUCTION-READY. USE AT YOUR OWN RISK!!!"
-fi
-
 if [ "${VERSION}" = "PURPUR" ]; then
+  AIRPLANE_BRANCH="Purpur-1.17"
+fi
+
+if [ "${VERSION}" = "PURPUR-1.16" ]; then
   AIRPLANE_BRANCH="Purpur-1.16"
 fi
 


### PR DESCRIPTION
This PR updates the Airplane branch names for the 1.17/1.17.1 release. The branch was named 1.17.1 for a short while, but was reverted back for consistency.