### PR TITLE
secruity: Fix CVE-2021-44228 mitigation

### DIFF
--- a/scripts/start-finalExec
+++ b/scripts/start-finalExec
@@ -107,7 +107,36 @@ if [ -n "$ICON" ]; then
     fi
 fi
 
+canUseRollingLogs=true
+
+patchLog4jConfig() {
+  file=${1?}
+  url=${2?}
+  if ! get -o "$file" "$url"; then
+    log "ERROR: failed to download corrected log4j config"
+    exit 1
+  fi
+  JVM_OPTS="-Dlog4j.configurationFile=${file} ${JVM_OPTS}"
+  canUseRollingLogs=false
+}
+
+# Patch Log4j remote code execution vulnerability
+# See https://www.minecraft.net/en-us/article/important-message--security-vulnerability-java-edition
+if versionLessThan 1.7; then
+  : # No patch required here.
+elif isFamily VANILLA && versionLessThan 1.12; then
+  patchLog4jConfig log4j2_17-111.xml https://launcher.mojang.com/v1/objects/dd2b723346a8dcd48e7f4d245f6bf09e98db9696/log4j2_17-111.xml
+elif isFamily VANILLA && versionLessThan 1.17; then
+  patchLog4jConfig log4j2_112-116.xml https://launcher.mojang.com/v1/objects/02937d122c86ce73319ef9975b58896fc1b491d1/log4j2_112-116.xml
+elif versionLessThan 1.18.1; then
+  JVM_OPTS="-Dlog4j2.formatMsgNoLookups=true ${JVM_OPTS}"
+fi
+
 if isTrue ${ENABLE_ROLLING_LOGS:-false}; then
+  if ! ${canUseRollingLogs}; then
+    log "ERROR: Using rolling logs is currently not possible in the selected version due to CVE-2021-44228"
+    exit 1
+  fi
   # Set up log configuration
   LOGFILE="/data/log4j2.xml"
   if [ ! -e "$LOGFILE" ]; then
@@ -148,28 +177,6 @@ if [ -n "$JVM_DD_OPTS" ]; then
       do
           expandedDOpts="${expandedDOpts} -D${dopt/:/=}"
       done
-fi
-
-patchLog4jConfig() {
-  file=${1?}
-  url=${2?}
-  if ! get -o "$file" "$url"; then
-    log "ERROR: failed to download corrected log4j config"
-    exit 1
-  fi
-  JVM_OPTS="-Dlog4j.configurationFile=${file} ${JVM_OPTS}"
-}
-
-# Patch Log4j remote code execution vulnerability
-# See https://www.minecraft.net/en-us/article/important-message--security-vulnerability-java-edition
-if versionLessThan 1.7; then
-  : # No patch required here.
-elif isFamily VANILLA && versionLessThan 1.12; then
-  patchLog4jConfig log4j2_17-111.xml https://launcher.mojang.com/v1/objects/dd2b723346a8dcd48e7f4d245f6bf09e98db9696/log4j2_17-111.xml
-elif isFamily VANILLA && versionLessThan 1.17; then
-  patchLog4jConfig log4j2_112-116.xml https://launcher.mojang.com/v1/objects/02937d122c86ce73319ef9975b58896fc1b491d1/log4j2_112-116.xml
-elif versionLessThan 1.18.1; then
-  JVM_OPTS="-Dlog4j2.formatMsgNoLookups=true ${JVM_OPTS}"
 fi
 
 if isTrue ${ENABLE_JMX}; then


### PR DESCRIPTION
Using rolling logs previously prevented the CVE-2021-44228 mitigation from working.
This commit forbids rolling logs if required to prevent CVE-2021-44228.

This can be considered a hotfix.

See #1189 