### PR TITLE
Rework whitelist and ops support

### DIFF
--- a/README.md
+++ b/README.md
@@ -852,7 +852,7 @@ To whitelist players for your Minecraft server, you can:
 - Provide a list of usernames and/or UUIDs separated by commas via the `WHITELIST` environment variable  
     `docker run -d -e WHITELIST=user1,uuid2 ...`
 
-If either `WHITELIST_FILE` or `WHITELIST` is provided, the server properties `white-list` and `whitelist` will automatically get set to `true`. Therefore **by default** any user can join your Minecraft server if it's publicly accessible.
+To enforce the whitelist and auto-kick players not included in whitelist configuration, set `ENFORCE_WHITELIST=TRUE`. **By default** any user can join your Minecraft server if it's publicly accessible, regardless of your whitelist configuration.
 
 If whitelist configuration already exists, `WHITELIST_FILE` will not be retrieved and any usernames in `WHITELIST` are **added** to the whitelist configuration. You can enforce regeneration of the whitelist on each server startup by setting `OVERRIDE_WHITELIST` to "true". This will delete the whitelist file before processing whitelist configuration.
 
@@ -862,7 +862,7 @@ If whitelist configuration already exists, `WHITELIST_FILE` will not be retrieve
 
 > If running Minecraft 1.7.5 or earlier, these variables will apply to `white-list.txt`, with 1.7.6 implementing support for `whitelist.json`. Make sure your `WHITELIST_FILE` is in the appropriate format.
 
-Alternatively, you can set `ENABLE_WHITELIST=true` to only set the server properties `white-list` and `whitelist` without modifying the whitelist file. In this case the whitelist is solely managed using the `whitelist add` and `whitelist remove` commands.
+If either `WHITELIST_FILE` or `WHITELIST` is provided, the server property `white-list` is automatically set to `true`, enabline whitelist functionality. Alternatively you can set `ENABLE_WHITELIST=TRUE` to only set the server property `white-list` without modifying the whitelist file. In this case the whitelist can be managed using the `whitelist add` and `whitelist remove` commands. Remember you can set enforcement via the `ENFORCE_WHITELIST` variable.
 
 ### Op/Administrator Players
 

--- a/README.md
+++ b/README.md
@@ -846,30 +846,35 @@ values.
 
 > **NOTE** it is very important to set this with servers exposed to the internet where you want only limited players to join.
 
-To whitelist players for your Minecraft server, pass the Minecraft usernames separated by commas via the `WHITELIST` environment variable, such as
+To whitelist players for your Minecraft server, you can:
+- Provide the url or path to a whitelist file via `WHITELIST_FILE` environment variable  
+    `docker run -d -e WHITELIST_FILE=/extra/whitelist.json ...`
+- Provide a list of usernames and/or UUIDs separated by commas via the `WHITELIST` environment variable  
+    `docker run -d -e WHITELIST=user1,uuid2 ...`
 
-    docker run -d -e WHITELIST=user1,user2 ...
+If either `WHITELIST_FILE` or `WHITELIST` is provided, the server properties `white-list` and `whitelist` will automatically get set to `true`. Therefore **by default** any user can join your Minecraft server if it's publicly accessible.
 
-or 
+If whitelist configuration already exists, `WHITELIST_FILE` will not be retrieved and any usernames in `WHITELIST` are **added** to the whitelist configuration. You can enforce regeneration of the whitelist on each server startup by setting `OVERRIDE_WHITELIST` to "true". This will delete the whitelist file before processing whitelist configuration.
 
-    docker run -d -e WHITELIST=uuid1,uuid2 ...
+> NOTE: You can provide both `WHITELIST_FILE` and `WHITELIST`, which are processed in that order.
 
-If the `WHITELIST` environment variable is not used, any user can join your Minecraft server if it's publicly accessible.
+> NOTE: UUIDs passed via `WHITELIST` need to be the dashed variant, otherwise it not be recognised and instead added as a username.
 
