### PR TITLE
Remove Airplane 1.16 as unsupported

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,7 +470,7 @@ An [Airplane](https://airplane.gg) server, which is "a stable, optimized, well s
 
     -e TYPE=AIRPLANE
 
-> NOTE: The `VERSION` variable is used to select an Airplane branch to download from. The available options are "LATEST" "1.17" "1.16" "PURPUR" and "PURPUR-1.16"
+> NOTE: The `VERSION` variable is used to select an Airplane branch to download from. The available options are "LATEST" "1.17" and "PURPUR"
 
 Extra variables:
 - `AIRPLANE_BUILD=lastSuccessfulBuild` : set a specific Airplane build to use

--- a/scripts/start-deployAirplane
+++ b/scripts/start-deployAirplane
@@ -6,8 +6,8 @@ isDebugging && set -x
 
 IFS=$'\n\t'
 
-if [ "${VERSION}" != "LATEST" ] && [ "${VERSION}" != "1.16" ] && [ "${VERSION}" != "1.17" ] && [ "${VERSION}" != "PURPUR" ] && [ "${VERSION}" != "PURPUR-1.16" ] ; then
-  log "ERROR: Airplane server type only supports VERSION=LATEST, VERSION=1.17, VERSION=1.16, VERSION=PURPUR or VERSION=PURPUR-1.16. Note that these are branches, not #.#.# versions."
+if [ "${VERSION}" != "LATEST" ] && [ "${VERSION}" != "1.17" ] && [ "${VERSION}" != "PURPUR" ] ; then
+  log "ERROR: Airplane server type only supports VERSION=LATEST, VERSION=1.17, VERSION=PURPUR. Note that these are branches, not #.#.# versions."
   exit 1
 fi
 
@@ -18,17 +18,8 @@ if  [ "${VERSION}" = "LATEST" ] || [ "${VERSION}" = "1.17" ]; then
   AIRPLANE_BRANCH="1.17"
 fi
 
-if [ "${VERSION}" = "1.16" ]; then
-  AIRPLANE_BRANCH="1.16"
-fi
-
 if [ "${VERSION}" = "PURPUR" ]; then
   AIRPLANE_BRANCH="Purpur-1.17"
-  AIRPLANE_TYPE="airplanepurpur"
-fi
-
-if [ "${VERSION}" = "PURPUR-1.16" ]; then
-  AIRPLANE_BRANCH="Purpur-1.16"
   AIRPLANE_TYPE="airplanepurpur"
 fi
 


### PR DESCRIPTION
This PR removes Airplane 1.16, as it is no longer supported or hosted.