### PR TITLE
Added --chmod to all COPY instructions in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -83,10 +83,9 @@ COPY --chmod=755 bin/ /usr/local/bin/
 COPY --chmod=755 bin/mc-health /health.sh
 COPY --chmod=644 files/server.properties /tmp/server.properties
 COPY --chmod=644 files/log4j2.xml /tmp/log4j2.xml
-COPY --chmod=644 files/autopause /autopause
+COPY --chmod=755 files/autopause /autopause
 
-RUN dos2unix /start* \
-    && dos2unix /autopause/* && chmod +x /autopause/*.sh
+RUN dos2unix /start* /autopause/*
 
 ENTRYPOINT [ "/start" ]
 HEALTHCHECK --start-period=1m CMD mc-health

--- a/Dockerfile
+++ b/Dockerfile
@@ -85,7 +85,7 @@ COPY --chmod=644 files/server.properties /tmp/server.properties
 COPY --chmod=644 files/log4j2.xml /tmp/log4j2.xml
 COPY --chmod=644 files/autopause /autopause
 
-RUN dos2unix /start* && chmod +x /start* \
+RUN dos2unix /start* \
     && dos2unix /autopause/* && chmod +x /autopause/*.sh
 
 ENTRYPOINT [ "/start" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update \
 RUN addgroup --gid 1000 minecraft \
   && adduser --system --shell /bin/false --uid 1000 --ingroup minecraft --home /data minecraft
 
-COPY files/sudoers* /etc/sudoers.d
+COPY --chmod=644 files/sudoers* /etc/sudoers.d
 
 EXPOSE 25565 25575
 
@@ -78,12 +78,12 @@ ENV UID=1000 GID=1000 \
   ENABLE_AUTOPAUSE=false AUTOPAUSE_TIMEOUT_EST=3600 AUTOPAUSE_TIMEOUT_KN=120 AUTOPAUSE_TIMEOUT_INIT=600 \
   AUTOPAUSE_PERIOD=10 AUTOPAUSE_KNOCK_INTERFACE=eth0
 
-COPY scripts/start* /
-COPY bin/ /usr/local/bin/
-COPY bin/mc-health /health.sh
-COPY files/server.properties /tmp/server.properties
-COPY files/log4j2.xml /tmp/log4j2.xml
-COPY files/autopause /autopause
+COPY --chmod=755 scripts/start* /
+COPY --chmod=755 bin/ /usr/local/bin/
+COPY --chmod=755 bin/mc-health /health.sh
+COPY --chmod=644 files/server.properties /tmp/server.properties
+COPY --chmod=644 files/log4j2.xml /tmp/log4j2.xml
+COPY --chmod=644 files/autopause /autopause
 
 RUN dos2unix /start* && chmod +x /start* \
     && dos2unix /autopause/* && chmod +x /autopause/*.sh


### PR DESCRIPTION
This removes any file-permission ambiguity that can result from a different umask set at git checkout
time on developer's or build machine.

This problem was noticed when running a `buildx` on MacOS with a `umask` set of `0077`.  Git doesn't do anything special with `rw` attributes, only `x`, so these are inherited from the checkout user's `umask`.  Since Docker passes these through, this seems to be a flaw in build-portability of Git Checkout -> Docker Build (same build args) -> Image.  So my image fails to run as `minecraft:minecraft` due mainly to missing group/world `r` permissions ... `x` that is added currently is not sufficient and will fail immediately with:

```
/bin/bash: /start-configuration: Permission denied
```

This PR adds `--chmod` to all `COPY` instructions in the `Dockerfile`, to force consistency.  Note that `COPY --chmod` is buildkit and not plain Docker, but that is already required.

# Testing

This command (apologies for the quoting) attempts to `ls` all the files copied-in to the image, and compare the permissions from the current image with one from a local build.

```
diff <(docker run --rm --entrypoint /bin/bash itzg/minecraft-server -c "ls -l /etc/sudoers.d /start* /usr/local/bin /health* /tmp /autopause | awk '{print \$1\" \"\$3\" \"\$4\" \"\$9}'") <(docker run --rm --entrypoint /bin/bash minecraft-server -c "ls -l /etc/sudoers.d /start* /usr/local/bin /health* /tmp /autopause | awk '{print \$1\" \"\$3\" \"\$4\" \"\$9}'")
```

Note the first diff input is from `itzg/minecraft-server`, the second is local tag `minecraft-server`.

For a "bad" build with `umask 0077`, there will be a lot of diffs, and the bad side looks like this:

```
-rwx------ root root /health.sh
-rwx--x--x root root /start
-rwx--x--x root root /start-autopause
-rwx--x--x root root /start-configuration
-rwx--x--x root root /start-deployAirplane
-rwx--x--x root root /start-deployBukkitSpigot
-rwx--x--x root root /start-deployCanyon
-rwx--x--x root root /start-deployCatserver
-rwx--x--x root root /start-deployCF
-rwx--x--x root root /start-deployCrucible
-rwx--x--x root root /start-deployCustom
-rwx--x--x root root /start-deployFabric
-rwx--x--x root root /start-deployForge
-rwx--x--x root root /start-deployFTBA
-rwx--x--x root root /start-deployLimbo
-rwx--x--x root root /start-deployMagma
-rwx--x--x root root /start-deployMohist
-rwx--x--x root root /start-deployPaper
-rwx--x--x root root /start-deployPurpur
-rwx--x--x root root /start-deploySpongeVanilla
-rwx--x--x root root /start-deployVanilla
-rwx--x--x root root /start-finalExec
-rwx--x--x root root /start-setupEnvVariables
-rwx--x--x root root /start-setupModconfig
-rwx--x--x root root /start-setupModpack
-rwx--x--x root root /start-setupMounts
-rwx--x--x root root /start-setupServerProperties
-rwx--x--x root root /start-setupWorld
-rwx--x--x root root /start-spiget
-rwx--x--x root root /start-utils

/autopause:
total
-rwx--x--x root root autopause-daemon.sh
-rwx--x--x root root autopause-fcns.sh
-rw------- root root knockd-config.cfg
-rwx--x--x root root pause.sh
-rwx--x--x root root resume.sh
...
```

Note the odd 711 perms.

Built with this PR, there are no diffs between official and locally-built image.

Downside - need to remember to add `--chmod` to any future `COPY` commands.