-> NOTE: When using uuids in the whitelist, please make sure it is the dashed variant otherwise it will not parse correctly.
-
-> NOTE: When `WHITELIST` is used the server properties `white-list` and `whitelist` will automatically get set to `true`.
-
-> By default, the players in `WHITELIST` are **added** to the final `whitelist.json` file by the Minecraft server. If you set `OVERRIDE_WHITELIST` to "true" then the `whitelist.json` file will be recreated on each server startup.
+> If running Minecraft 1.7.5 or earlier, these variables will apply to `white-list.txt`, with 1.7.6 implementing support for `whitelist.json`. Make sure your `WHITELIST_FILE` is in the appropriate format.
 
 Alternatively, you can set `ENABLE_WHITELIST=true` to only set the server properties `white-list` and `whitelist` without modifying the whitelist file. In this case the whitelist is solely managed using the `whitelist add` and `whitelist remove` commands.
+
 ### Op/Administrator Players
 
-To add more "op" (aka adminstrator) users to your Minecraft server, pass the Minecraft usernames separated by commas via the `OPS` environment variable, such as
+Similar to the whitelist, to add users as operators (aka adminstrators) to your Minecraft server, you can:
+- Provide te url or path to an ops file via `OPS_FILE` environment variable  
+    `docker run -d -e OPS_FILE=https://config.example.com/extra/ops.json ...`
+- Provide a list of usernames and/or UUIDs separated by commas via the `OPS` environment variable  
+    `docker run -d -e OPS=user1,uuid2 ...`
 
-    docker run -d -e OPS=user1,user2 ...
+If ops configuration already exists, `OPS_FILE` will not be retrieved and any usernames in `OPS` are **added** to the ops configuration. You can enforce regeneration of the ops configuration on each server startup by setting `OVERRIDE_OPS` to "true". This will delete the ops file before processing ops configuration.
 
-> By default, the players in `OPS` are **added** to the final `ops.json` file by the Minecraft server. If you set `OVERRIDE_OPS` to "true" then the `ops.json` file will be recreated on each server startup.
+> Similar to whitelists, you can provide both `OPS_FILE` and `OPS`, and Minecraft 1.7.5 or earlier will use `ops.txt` rather than `ops.json`.
 
 ### Server icon
 

--- a/scripts/start-finalExec
+++ b/scripts/start-finalExec
@@ -3,16 +3,20 @@
 . ${SCRIPTS:-/}start-utils
 isDebugging && set -x
 
+if isTrue "${OVERRIDE_OPS}"; then
+  log "Recreating ops.json file at server startup"
+  rm -f /data/ops.json
+fi
 if [ -n "$OPS" ]; then
   log "Updating ops"
   rm -f /data/ops.txt.converted
   echo $OPS | awk -v RS=, '{print}' > /data/ops.txt
 fi
-if isTrue "${OVERRIDE_OPS}"; then
-  log "Recreating ops.json file at server startup"
-  rm -f /data/ops.json
-fi
 
+if isTrue "${OVERRIDE_WHITELIST}"; then
+  log "Recreating whitelist.json file at server startup"
+  rm -f /data/whitelist.json
+fi
 if [ -n "$WHITELIST" ]; then
   log "Updating whitelist"
   rm -f /data/white-list.txt.converted
@@ -21,10 +25,6 @@ if [ -n "$WHITELIST" ]; then
   else
     echo $WHITELIST | awk -v RS=, '{print}' > /data/white-list.txt
   fi
-fi
-if isTrue "${OVERRIDE_WHITELIST}"; then
-  log "Recreating whitelist.json file at server startup"
-  rm -f /data/whitelist.json
 fi
 
 if [ -n "$ICON" ]; then

--- a/scripts/start-finalExec
+++ b/scripts/start-finalExec
@@ -4,10 +4,19 @@
 isDebugging && set -x
 
 if isTrue "${OVERRIDE_OPS}"; then
-  log "Recreating ops.json file at server startup"
-  rm -f /data/ops.json
+  if versionLessThan 1.7.6; then
+    log "Recreating ops.txt file at server startup"
+    rm -f /data/ops.txt
+  else
+    log "Recreating ops.json file at server startup"
+    rm -f /data/ops.json
+  fi
 fi
 if [ -n "$OPS_JSON" ] && [ ! -e "/data/ops.json" ]; then
+  if versionLessThan 1.7.6; then
+    log "ERROR: OPS_JSON not supported on 1.7.5 and below!"
+    exit 1
+  fi
   if isURL "${OPS_JSON}"; then
     log "Downloading ops.json from ${OPS_JSON}"
     if ! get -o /data/ops.json "${OPS_JSON}"; then
