### PR TITLE
fix: verify that the downloaded resource is a valid plugin

### DIFF
--- a/scripts/start-spiget
+++ b/scripts/start-spiget
@@ -22,6 +22,20 @@ containsJars() {
   return 1
 }
 
+containsPlugin() {
+  file=${1?}
+
+  pat='plugin.yml$'
+
+  while read -r line; do
+    if [[ $line =~ $pat ]]; then
+      return 0
+    fi
+  done <<<$(unzip -l "$file")
+
+  return 1
+}
+
 getResourceFromSpiget() {
   resource=${1?}
 
@@ -81,9 +95,12 @@ downloadResourceFromSpiget() {
     log "Extracting contents of resource ${resource} into plugins"
     unzip -o -q -d /data/plugins "${tmpfile}"
     rm "${tmpfile}"
-  else
+  elif containsPlugin "${tmpfile}"; then
     log "Moving resource ${resource} into plugins"
     mv "${tmpfile}" "/data/plugins/${resource}.jar"
+  else
+    log "ERROR downloaded resource '${resource}' seems to be not a valid plugin"
+    exit 2
   fi
 
 }


### PR DESCRIPTION
I came across the issue that the downloaded resources was in fact some kind of html output. Looks like the download failed somehow (in my case the dynmap plugin (274).

Example:

    http://api.spiget.org/v2/resources/274/download --> https://dev.bukkit.org/projects/dynmap/files/3561925

Sure ... the owner of dynmap is using a link that points to a webpage instead of the real download.

So the curl download generates a html output which gets saves to 274.jar ... which then creates errors when the server trys to load the plugin. At least we should verify that the downloaded .jar file is a valid minecraft plugin with `plugin.yml` in it.