### PR TITLE
fix: SPIGET_RESOURCES not always download

### DIFF
--- a/start-spiget
+++ b/start-spiget
@@ -26,21 +26,28 @@ getResourceFromSpiget() {
 
   log "Downloading resource ${resource} ..."
 
-  tmpfile="/tmp/${resource}.zip"
-  url="https://api.spiget.org/v2/resources/${resource}/download"
-  if ! curl -o "${tmpfile}" -fsSL -H "User-Agent: itzg/minecraft-server" "${extraCurlArgs[@]}" "${url}"; then
-    log "ERROR failed to download resource '${resource}' from ${url}"
-    exit 2
-  fi
-
   mkdir -p /data/plugins
-  if containsJars "${tmpfile}"; then
-    log "Extracting contents of resource ${resource} into plugins"
-    unzip -o -q -d /data/plugins "${tmpfile}"
-    rm "${tmpfile}"
+
+  if [ -f /data/plugins/.${resource} ]; then
+    log "Resource '${$resource}' already downloaded"
   else
-    log "Moving resource ${resource} into plugins"
-    mv "${tmpfile}" "/data/plugins/${resource}.jar"
+    tmpfile="/tmp/${resource}.zip"
+    url="https://api.spiget.org/v2/resources/${resource}/download"
+    if ! curl -o "${tmpfile}" -fsSL -H "User-Agent: itzg/minecraft-server" "${extraCurlArgs[@]}" "${url}"; then
+      log "ERROR failed to download resource '${resource}' from ${url}"
+      exit 2
+    fi
+
+    if containsJars "${tmpfile}"; then
+      log "Extracting contents of resource ${resource} into plugins"
+      unzip -o -q -d /data/plugins "${tmpfile}"
+      touch "/data/plugins/.${resource}"
+      rm "${tmpfile}"
+    else
+      log "Moving resource ${resource} into plugins"
+      mv "${tmpfile}" "/data/plugins/${resource}.jar"
+      touch "/data/plugins/.${resource}"
+    fi
   fi
 
 }


### PR DESCRIPTION
implemented to only re-download SPIGET resources with REMOVE_OLD_MODS enabled

fixes #974 partially

todo:
- [ ] save timestamp instead of empty file
- [ ] compare timestamp in file with timestamp from SPIGET API

^ todos not needed because getting the timestamps from the API also might rate limit.