### PR TITLE
Fix/825 (part 1): specify SPIGET resource version

### DIFF
--- a/start-spiget
+++ b/start-spiget
@@ -67,11 +67,33 @@ getResourceFromSpiget() {
 
 }
 
+getResourceVersionSpecificFromSpiget() {
+  resource=${1?}
+  resourceVersion=${2?}
+
+  log "Downloading resource ${resource} version ${resourceVersion} ..."
+
+  mkdir -p /data/plugins
+
+  versionSpecifiedFile="/data/plugins/.${resource}-versionSpecified.txt"
+  versionSpecified="$(cat $versionSpecifiedFile)"
+
+  if [ "$versionSpecified" = "$resourceVersion" ]; then
+    log "resource '${resource}' not downloaded because installed version '${versionSpecified}' same as specified version ('${resourceVersion}')"
+  else
+    if downloadResourceFromSpiget "${resource}" "${resourceVersion}"; then
+      echo "${resourceVersion}" > $versionSpecifiedFile
+    fi
+  fi
+
+}
+
 downloadResourceFromSpiget() {
   resource=${1?}
+  resourceVersion=${2:=latest}
 
   tmpfile="/tmp/${resource}.zip"
-  url="https://api.spiget.org/v2/resources/${resource}/download"
+  url="https://api.spiget.org/v2/resources/${resource}/versions/${resourceVersion}/download"
   if ! curl -o "${tmpfile}" -fsSL -H "User-Agent: itzg/minecraft-server" "${extraCurlArgs[@]}" "${url}"; then
     log "ERROR failed to download resource '${resource}' from ${url}"
     exit 2
@@ -97,7 +119,12 @@ if [[ ${SPIGET_RESOURCES} ]]; then
   log "Getting plugins via Spiget"
   IFS=',' read -r -a resources <<<"${SPIGET_RESOURCES}"
   for resource in "${resources[@]}"; do
-    getResourceFromSpiget "${resource}"
+    IFS=':' read -r -a resource_separated <<<"${resource}"
+    if [[ -n "${resource_separated[1]}" ]]; then
+      getResourceFromSpiget "${resource_separated[0]}"
+    else
+      getResourceVersionSpecificFromSpiget "${resource_separated[0]}" "${resource_separated[1]}"
+    fi
   done
 fi
 

--- a/start-spiget
+++ b/start-spiget
@@ -76,7 +76,9 @@ getResourceVersionSpecificFromSpiget() {
   mkdir -p /data/plugins
 
   versionSpecifiedFile="/data/plugins/.${resource}-versionSpecified.txt"
-  versionSpecified="$(cat $versionSpecifiedFile)"
+  if [ -f "$versionSpecifiedFile" ]; then
+    versionSpecified="$(cat $versionSpecifiedFile)"
+  fi
 
   if [ "$versionSpecified" = "$resourceVersion" ]; then
     log "resource '${resource}' not downloaded because installed version '${versionSpecified}' same as specified version ('${resourceVersion}')"

--- a/start-spiget
+++ b/start-spiget
@@ -119,11 +119,14 @@ if [[ ${SPIGET_RESOURCES} ]]; then
   log "Getting plugins via Spiget"
   IFS=',' read -r -a resources <<<"${SPIGET_RESOURCES}"
   for resource in "${resources[@]}"; do
-    IFS=':' read -r -a resource_separated <<<"${resource}"
-    if [[ "${resource_separated[1]}" ]]; then
-      getResourceFromSpiget "${resource_separated[0]}"
+    resourceId=${resource%%:*}
+    resourceVersion=${resource##*:}
+    # source: https://stackoverflow.com/questions/19482123/extract-part-of-a-string-using-bash-cut-split/19482947#19482947
+    
+    if [ "$resourceId" = "$resourceVersion" ]; then
+      getResourceFromSpiget "${resourceId}"
     else
-      getResourceVersionSpecificFromSpiget "${resource_separated[0]}" "${resource_separated[1]}"
+      getResourceVersionSpecificFromSpiget "${resourceId}" "${resourceVersion}"
     fi
   done
 fi

--- a/start-spiget
+++ b/start-spiget
@@ -78,10 +78,13 @@ getResourceVersionSpecificFromSpiget() {
   versionSpecifiedFile="/data/plugins/.${resource}-versionSpecified.txt"
   if [ -f "$versionSpecifiedFile" ]; then
     versionSpecified="$(cat $versionSpecifiedFile)"
-  fi
-
-  if [ "$versionSpecified" = "$resourceVersion" ]; then
-    log "resource '${resource}' not downloaded because installed version '${versionSpecified}' same as specified version ('${resourceVersion}')"
+    if [ "$versionSpecified" = "$resourceVersion" ]; then
+      log "resource '${resource}' not downloaded because installed version '${versionSpecified}' same as specified version ('${resourceVersion}')"
+    else
+      if downloadResourceFromSpiget "${resource}" "${resourceVersion}"; then
+        echo "${resourceVersion}" > $versionSpecifiedFile
+      fi
+    fi
   else
     if downloadResourceFromSpiget "${resource}" "${resourceVersion}"; then
       echo "${resourceVersion}" > $versionSpecifiedFile

--- a/start-spiget
+++ b/start-spiget
@@ -120,7 +120,7 @@ if [[ ${SPIGET_RESOURCES} ]]; then
   IFS=',' read -r -a resources <<<"${SPIGET_RESOURCES}"
   for resource in "${resources[@]}"; do
     IFS=':' read -r -a resource_separated <<<"${resource}"
-    if [[ -n "${resource_separated[1]}" ]]; then
+    if [[ "${resource_separated[1]}" ]]; then
       getResourceFromSpiget "${resource_separated[0]}"
     else
       getResourceVersionSpecificFromSpiget "${resource_separated[0]}" "${resource_separated[1]}"


### PR DESCRIPTION
allows to specify which version of the SPIGET resource to download
probably fixes #825 partially

Sorry for first contribution bug (#981), this time it won't have `${$var}` in it :/, but I still didn't build the docker image from my code, so not fully tested.