### PR TITLE
Feature/spiget slowdown

### DIFF
--- a/start-spiget
+++ b/start-spiget
@@ -21,6 +21,48 @@ containsJars() {
   return 1
 }
 
+getResourceFromSpiget() {
+  resource=${1?}
+
+  log "Downloading resource ${resource} ..."
+
+  if [ ! -d /data/plugins ]; then
+    mkdir -p /data/plugins
+  fi
+
+  SPIGET_DOWNLOAD_TOLERANCE=2 # in minutes
+
+  versionfile="/data/plugins/.${resource}-version.json"
+  versionfileNew="/tmp/.${resource}-version.json"
+  versionfileTimestamp=$(date +%s -r $versionfile)
+  versionfileMinTimestamp=$(($(date +%s) - 60 * $SPIGET_DOWNLOAD_TOLERANCE))
+
+  if [ "$versionfileTimestamp" -ge "$versionfileMinTimestamp" ]; then
+    log "resource '${resource}' not checked because version meta file newer than '${SPIGET_DOWNLOAD_TOLERANCE}' minutes"
+  else
+    urlVersion="https://api.spiget.org/v2/resources/${resource}/versions/latest"
+    if ! curl -o "${versionfile}" -fsSL -H "User-Agent: itzg/minecraft-server" "${extraCurlArgs[@]}" "${urlVersion}"; then
+      log "ERROR failed to download resource version meta data '${resource}' from ${urlVersion}"
+      exit 2
+    fi
+    if [ -f "$versionfile" ]; then
+      installedVersion=$(jq '.name' $versionfile)
+      newVersion=$(jq '.name' $versionfileNew)
+      if [ "$installedVersion" = "$newVersion" ]; then
+        log "resource '${resource}' not downloaded because installed version '${installedVersion}' already up to date ('${newVersion}')"
+      else
+        if getResourceFromSpiget "${resource}"; then
+          mv "${versionfileNew}" "${versionfile}"
+        fi
+      fi
+    else
+      if getResourceFromSpiget "${resource}"; then
+        mv "${versionfileNew}" "${versionfile}"
+      fi
+    fi
+  fi
+}
+
 downloadResourceFromSpiget() {
   resource=${1?}
 

--- a/start-spiget
+++ b/start-spiget
@@ -27,9 +27,7 @@ getResourceFromSpiget() {
 
   log "Downloading resource ${resource} ..."
 
-  if [ ! -d /data/plugins ]; then
-    mkdir -p /data/plugins
-  fi
+  mkdir -p /data/plugins
 
   versionfile="/data/plugins/.${resource}-version.json"
   versionfileNew="/tmp/.${resource}-version.json"

--- a/start-spiget
+++ b/start-spiget
@@ -33,12 +33,7 @@ getResourceFromSpiget() {
   versionfileNew="/tmp/.${resource}-version.json"
 
   if [ -f "$versionfile" ]; then
-    versionfileTimestamp=$(date +%s -r $versionfile)
-    versionfileMinTimestamp=$(($(date +%s) - 60 * $SPIGET_DOWNLOAD_TOLERANCE))
-
-    if [ "$versionfileTimestamp" -ge "$versionfileMinTimestamp" ]; then
-      log "resource '${resource}' not checked because version meta file newer than '${SPIGET_DOWNLOAD_TOLERANCE}' minutes"
-    else
+    if [[ -n $(find "$versionfile" -mmin +${SPIGET_DOWNLOAD_TOLERANCE}) ]]; then
       urlVersion="https://api.spiget.org/v2/resources/${resource}/versions/latest"
       if ! curl -o "${versionfile}" -fsSL -H "User-Agent: itzg/minecraft-server" "${extraCurlArgs[@]}" "${urlVersion}"; then
         log "ERROR failed to download resource version meta data '${resource}' from ${urlVersion}"
@@ -56,6 +51,8 @@ getResourceFromSpiget() {
           mv "${versionfileNew}" "${versionfile}"
         fi
       fi
+    else
+      log "resource '${resource}' not checked because version meta file newer than '${SPIGET_DOWNLOAD_TOLERANCE}' minutes"
     fi
   else
     if downloadResourceFromSpiget "${resource}"; then

--- a/start-spiget
+++ b/start-spiget
@@ -35,7 +35,7 @@ getResourceFromSpiget() {
   if [ -f "$versionfile" ]; then
     if [[ -n $(find "$versionfile" -mmin +${SPIGET_DOWNLOAD_TOLERANCE}) ]]; then
       urlVersion="https://api.spiget.org/v2/resources/${resource}/versions/latest"
-      if ! curl -o "${versionfile}" -fsSL -H "User-Agent: itzg/minecraft-server" "${extraCurlArgs[@]}" "${urlVersion}"; then
+      if ! curl -o "${versionfileNew}" -fsSL -H "User-Agent: itzg/minecraft-server" "${extraCurlArgs[@]}" "${urlVersion}"; then
         log "ERROR failed to download resource version meta data '${resource}' from ${urlVersion}"
         exit 2
       fi
@@ -56,6 +56,11 @@ getResourceFromSpiget() {
     fi
   else
     if downloadResourceFromSpiget "${resource}"; then
+      urlVersion="https://api.spiget.org/v2/resources/${resource}/versions/latest"
+      if ! curl -o "${versionfileNew}" -fsSL -H "User-Agent: itzg/minecraft-server" "${extraCurlArgs[@]}" "${urlVersion}"; then
+        log "ERROR failed to download resource version meta data '${resource}' from ${urlVersion}"
+        exit 2
+      fi
       mv "${versionfileNew}" "${versionfile}"
     fi
   fi

--- a/start-spiget
+++ b/start-spiget
@@ -36,20 +36,23 @@ getResourceFromSpiget() {
 
   versionfile="/data/plugins/.${resource}-version.json"
   versionfileNew="/tmp/.${resource}-version.json"
-  versionfileTimestamp=$(date +%s -r $versionfile)
-  versionfileMinTimestamp=$(($(date +%s) - 60 * $SPIGET_DOWNLOAD_TOLERANCE))
 
-  if [ "$versionfileTimestamp" -ge "$versionfileMinTimestamp" ]; then
-    log "resource '${resource}' not checked because version meta file newer than '${SPIGET_DOWNLOAD_TOLERANCE}' minutes"
-  else
-    urlVersion="https://api.spiget.org/v2/resources/${resource}/versions/latest"
-    if ! curl -o "${versionfile}" -fsSL -H "User-Agent: itzg/minecraft-server" "${extraCurlArgs[@]}" "${urlVersion}"; then
-      log "ERROR failed to download resource version meta data '${resource}' from ${urlVersion}"
-      exit 2
-    fi
-    if [ -f "$versionfile" ]; then
+  if [ -f "$versionfile" ]; then
+    versionfileTimestamp=$(date +%s -r $versionfile)
+    versionfileMinTimestamp=$(($(date +%s) - 60 * $SPIGET_DOWNLOAD_TOLERANCE))
+
+    if [ "$versionfileTimestamp" -ge "$versionfileMinTimestamp" ]; then
+      log "resource '${resource}' not checked because version meta file newer than '${SPIGET_DOWNLOAD_TOLERANCE}' minutes"
+    else
+      urlVersion="https://api.spiget.org/v2/resources/${resource}/versions/latest"
+      if ! curl -o "${versionfile}" -fsSL -H "User-Agent: itzg/minecraft-server" "${extraCurlArgs[@]}" "${urlVersion}"; then
+        log "ERROR failed to download resource version meta data '${resource}' from ${urlVersion}"
+        exit 2
+      fi
+
       installedVersion=$(jq '.name' $versionfile)
       newVersion=$(jq '.name' $versionfileNew)
+      
       if [ "$installedVersion" = "$newVersion" ]; then
         log "resource '${resource}' not downloaded because installed version '${installedVersion}' already up to date ('${newVersion}')"
       else
@@ -57,12 +60,13 @@ getResourceFromSpiget() {
           mv "${versionfileNew}" "${versionfile}"
         fi
       fi
-    else
-      if getResourceFromSpiget "${resource}"; then
-        mv "${versionfileNew}" "${versionfile}"
-      fi
+    fi
+  else
+    if getResourceFromSpiget "${resource}"; then
+      mv "${versionfileNew}" "${versionfile}"
     fi
   fi
+
 }
 
 downloadResourceFromSpiget() {

--- a/start-spiget
+++ b/start-spiget
@@ -6,6 +6,7 @@ IFS=$'\n\t'
 handleDebugMode
 
 : ${SPIGET_RESOURCES:=}
+: ${SPIGET_DOWNLOAD_TOLERANCE:=5} # in minutes
 
 containsJars() {
   file=${1?}
@@ -28,10 +29,6 @@ getResourceFromSpiget() {
 
   if [ ! -d /data/plugins ]; then
     mkdir -p /data/plugins
-  fi
-
-  if [[ ! ${SPIGET_DOWNLOAD_TOLERANCE} ]]; then
-    SPIGET_DOWNLOAD_TOLERANCE=2 # in minutes
   fi
 
   versionfile="/data/plugins/.${resource}-version.json"

--- a/start-spiget
+++ b/start-spiget
@@ -30,7 +30,9 @@ getResourceFromSpiget() {
     mkdir -p /data/plugins
   fi
 
-  SPIGET_DOWNLOAD_TOLERANCE=2 # in minutes
+  if [[ ! ${SPIGET_DOWNLOAD_TOLERANCE} ]]; then
+    SPIGET_DOWNLOAD_TOLERANCE=2 # in minutes
+  fi
 
   versionfile="/data/plugins/.${resource}-version.json"
   versionfileNew="/tmp/.${resource}-version.json"

--- a/start-spiget
+++ b/start-spiget
@@ -21,33 +21,23 @@ containsJars() {
   return 1
 }
 
-getResourceFromSpiget() {
+downloadResourceFromSpiget() {
   resource=${1?}
 
-  log "Downloading resource ${resource} ..."
+  tmpfile="/tmp/${resource}.zip"
+  url="https://api.spiget.org/v2/resources/${resource}/download"
+  if ! curl -o "${tmpfile}" -fsSL -H "User-Agent: itzg/minecraft-server" "${extraCurlArgs[@]}" "${url}"; then
+    log "ERROR failed to download resource '${resource}' from ${url}"
+    exit 2
+  fi
 
-  mkdir -p /data/plugins
-
-  if [ -f /data/plugins/.${resource} ]; then
-    log "Resource '${$resource}' already downloaded"
+  if containsJars "${tmpfile}"; then
+    log "Extracting contents of resource ${resource} into plugins"
+    unzip -o -q -d /data/plugins "${tmpfile}"
+    rm "${tmpfile}"
   else
-    tmpfile="/tmp/${resource}.zip"
-    url="https://api.spiget.org/v2/resources/${resource}/download"
-    if ! curl -o "${tmpfile}" -fsSL -H "User-Agent: itzg/minecraft-server" "${extraCurlArgs[@]}" "${url}"; then
-      log "ERROR failed to download resource '${resource}' from ${url}"
-      exit 2
-    fi
-
-    if containsJars "${tmpfile}"; then
-      log "Extracting contents of resource ${resource} into plugins"
-      unzip -o -q -d /data/plugins "${tmpfile}"
-      touch "/data/plugins/.${resource}"
-      rm "${tmpfile}"
-    else
-      log "Moving resource ${resource} into plugins"
-      mv "${tmpfile}" "/data/plugins/${resource}.jar"
-      touch "/data/plugins/.${resource}"
-    fi
+    log "Moving resource ${resource} into plugins"
+    mv "${tmpfile}" "/data/plugins/${resource}.jar"
   fi
 
 }

--- a/start-spiget
+++ b/start-spiget
@@ -56,13 +56,13 @@ getResourceFromSpiget() {
       if [ "$installedVersion" = "$newVersion" ]; then
         log "resource '${resource}' not downloaded because installed version '${installedVersion}' already up to date ('${newVersion}')"
       else
-        if getResourceFromSpiget "${resource}"; then
+        if downloadResourceFromSpiget "${resource}"; then
           mv "${versionfileNew}" "${versionfile}"
         fi
       fi
     fi
   else
-    if getResourceFromSpiget "${resource}"; then
+    if downloadResourceFromSpiget "${resource}"; then
       mv "${versionfileNew}" "${versionfile}"
     fi
   fi

--- a/start-spiget
+++ b/start-spiget
@@ -52,6 +52,7 @@ getResourceFromSpiget() {
       
       if [ "$installedVersion" = "$newVersion" ]; then
         log "resource '${resource}' not downloaded because installed version '${installedVersion}' already up to date ('${newVersion}')"
+        mv "${versionfileNew}" "${versionfile}"
       else
         if downloadResourceFromSpiget "${resource}"; then
           mv "${versionfileNew}" "${versionfile}"


### PR DESCRIPTION
implements **file time check** and **resource version check** via SPIGET API

`SPIGET_DOWNLOAD_TOLERANCE` environment variable for setting the min allowed age before even consider checking SPIGET API for version metadata. _(currently undocumented/no README additions)_

enhancement/followup of #974 / #975

maybe there is a better name for the variables, especially for SPIGET_DOWNLOAD_TOLERANCE, if you want you might change them.

Also it might be useful to put all these many commits into less, for better overview of the project history maybe?