### PR TITLE
Fix downloading of craftbukkit when using 1.16.5

### DIFF
--- a/scripts/start-deployBukkitSpigot
+++ b/scripts/start-deployBukkitSpigot
@@ -64,7 +64,7 @@ function downloadSpigot {
   fi
 
   if [[ -z $downloadUrl ]]; then
-    if versionLessThan 1.16.5; then
+    if versionLessThan 1.16.5 || ([[ ${getbukkitFlavor} = "craftbukkit" ]] && [[ ${VANILLA_VERSION} = "1.16.5" ]]); then
       downloadUrl="https://cdn.getbukkit.org/${getbukkitFlavor}/${getbukkitFlavor}-${VANILLA_VERSION}.jar"
     else
       downloadUrl="https://download.getbukkit.org/${getbukkitFlavor}/${getbukkitFlavor}-${VANILLA_VERSION}.jar"


### PR DESCRIPTION
The previous logic attempted to download craftbukkit from [1]. This resulted in a 404.
This commit adjusts this logic and uses the alternative download site at [2].

[1]: https://download.getbukkit.org/craftbukkit/craftbukkit-1.16.5.jar
[2]: https://cdn.getbukkit.org/craftbukkit/craftbukkit-1.16.5.jar

---

# Verifying the fix

## Current logic

```bash
docker run --rm -it -e EULA=true -e TYPE=craftbukkit -e VERSION=1.16.5 itzg/minecraft-server:java8
[init] Running as uid=1000 gid=1000 with /data as 'drwxrwxrwx    2 1000     1000          4096 Nov 24 20:37 /data'
[init] Resolved version given 1.16.5 into 1.16.5
[init] Resolving type given craftbukkit
[init] Downloading CraftBukkit from https://download.getbukkit.org/craftbukkit/craftbukkit-1.16.5.jar ...
curl: (22) The requested URL returned error: 404 Not Found
```

## Updated logic

```bash
docker run --rm -it -e EULA=true -e TYPE=craftbukkit -e VERSION=1.16.5 mc-multiarch
[init] Running as uid=1000 gid=1000 with /data as 'drwxrwxr-x 2 1000 1000 4096 Dec  2 15:39 /data'
[init] Resolved version given 1.16.5 into 1.16.5
[init] Resolving type given craftbukkit
[init] Downloading CraftBukkit from https://cdn.getbukkit.org/craftbukkit/craftbukkit-1.16.5.jar ...
[init] Creating server.properties in /data/server.properties
[init] Disabling whitelist
[init] Setting whitelist to 'false' in /data/server.properties
[init] Setting white-list to 'false' in /data/server.properties
[init] Setting enable-rcon to 'true' in /data/server.properties
[init] Setting rcon.password to 'minecraft' in /data/server.properties
[init] Setting rcon.port to '25575' in /data/server.properties
[init] Setting motd to 'A Craftbukkit Minecraft Server powered by Docker' in /data/server.properties
[init] Checking for JSON files.
[init] Setting initial memory to 1G and max to 1G
[init] Starting the Minecraft server...
Unsupported Java detected (61.0). Only up to Java 15 is supported.
```