@@ -28,15 +37,29 @@ if [ -n "$OPS_JSON" ] && [ ! -e "/data/ops.json" ]; then
 fi
 if [ -n "$OPS" ]; then
   log "Updating ops"
-  rm -f /data/ops.txt.converted
-  echo $OPS | awk -v RS=, '{print}' > /data/ops.txt
+  if versionLessThan 1.7.6; then
+    echo $OPS | awk -v RS=, '{print}' >> /data/ops.txt
+    sort -u ops.txt -o ops.txt
+  else
+    rm -f /data/ops.txt.converted
+    echo $OPS | awk -v RS=, '{print}' > /data/ops.txt
+  fi
 fi
 
 if isTrue "${OVERRIDE_WHITELIST}"; then
-  log "Recreating whitelist.json file at server startup"
-  rm -f /data/whitelist.json
+  if versionLessThan 1.7.6; then
+    log "Recreating white-list.txt file at server startup"
+    rm -f /data/white-list.txt
+  else
+    log "Recreating whitelist.json file at server startup"
+    rm -f /data/whitelist.json
+  fi
 fi
 if [ -n "$WHITELIST_JSON" ] && [ ! -e "/data/whitelist.json" ]; then
+  if versionLessThan 1.7.6; then
+    log "ERROR: WHITELIST_JSON not supported on 1.7.5 and below!"
+    exit 1
+  fi
   if isURL "${WHITELIST_JSON}"; then
     log "Downloading whitelist.json from ${WHITELIST_JSON}"
     if ! get -o /data/whitelist.json "${WHITELIST_JSON}"; then
@@ -57,11 +80,22 @@ if [ -n "$WHITELIST_JSON" ] && [ ! -e "/data/whitelist.json" ]; then
 fi
 if [ -n "$WHITELIST" ]; then
   log "Updating whitelist"
-  rm -f /data/white-list.txt.converted
-  if [[ $WHITELIST == *"-"* ]]; then
-    echo $WHITELIST | awk -v RS=, '{print}' | xargs -l -i curl -s https://playerdb.co/api/player/minecraft/{} | jq -r '.["data"]["player"] | {"uuid": .id, "name": .username}' | jq -s . > "whitelist.json"
+  if versionLessThan 1.7.6; then
+    echo $WHITELIST | awk -v RS=, '{print}' >> /data/white-list.txt
+    sort -u white-list.txt -o white-list.txt
   else
