### PR TITLE
document that default RCON_PASSWORD = minecraft in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -875,6 +875,7 @@ The server icon which has been set doesn't get overridden by default. It can be 
 ### Rcon
 
 To use rcon use the `ENABLE_RCON` and `RCON_PASSWORD` variables.
+The default RCON password is _"minecraft",_ but it's **highly** recommended to override that.
 By default rcon port will be `25575` but can easily be changed with the `RCON_PORT` variable.
 
     docker run -d -e ENABLE_RCON=true -e RCON_PASSWORD=testing


### PR DESCRIPTION
because while experimenting with RCON, it's highly confusing why without a RCON_PASSWORD it happens
to "just work" e.g. with https://github.com/willroberts/minecraft-client (which uses "minecraft" as the default password itself!)
but not with https://github.com/itzg/rcon-cli (which has no default password).

Default passwords are always a bad idea, and should ideally ideally just be removed (if you are willing to make that backward compatible breaking change).