### PR TITLE
detect and download ARM installer if needed

### DIFF
--- a/start-deployFTBA
+++ b/start-deployFTBA
@@ -30,7 +30,13 @@ if ! [ -f "${ftbInstallMarker}" ] || [ $(cat "${ftbInstallMarker}") != "${FTB_MO
   ftbInstaller=/data/ftb-installer
   if ! [[ -f "${ftbInstaller}" ]]; then
     log "Downloading FTB installer"
-    curl -fsSL https://api.modpacks.ch/public/modpack/1/1/server/linux -o "${ftbInstaller}"
+    if [ "$(uname -m)" == "aarch64" ]; then
+      log "Downloading ARM installer"
+      curl -fsSL https://api.modpacks.ch/public/modpack/1/1/server/arm/linux -o "${ftbInstaller}"
+    else
+      log "Downloading x86 installer"
+      curl -fsSL https://api.modpacks.ch/public/modpack/1/1/server/linux -o "${ftbInstaller}"
+    fi
     chmod +x "${ftbInstaller}"
   fi
 


### PR DESCRIPTION
this should fix #773 

detect if we're running on ARM and switch to downloading the ARM FTB installer

not tested yet (other than confirming the FTB installer works on ARM)