### PR TITLE
Whitelist UUID Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -846,7 +846,13 @@ To whitelist players for your Minecraft server, pass the Minecraft usernames sep
 
     docker run -d -e WHITELIST=user1,user2 ...
 
+or 
+
+    docker run -d -e WHITELIST=uuid1,uuid2 ...
+
 If the `WHITELIST` environment variable is not used, any user can join your Minecraft server if it's publicly accessible.
+
+> NOTE: When using uuids in the whitelist, please make sure it is the dashed variant otherwise it will not parse correctly.
 
 > NOTE: When `WHITELIST` is used the server properties `white-list` and `whitelist` will automatically get set to `true`.
 

--- a/scripts/start-finalExec
+++ b/scripts/start-finalExec
@@ -16,7 +16,11 @@ fi
 if [ -n "$WHITELIST" ]; then
   log "Updating whitelist"
   rm -f /data/white-list.txt.converted
-  echo $WHITELIST | awk -v RS=, '{print}' > /data/white-list.txt
+  if [[ $WHITELIST == *"-"* ]]; then
+    echo $WHITELIST | awk -v RS=, '{print}' | xargs -l -i curl -s https://playerdb.co/api/player/minecraft/{} | jq -r '.["data"]["player"] | {"uuid": .id, "name": .username}' | jq -s . > "whitelist.json"
+  else
+    echo $WHITELIST | awk -v RS=, '{print}' > /data/white-list.txt
+  fi
 fi
 if isTrue "${OVERRIDE_WHITELIST}"; then
   log "Recreating whitelist.json file at server startup"


### PR DESCRIPTION
- Added a check to see if WHITELIST contains a "-", if it does then parse it as a list of UUIDs rather than normal Usernames

NOTE: It's a crude fix and I am by no means good at bash. I just wanted to give it a shot. 