### PR TITLE
Fix 'curl: unknown --write-out variable' for .zip modpacks

### DIFF
--- a/start-setupModpack
+++ b/start-setupModpack
@@ -22,7 +22,7 @@ if [[ "$MODPACK" ]]; then
     if [[ "${MODPACK}" == *.zip ]]; then
       downloadUrl="${MODPACK}"
     else
-      downloadUrl=$(curl -Ls -o /dev/null -w %{effective_url} $MODPACK)
+      downloadUrl=$(curl -Ls -o /dev/null -w %{url_effective} $MODPACK)
       if ! [[ $downloadUrl == *.zip ]]; then
         log "ERROR Invalid URL given for MODPACK: $downloadUrl resolved from $MODPACK"
         log "      Must be HTTP, HTTPS or FTP and a ZIP file"


### PR DESCRIPTION
I ran into this bug when trying to use the MODPACK envar. Example log:
```
[init] Running as uid=1000 gid=1000 with /data as 'drwxrwxr-x 9 1000 1000 4096 Sep 24 04:41 /data'
[init] Resolved version given latest into 1.17.1
[init] Resolving type given FABRIC
curl: unknown --write-out variable: 'effective_url'
[init] ERROR Invalid URL given for MODPACK:  resolved from https://gitlab.com/avionix/minecraft-mods/-/jobs/artifacts/master/raw/ueg-modpack-server.zip?job=ueg
[init]       Must be HTTP, HTTPS or FTP and a ZIP file
```
It seems to be a one-line fix (a typo in a curl variable). I've tested the fix locally and it works as expected.