### PR TITLE
For autopause, added use of mc-monitor to detect players connected

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ RUN easy-add --var os=${TARGETOS} --var arch=${TARGETARCH}${TARGETVARIANT} \
  --from https://github.com/itzg/{{.app}}/releases/download/{{.version}}/{{.app}}_{{.version}}_{{.os}}_{{.arch}}.tar.gz
 
 RUN easy-add --var os=${TARGETOS} --var arch=${TARGETARCH}${TARGETVARIANT} \
- --var version=0.7.1 --var app=mc-monitor --file {{.app}} \
+ --var version=0.10.0 --var app=mc-monitor --file {{.app}} \
  --from https://github.com/itzg/{{.app}}/releases/download/{{.version}}/{{.app}}_{{.version}}_{{.os}}_{{.arch}}.tar.gz
 
 RUN easy-add --var os=${TARGETOS} --var arch=${TARGETARCH}${TARGETVARIANT} \

--- a/examples/docker-compose-autopause.yml
+++ b/examples/docker-compose-autopause.yml
@@ -9,8 +9,6 @@ services:
       - "mc:/data"
     environment:
       EULA: "TRUE"
-      # PAPER starts up faster
-      TYPE: PAPER
       ENABLE_AUTOPAUSE: "TRUE"
       OVERRIDE_SERVER_PROPERTIES: "TRUE"
       MAX_TICK_TIME: "-1"

--- a/examples/docker-compose-autopause.yml
+++ b/examples/docker-compose-autopause.yml
@@ -9,10 +9,15 @@ services:
       - "mc:/data"
     environment:
       EULA: "TRUE"
+      # PAPER starts up faster
+      TYPE: PAPER
       ENABLE_AUTOPAUSE: "TRUE"
       OVERRIDE_SERVER_PROPERTIES: "TRUE"
       MAX_TICK_TIME: "-1"
-    restart: always
+      # More aggressive settings for demo purposes
+      AUTOPAUSE_TIMEOUT_INIT: "30"
+      AUTOPAUSE_TIMEOUT_EST: "10"
+    restart: unless-stopped
 
 volumes:
   mc: {}

--- a/files/autopause/autopause-fcns.sh
+++ b/files/autopause/autopause-fcns.sh
@@ -22,6 +22,10 @@ mc_server_listening() {
 
 java_clients_connected() {
   local connections
-  connections=$(mc-monitor status --host localhost --port $SERVER_PORT --show-player-count)
+  if java_running ; then
+    connections=$(mc-monitor status --host localhost --port $SERVER_PORT --show-player-count)
+  else
+    connections=0
+  fi
   (( $connections > 0 ))
 }

--- a/files/autopause/autopause-fcns.sh
+++ b/files/autopause/autopause-fcns.sh
@@ -17,7 +17,7 @@ rcon_client_exists() {
 }
 
 mc_server_listening() {
-  mc-monitor status --host localhost --port $SERVER_PORT >& /dev/null
+  mc-monitor status --host localhost --port $SERVER_PORT --timeout 10s >& /dev/null
 }
 
 java_clients_connected() {

--- a/files/autopause/autopause-fcns.sh
+++ b/files/autopause/autopause-fcns.sh
@@ -17,26 +17,11 @@ rcon_client_exists() {
 }
 
 mc_server_listening() {
-  [[ -n $(netstat -tln | grep -e "0.0.0.0:$SERVER_PORT" -e ":::$SERVER_PORT" | grep LISTEN) ]]
+  mc-monitor status --host localhost --port $SERVER_PORT >& /dev/null
 }
 
 java_clients_connected() {
   local connections
-  connections=$(netstat -tn | grep ":$SERVER_PORT" | grep ESTABLISHED)
-  if [[ -z "$connections" ]] ; then
-    return 1
-  fi
-  IFS=$'\n'
-  connections=($connections)
-  unset IFS
-  # check that at least one external address is not localhost
-  # remember, that the host network mode does not work with autopause because of the knockd utility
-  for (( i=0; i<${#connections[@]}; i++ ))
-  do
-    if [[ ! $(echo "${connections[$i]}" | awk '{print $5}') =~ ^localhost$|^127(?:\.[0-9]+){0,2}\.[0-9]+$|^(?:0*\:)*?:?0*1$ ]] ; then
-      # not localhost
-      return 0
-    fi
-  done
-  return 1
+  connections=$(mc-monitor status --host localhost --port $SERVER_PORT --show-player-count)
+  (( $connections > 0 ))
 }


### PR DESCRIPTION
Image is available for testing `itzg/minecraft-server:test-auto-pause-use-mc-monitor`

cc @Oekn5w @kjburr 

Closes #1046 