### PR TITLE
Feature: Enforcing resource packs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1067,6 +1067,8 @@ You can set a link to a custom resource pack and set it's checksum using the `RE
 
 **NOTE:** `:` and `=` must be escaped using `\`. The checksum plain-text hexadecimal.
 
+You can enforce the resource pack on clients by setting `RESOURCE_PACK_ENFORCE` to `TRUE` (default: `FALSE`).
+
 ### Level / World Save Name
 
 You can either switch between world saves or run multiple containers with different saves by using the `LEVEL` option,

--- a/README.md
+++ b/README.md
@@ -1063,9 +1063,7 @@ In Minecraft 1.13+ you need to pass json ([generator site](https://misode.github
 
 You can set a link to a custom resource pack and set it's checksum using the `RESOURCE_PACK` and `RESOURCE_PACK_SHA1` options respectively, the default is blank:
 
-    docker run -d -e 'RESOURCE_PACK=http\://link.com/to/pack.zip?\=1' -e 'RESOURCE_PACK_SHA1=d5db29cd03a2ed055086cef9c31c252b4587d6d0'
-
-**NOTE:** `:` and `=` must be escaped using `\`. The checksum plain-text hexadecimal.
+    docker run -d -e 'RESOURCE_PACK=http://link.com/to/pack.zip?=1' -e 'RESOURCE_PACK_SHA1=d5db29cd03a2ed055086cef9c31c252b4587d6d0'
 
 You can enforce the resource pack on clients by setting `RESOURCE_PACK_ENFORCE` to `TRUE` (default: `FALSE`).
 

--- a/scripts/start-setupServerProperties
+++ b/scripts/start-setupServerProperties
@@ -91,6 +91,7 @@ function customizeServerProps {
   setServerProp "allow-flight" ALLOW_FLIGHT
   setServerProp "resource-pack" RESOURCE_PACK
   setServerProp "resource-pack-sha1" RESOURCE_PACK_SHA1
+  setServerProp "require-resource-pack" RESOURCE_PACK_ENFORCE
   setServerProp "player-idle-timeout" PLAYER_IDLE_TIMEOUT
   setServerProp "broadcast-console-to-ops" BROADCAST_CONSOLE_TO_OPS
   setServerProp "broadcast-rcon-to-ops" BROADCAST_RCON_TO_OPS


### PR DESCRIPTION
I've added a `server.properties` override for the 'require-resource-pack' option, to allow server operators to set this in tandem with the other resource pack options.

As an additional change, I've removed the details around escaping requirements, as this is now handled with the setServerPropValue function.

- Add server.properties override for 'require-resource-pack'
- Removed escape requirement note