-    echo $WHITELIST | awk -v RS=, '{print}' > /data/white-list.txt
+    if [[ $WHITELIST == *"-"* ]]; then
+      local newList=$(echo $WHITELIST | awk -v RS=, '{print}' | xargs -l -i curl -s https://playerdb.co/api/player/minecraft/{} | jq -r '.["data"]["player"] | {"uuid": .id, "name": .username}' | jq -s .)
+      if [ -e /data/whitelist.json ]; then
+        local currentList=$(cat /data/whitelist.json)
+        jq --argjson current "$currentList" --argjson new "$newList" -n '$new + $current | unique_by(.uuid)' > /data/whitelist.json
+      else
+        echo $newList > /data/whitelist.json
+      fi
+    else
+      rm -f /data/white-list.txt.converted
+      echo $WHITELIST | awk -v RS=, '{print}' > /data/white-list.txt
+    fi
   fi
 fi
 

--- a/scripts/start-finalExec
+++ b/scripts/start-finalExec
@@ -11,92 +11,80 @@ else
   whitelistFile=whitelist.json
 fi
 
+function process_user_file() {
+  local output=$1
+  local source=$2
+
+  if isURL "$source"; then
+    log "Downloading $output from $source"
+    if ! get -o /data/$output "$source"; then
+      log "ERROR: failed to download from $source"
+      exit 2
+    fi
+  else
+    log "Copying $output from $source"
+    if ! cp "$source" /data/$output; then
+      log "ERROR: failed to copy from $source"
+      exit 1
+    fi
+  fi
+}
+
+function process_user_csv() {
+  local output=$1
+  local list=$2
+
+  if [[ "$output" == *"ops"* ]]; then
+    # Extra data for ops.json
+    userData='{"uuid": .id, "name": .username, "level": 4}'
+  else
+    userData='{"uuid": .id, "name": .username}'
+  fi
+
+  log "Updating ${output%.*}"
+  for i in ${list//,/ }
+  do
+    if ! playerData=$(get "https://playerdb.co/api/player/minecraft/$i" | jq -re ".data.player"); then
+      log "WARNING: Could not lookup user $i for ${output} addition"
+    else
+      playerDataList=$playerDataList$(echo $playerData | jq -r "$userData")
+    fi
+  done
+  local newUsers=$(echo $playerDataList | jq -s .)
+  if [[ $output =~ .*\.txt ]]; then
+    # username list for txt config (Minecraft <= 1.7.5)
+    echo $newUsers | jq -r '.[].name' >> /data/${output}
+    sort -u /data/${output} -o /data/${output}
+  elif [ -e /data/${output} ]; then
+    # Merge with existing json file
+    local currentUsers=$(cat /data/${output})
+    jq --argjson current "$currentUsers" --argjson new "$newUsers" -n '$new + $current | unique_by(.uuid)' > /data/${output}
+  else
+    # New json file
+    echo $newUsers > /data/${output}
+  fi
+}
+
 if isTrue "${OVERRIDE_OPS}"; then
   log "Recreating ${opsFile} file at server startup"
   rm -f /data/${opsFile}
 fi
-if [ -n "$OPS_FILE" ] && [ ! -e /data/${opsFile} ]; then
-  if isURL "${OPS_FILE}"; then
-    log "Downloading ${opsFile} from ${OPS_FILE}"
-    if ! get -o /data/${opsFile} "${OPS_FILE}"; then
-      log "ERROR: failed to download from ${OPS_FILE}"
-      exit 2
-    fi
-  else
-    log "Copying ${opsFile} from ${OPS_FILE}"
-    if ! cp "${OPS_FILE}" /data/${opsFile}; then
-      log "ERROR: failed to copy from ${OPS_FILE}"
-      exit 1
-    fi
-  fi
+if [ -n "${OPS_FILE}" ] && [ ! -e "/data/${opsFile}" ]; then
+  process_user_file ${opsFile} "$OPS_FILE"
 fi
-if [ -n "$OPS" ]; then
-  log "Updating ops"
-  for i in ${OPS//,/}
-  do
-    if ! playerData=$(get --json-path '.["data"]["player"]' "https://playerdb.co/api/player/minecraft/$i"); then
-      log "WARNING: Could not lookup user $i for ${opsFile} addition"
-    else
-      opsData=$opsData$(echo $playerData | jq -r '{"uuid": .id, "name": .username, "level": 4, "bypassesPlayerLimit": false}')
-    fi
-  done
-  local newOps=$(echo $opsData | jq -s .)
-  if [ $opsFile == ops.txt ]; then
-    # username list for ops.txt (Minecraft <= 1.7.5)
-    echo $newOps | jq -r '.[].name' >> /data/${opsFile}
-    sort -u /data/${opsFile} -o /data/${opsFile}
-  elif [ -e /data/${opsFile} ]; then
-    # Merge with existing ops.json file
-    local currentOps=$(cat /data/${opsFile})
-    jq --argjson current "$currentOps" --argjson new "$newOps" -n '$new + $current | unique_by(.uuid)' > /data/${opsFile}
-  else
-    # New ops.json file
-    echo $newOps > /data/${opsFile}
-  fi
+if [ -n "${OPS}" ]; then
+  process_user_csv ${opsFile} "$OPS"
 fi
 
 if isTrue "${OVERRIDE_WHITELIST}"; then
   log "Recreating ${whitelistFile} file at server startup"
   rm -f /data/${whitelistFile}
 fi
-if [ -n "$WHITELIST_FILE" ] && [ ! -e "/data/${whitelistFile}" ]; then
-  if isURL "${WHITELIST_FILE}"; then
-    log "Downloading ${whitelistFile} from ${WHITELIST_FILE}"
-    if ! get -o /data/${whitelistFile} "${WHITELIST_FILE}"; then
-      log "ERROR: failed to download from ${WHITELIST_FILE}"
-      exit 2
-    fi
-  else
-    log "Copying ${whitelistFile} from ${WHITELIST_FILE}"
-    if ! cp "${WHITELIST_FILE}" /data/${whitelistFile}; then
-      log "ERROR: failed to copy from ${WHITELIST_FILE}"
-      exit 1
-    fi
-  fi
+if [ -n "${WHITELIST_FILE}" ] && [ ! -e "/data/${whitelistFile}" ]; then
+  process_user_file ${whitelistFile} "$WHITELIST_FILE"
 fi
-if [ -n "$WHITELIST" ]; then
-  log "Updating whitelist"
-  for i in ${WHITELIST//,/}
-  do
-    if ! playerData=$(get --json-path '.["data"]["player"]' "https://playerdb.co/api/player/minecraft/$i"); then
-      log "WARNING: Could not lookup user $i for ${whitelistFile} addition"
-    else
-      listData=$listData$(echo $playerData | jq -r '{"uuid": .id, "name": .username}')
-    fi
-  done
-  local newList=$(echo $listData | jq -s .)
-  if [ $whitelistFile == white-list.txt ]; then
-    # username list for white-list.txt (Minecraft <= 1.7.5)
-    echo $newList | jq -r '.[].name' >> /data/${whitelistFile}
-    sort -u /data/${whitelistFile} -o /data/${whitelistFile}
-  elif [ -e /data/${whitelistFile} ]; then
-    # Merge with existing whitelist.json file
-    local currentList=$(cat /data/${whitelistFile})
-    jq --argjson current "$currentList" --argjson new "$newList" -n '$new + $current | unique_by(.uuid)' > /data/${whitelistFile}
-  else
-    # New whitelist.json file
-    echo $newList > /data/${whitelistFile}
-  fi
+if [ -n "${WHITELIST}" ]; then
+  process_user_csv ${whitelistFile} "$WHITELIST"
 fi
 
 if [ -n "$ICON" ]; then

--- a/scripts/start-finalExec
+++ b/scripts/start-finalExec
@@ -32,9 +32,27 @@ if [ -n "$OPS_FILE" ] && [ ! -e /data/${opsFile} ]; then
 fi
 if [ -n "$OPS" ]; then
   log "Updating ops"
-  echo $OPS | awk -v RS=, '{print}' >> /data/ops.txt
-  sort -u ops.txt -o ops.txt
-  rm -f /data/ops.txt.converted
+  for i in ${OPS//,/}
+  do
+    if ! playerData=$(get --json-path '.["data"]["player"]' "https://playerdb.co/api/player/minecraft/$i"); then
+      log "WARNING: Could not lookup user $i for ${opsFile} addition"
+    else
+      opsData=$opsData$(echo $playerData | jq -r '{"uuid": .id, "name": .username, "level": 4, "bypassesPlayerLimit": false}')
+    fi
+  done
+  local newOps=$(echo $opsData | jq -s .)
+  if [ $opsFile == ops.txt ]; then
+    # username list for ops.txt (Minecraft <= 1.7.5)
+    echo $newOps | jq -r '.[].name' >> /data/${opsFile}
+    sort -u /data/${opsFile} -o /data/${opsFile}
+  elif [ -e /data/${opsFile} ]; then
+    # Merge with existing ops.json file
+    local currentOps=$(cat /data/${opsFile})
+    jq --argjson current "$currentOps" --argjson new "$newOps" -n '$new + $current | unique_by(.uuid)' > /data/${opsFile}
+  else
+    # New ops.json file
+    echo $newOps > /data/${opsFile}
+  fi
 fi
 
 if isTrue "${OVERRIDE_WHITELIST}"; then
@@ -58,22 +76,26 @@ if [ -n "$WHITELIST_FILE" ] && [ ! -e "/data/${whitelistFile}" ]; then
 fi
 if [ -n "$WHITELIST" ]; then
   log "Updating whitelist"
-  if versionLessThan 1.7.6; then
-    echo $WHITELIST | awk -v RS=, '{print}' >> /data/white-list.txt
-    sort -u white-list.txt -o white-list.txt
-  else
-    if [[ $WHITELIST == *"-"* ]]; then
-      local newList=$(echo $WHITELIST | awk -v RS=, '{print}' | xargs -l -i curl -s https://playerdb.co/api/player/minecraft/{} | jq -r '.["data"]["player"] | {"uuid": .id, "name": .username}' | jq -s .)
-      if [ -e /data/whitelist.json ]; then
-        local currentList=$(cat /data/whitelist.json)
-        jq --argjson current "$currentList" --argjson new "$newList" -n '$new + $current | unique_by(.uuid)' > /data/whitelist.json
-      else
-        echo $newList > /data/whitelist.json
-      fi
+  for i in ${WHITELIST//,/}
+  do
+    if ! playerData=$(get --json-path '.["data"]["player"]' "https://playerdb.co/api/player/minecraft/$i"); then
+      log "WARNING: Could not lookup user $i for ${whitelistFile} addition"
     else
-      rm -f /data/white-list.txt.converted
-      echo $WHITELIST | awk -v RS=, '{print}' > /data/white-list.txt
+      listData=$listData$(echo $playerData | jq -r '{"uuid": .id, "name": .username}')
     fi
+  done
+  local newList=$(echo $listData | jq -s .)
+  if [ $whitelistFile == white-list.txt ]; then
+    # username list for white-list.txt (Minecraft <= 1.7.5)
+    echo $newList | jq -r '.[].name' >> /data/${whitelistFile}
+    sort -u /data/${whitelistFile} -o /data/${whitelistFile}
+  elif [ -e /data/${whitelistFile} ]; then
+    # Merge with existing whitelist.json file
+    local currentList=$(cat /data/${whitelistFile})
+    jq --argjson current "$currentList" --argjson new "$newList" -n '$new + $current | unique_by(.uuid)' > /data/${whitelistFile}
+  else
+    # New whitelist.json file
+    echo $newList > /data/${whitelistFile}
   fi
 fi
 

--- a/scripts/start-finalExec
+++ b/scripts/start-finalExec
@@ -33,6 +33,7 @@ function process_user_file() {
 function process_user_csv() {
   local output=$1
   local list=$2
+  local playerDataList
 
   if [[ "$output" == *"ops"* ]]; then
     # Extra data for ops.json

--- a/scripts/start-finalExec
+++ b/scripts/start-finalExec
@@ -3,79 +3,57 @@
 . ${SCRIPTS:-/}start-utils
 isDebugging && set -x
 
-if isTrue "${OVERRIDE_OPS}"; then
-  if versionLessThan 1.7.6; then
-    log "Recreating ops.txt file at server startup"
-    rm -f /data/ops.txt
-  else
-    log "Recreating ops.json file at server startup"
-    rm -f /data/ops.json
-  fi
+if versionLessThan 1.7.6; then
+  opsFile=ops.txt
+  whitelistFile=white-list.txt
+else
+  opsFile=ops.json
+  whitelistFile=whitelist.json
 fi
-if [ -n "$OPS_JSON" ] && [ ! -e "/data/ops.json" ]; then
-  if versionLessThan 1.7.6; then
-    log "ERROR: OPS_JSON not supported on 1.7.5 and below!"
-    exit 1
-  fi
-  if isURL "${OPS_JSON}"; then
-    log "Downloading ops.json from ${OPS_JSON}"
-    if ! get -o /data/ops.json "${OPS_JSON}"; then
-      log "ERROR: failed to download from ${OPS_JSON}"
+
+if isTrue "${OVERRIDE_OPS}"; then
+  log "Recreating ${opsFile} file at server startup"
+  rm -f /data/${opsFile}
+fi
+if [ -n "$OPS_FILE" ] && [ ! -e /data/${opsFile} ]; then
+  if isURL "${OPS_FILE}"; then
+    log "Downloading ${opsFile} from ${OPS_FILE}"
+    if ! get -o /data/${opsFile} "${OPS_FILE}"; then
+      log "ERROR: failed to download from ${OPS_FILE}"
       exit 2
     fi
   else
-    log "Copying ops.json from ${OPS_JSON}"
-    if ! cp "${OPS_JSON}" /data/ops.json; then
-      log "ERROR: failed to copy from ${OPS_JSON}"
+    log "Copying ${opsFile} from ${OPS_FILE}"
+    if ! cp "${OPS_FILE}" /data/${opsFile}; then
+      log "ERROR: failed to copy from ${OPS_FILE}"
       exit 1
     fi
-  fi
-  if ! cat /data/ops.json | jq empty; then
-    log "ERROR: ${OPS_JSON} is not valid JSON!"
-    exit 1
   fi
 fi
 if [ -n "$OPS" ]; then
   log "Updating ops"
-  if versionLessThan 1.7.6; then
-    echo $OPS | awk -v RS=, '{print}' >> /data/ops.txt
-    sort -u ops.txt -o ops.txt
-  else
-    rm -f /data/ops.txt.converted
-    echo $OPS | awk -v RS=, '{print}' > /data/ops.txt
-  fi
+  echo $OPS | awk -v RS=, '{print}' >> /data/ops.txt
+  sort -u ops.txt -o ops.txt
+  rm -f /data/ops.txt.converted
 fi
 
 if isTrue "${OVERRIDE_WHITELIST}"; then
-  if versionLessThan 1.7.6; then
-    log "Recreating white-list.txt file at server startup"
-    rm -f /data/white-list.txt
-  else
-    log "Recreating whitelist.json file at server startup"
-    rm -f /data/whitelist.json
-  fi
+  log "Recreating ${whitelistFile} file at server startup"
+  rm -f /data/${whitelistFile}
 fi
-if [ -n "$WHITELIST_JSON" ] && [ ! -e "/data/whitelist.json" ]; then
-  if versionLessThan 1.7.6; then
-    log "ERROR: WHITELIST_JSON not supported on 1.7.5 and below!"
-    exit 1
-  fi
-  if isURL "${WHITELIST_JSON}"; then
-    log "Downloading whitelist.json from ${WHITELIST_JSON}"
-    if ! get -o /data/whitelist.json "${WHITELIST_JSON}"; then
-      log "ERROR: failed to download from ${WHITELIST_JSON}"
+if [ -n "$WHITELIST_FILE" ] && [ ! -e "/data/${whitelistFile}" ]; then
+  if isURL "${WHITELIST_FILE}"; then
+    log "Downloading ${whitelistFile} from ${WHITELIST_FILE}"
+    if ! get -o /data/${whitelistFile} "${WHITELIST_FILE}"; then
+      log "ERROR: failed to download from ${WHITELIST_FILE}"
       exit 2
     fi
   else
-    log "Copying whitelist.json from ${WHITELIST_JSON}"
-    if ! cp "${WHITELIST_JSON}" /data/whitelist.json; then
-      log "ERROR: failed to copy from ${WHITELIST_JSON}"
+    log "Copying ${whitelistFile} from ${WHITELIST_FILE}"
+    if ! cp "${WHITELIST_FILE}" /data/${whitelistFile}; then
+      log "ERROR: failed to copy from ${WHITELIST_FILE}"
       exit 1
     fi
-  fi
-  if ! cat /data/whitelist.json | jq empty; then
-    log "ERROR: ${WHITELIST_JSON} is not valid JSON!"
-    exit 1
   fi
 fi
 if [ -n "$WHITELIST" ]; then

--- a/scripts/start-finalExec
+++ b/scripts/start-finalExec
@@ -44,6 +44,10 @@ function process_user_csv() {
   log "Updating ${output%.*}"
   for i in ${list//,/ }
   do
+    if [ -e "$output" ] && grep -q "$i" "$output"; then
+      log "$i already present in $output, skipping"
+      continue
+    fi
     if ! playerData=$(get "https://playerdb.co/api/player/minecraft/$i" | jq -re ".data.player"); then
       log "WARNING: Could not lookup user $i for ${output} addition"
     else

--- a/scripts/start-finalExec
+++ b/scripts/start-finalExec
@@ -7,6 +7,25 @@ if isTrue "${OVERRIDE_OPS}"; then
   log "Recreating ops.json file at server startup"
   rm -f /data/ops.json
 fi
+if [ -n "$OPS_JSON" ] && [ ! -e "/data/ops.json" ]; then
+  if isURL "${OPS_JSON}"; then
+    log "Downloading ops.json from ${OPS_JSON}"
+    if ! get -o /data/ops.json "${OPS_JSON}"; then
+      log "ERROR: failed to download from ${OPS_JSON}"
+      exit 2
+    fi
+  else
+    log "Copying ops.json from ${OPS_JSON}"
+    if ! cp "${OPS_JSON}" /data/ops.json; then
+      log "ERROR: failed to copy from ${OPS_JSON}"
+      exit 1
+    fi
+  fi
+  if ! cat /data/ops.json | jq empty; then
+    log "ERROR: ${OPS_JSON} is not valid JSON!"
+    exit 1
+  fi
+fi
 if [ -n "$OPS" ]; then
   log "Updating ops"
   rm -f /data/ops.txt.converted
@@ -16,6 +35,25 @@ fi
 if isTrue "${OVERRIDE_WHITELIST}"; then
   log "Recreating whitelist.json file at server startup"
   rm -f /data/whitelist.json
+fi
+if [ -n "$WHITELIST_JSON" ] && [ ! -e "/data/whitelist.json" ]; then
+  if isURL "${WHITELIST_JSON}"; then
+    log "Downloading whitelist.json from ${WHITELIST_JSON}"
+    if ! get -o /data/whitelist.json "${WHITELIST_JSON}"; then
+      log "ERROR: failed to download from ${WHITELIST_JSON}"
+      exit 2
+    fi
+  else
+    log "Copying whitelist.json from ${WHITELIST_JSON}"
+    if ! cp "${WHITELIST_JSON}" /data/whitelist.json; then
+      log "ERROR: failed to copy from ${WHITELIST_JSON}"
+      exit 1
+    fi
+  fi
+  if ! cat /data/whitelist.json | jq empty; then
+    log "ERROR: ${WHITELIST_JSON} is not valid JSON!"
+    exit 1
+  fi
 fi
 if [ -n "$WHITELIST" ]; then
   log "Updating whitelist"

--- a/scripts/start-setupServerProperties
+++ b/scripts/start-setupServerProperties
@@ -33,14 +33,17 @@ function setServerProp {
 }
 
 function customizeServerProps {
-  if [ -n "$WHITELIST" ] || isTrue "${ENABLE_WHITELIST:-false}"; then
-    log "Creating whitelist"
-    setServerPropValue "whitelist" "true"
+  # Whitelist processing
+  if [ -n "$WHITELIST" ] || [ -n "$WHITELIST_FILE" ] || isTrue "${ENABLE_WHITELIST:-false}"; then
+    log "Enabling whitelist functionality"
     setServerPropValue "white-list" "true"
   else
-    log "Disabling whitelist"
-    setServerPropValue "whitelist" "false"
+    log "Disabling whitelist functionality"
     setServerPropValue "white-list" "false"
+  fi
+  setServerProp "enforce-whitelist" ENFORCE_WHITELIST
+  if [[ $(grep "enforce-whitelist" $SERVER_PROPERTIES) != *true ]]; then
+    log "WARNING: whitelist enabled but not enforced. Set ENFORCE_WHITELIST=TRUE or update 'enforce-whitelist' in server.properties to enforce the whitelist."
   fi
 
   # If not provided, generate a reasonable default message-of-the-day,
@@ -104,7 +107,6 @@ function customizeServerProps {
   setServerProp "op-permission-level" OP_PERMISSION_LEVEL
   setServerProp "prevent-proxy-connections" PREVENT_PROXY_CONNECTIONS
   setServerProp "use-native-transport" USE_NATIVE_TRANSPORT
-  setServerProp "enforce-whitelist" ENFORCE_WHITELIST
   setServerProp "simulation-distance" SIMULATION_DISTANCE
   setServerPropValue "motd" "$(echo "$MOTD" | mc-image-helper asciify)"
   [[ $LEVEL_TYPE ]] && setServerPropValue "level-type" "${LEVEL_TYPE^^}"


### PR DESCRIPTION
This PR implements a few notable changes to the handling of ops and whitelist configurations, including:
* Support for a preconfigured file (via `OPS_FILE` and `WHITELIST_FILE`)
* Extension of UUID support to `OPS` and better handling of mixed configurations
* Additional handling of txt/json generation in the vanilla 1.7.5 -> 1.7.6 jump (support for usernames & uuids in all server binaries)

Documentation has been updated to clarify the configuration options, and draw attention to the `ENFORCE_WHITELIST` variable (with a warning being added to the logs when whitelist is enabled but not enforced).

Detailed changes and rationale can be seen in the expanded commit messages.