### PR TITLE
Implement support for packwiz modpacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ By default, the container will download the latest version of the "vanilla" [Min
       * [Modpack data directory](#modpack-data-directory)
       * [Buggy start scripts](#buggy-start-scripts)
       * [Fixing "unable to launch forgemodloader"](#fixing-unable-to-launch-forgemodloader)
+   * [Running a server with a packwiz modpack](#running-a-server-with-a-packwiz-modpack)
    * [Working with mods and plugins](#working-with-mods-and-plugins)
       * [Optional plugins, mods, and config attach points](#optional-plugins-mods-and-config-attach-points)
       * [Auto-downloading SpigotMC/Bukkit/PaperMC plugins](#auto-downloading-spigotmcbukkitpapermc-plugins)
@@ -659,6 +660,20 @@ If your server's modpack fails to load with an error [like this](https://support
 then you apply a workaround by adding this to the run invocation:
 
     -e FTB_LEGACYJAVAFIXER=true
+
+## Running a server with a packwiz modpack
+
+[packwiz](https://packwiz.infra.link/) is a CLI tool for maintaining and providing modpack definitions, with support for both CurseForge and Modrinth as sources. See the [packwiz tutorial](https://packwiz.infra.link/tutorials/getting-started/) for more information.
+
+To configure server mods using a packwiz modpack, set the `PACKWIZ_URL` environment variable to the location of your `pack.toml` modpack definition:
+
+    docker run -d -v /path/on/host:/data -e TYPE=FABRIC \
+        -e "PACKWIZ_URL=https://example.com/modpack/pack.toml" \
+        itzg/minecraft-server
+
+packwiz modpack defitions are processed before other mod definitions (`MODPACK`, `MODS`, etc.) to allow for additional processing/overrides you may want to perform (in case of mods not available via Modrinth/CurseForge, or you do not maintain the pack).
+
+> packwiz is pre-configured to only download server mods. If client-side mods are downloaded and cause issues, check your pack.toml configuration, and make sure any client-only mods are not set to `"both"`, but rather `"client"` for the side configuration item.
 
 ## Working with mods and plugins
 

--- a/scripts/start-setupModpack
+++ b/scripts/start-setupModpack
@@ -20,6 +20,33 @@ if isTrue "${REMOVE_OLD_MODS}" && [ -z "${MODS_FILE}" ]; then
   removeOldMods /data/plugins
 fi
 
+# If packwiz url passed, bootstrap packwiz and update mods before other modpack processing
+if [[ "${PACKWIZ_URL}" ]]; then
+  # Ensure we have the latest packwiz bootstrap installer
+  latestPackwiz=$(curl -fsSL https://api.github.com/repos/comp500/packwiz-installer-bootstrap/releases/latest)
+  if [[ -z "${latestPackwiz}" ]]; then
+    log "WARNING: Could not retrieve Packwiz bootstrap installer release information"
+  else
+    isDebugging && log "Latest packwiz ${latestPackWiz}"
+    latestPackwizVer=$(echo ${latestPackwiz} | jq --raw-output '.tag_name')
+    latestPackwizUrl=$(echo ${latestPackwiz} | jq --raw-output '.assets[] | select(.name | match("packwiz-installer-bootstrap.jar")) | .url')
+    : "${PACKWIZ_JAR:=packwiz-installer-bootstrap_${latestPackwizVer}.jar}"
+    if [[ ! -e $PACKWIZ_JAR ]]; then
+      log "Downloading Packwiz ${latestPackwizVer}"
+      curl -H "Accept:application/octet-stream" -o "$PACKWIZ_JAR" -fsSL ${latestPackwizUrl}
+      ln -sf "${PACKWIZ_JAR}" packwiz-installer-bootstrap.jar
+    fi
+  fi
+  if [[ ! -e packwiz-installer-bootstrap.jar ]]; then
+    log "ERROR: Packwiz not available or could not be downloaded from Github!"
+    exit 1
+  fi
+  if isURL "${PACKWIZ_URL}"; then
+    log "Running packwiz against URL: ${PACKWIZ_URL}"
+    java -jar packwiz-installer-bootstrap.jar -g -s server "${PACKWIZ_URL}"
+  fi
+fi
+
 # If supplied with a URL for a modpack (simple zip of jars), download it and unpack
 if [[ "$MODPACK" ]]; then
   if isURL "${MODPACK}"; then


### PR DESCRIPTION
See https://packwiz.infra.link/ for packwiz information

This PR adds support for packwiz server modpack definitions provided via the `PACKWIZ_URL` environment variable.

Packwiz modpack definitions are processed before other mod definitions (`MODPACK`, `MODS`, etc.) to allow for additional processing/overrides the operator may want to perform (in case of mods not available via Modrinth/CurseForge, or where the pack is not maintained by the operator).

We attempt to retrieve the latest bootstrap jar from Github if it doesn't already exist. If for any reason retrieving release information from Github isn't possible, we'll use the existing bootstrap jar if already available.

Packwiz is pre-configured to show no GUI and only download server mods. A relevant note to `README.md` has been added to clarify this, and informs operators to check their packwiz definition is correct in case client mods are downloaded and cause such issues.