### PR TITLE
fix: log4j patch being applied to <1.7 versions

### DIFF
--- a/scripts/start-finalExec
+++ b/scripts/start-finalExec
@@ -96,7 +96,10 @@ patchLog4jConfig() {
 }
 
 # Patch Log4j remote code execution vulnerability
-if isFamily VANILLA && versionLessThan 1.12; then
+# See https://www.minecraft.net/en-us/article/important-message--security-vulnerability-java-edition
+if versionLessThan 1.7; then
+  : # No patch required here.
+elif isFamily VANILLA && versionLessThan 1.12; then
   patchLog4jConfig log4j2_17-111.xml https://launcher.mojang.com/v1/objects/dd2b723346a8dcd48e7f4d245f6bf09e98db9696/log4j2_17-111.xml
 elif isFamily VANILLA && versionLessThan 1.17; then
   patchLog4jConfig log4j2_112-116.xml https://launcher.mojang.com/v1/objects/02937d122c86ce73319ef9975b58896fc1b491d1/log4j2_112-116.xml


### PR DESCRIPTION
It appears we missed this in our first patch @itzg.

I've ___not___ tested this, but it should be fine.