### PR TITLE
Direct RUN based on previous setup if RUN_FROM_ARGSFILE is true

### DIFF
--- a/README.md
+++ b/README.md
@@ -1418,6 +1418,17 @@ When the container is signalled to stop, the Minecraft process wrapper will atte
 
 If you are using a host-attached data directory, then you can have the image setup the Minecraft server files and stop prior to launching the server process by setting `SETUP_ONLY` to `true`. 
 
+You can choose to store the executable arguments created with `SETUP_ONLY` for later use into `runargs.txt` by setting `SAVE_RUNARGS` to `true`
+
+#### Run from arguments file
+
+If you've chosen to store the executable arguments into `runargs.txt` you can boot your server faster by setting `RUN_FROM_ARGSFILE` to `true`.
+
+This means it will bypass every script used to build your server, like downloading new plugin versions, server specific updates, security checks and fixes... So it is faster boot but comes with a cost. 
+**Use with caution**
+
+> **NOTE:** You can not use `SETUP_ONLY=true` and `RUN_FROM_ARGSFILE=true` at the same time, because the later will skip every script used in the setup process.
+
 ## Autopause
 
 ### Description

--- a/scripts/start
+++ b/scripts/start
@@ -5,6 +5,19 @@
 umask 0002
 chmod g+w /data
 
+function check_if_runargs() {
+  if [ -f /data/runargs.txt ]; then
+    if isTrue "${RUN_FROM_ARGSFILE:=false}"; then
+      if isTrue "${SETUP_ONLY:=false}"; then
+          echo "RUN_FROM_ARGSFILE and SETUP_ONLY are incompatible."
+          exit 1
+      fi
+      echo "$(</data/runargs.txt)"
+    fi
+  fi
+}
+RUN_ARGS=$(check_if_runargs)
+
 if ! isTrue "${SKIP_SUDO:-false}" && [ $(id -u) = 0 ]; then
   runAsUser=minecraft
   runAsGroup=minecraft
@@ -40,7 +53,15 @@ if ! isTrue "${SKIP_SUDO:-false}" && [ $(id -u) = 0 ]; then
     echo 'hosts: files dns' > /etc/nsswitch.conf
   fi
 
-  exec gosu ${runAsUser}:${runAsGroup} ${SCRIPTS:-/}start-configuration "$@"
+  if [[ -n "$RUN_ARGS" ]]; then
+    exec gosu ${runAsUser}:${runAsGroup} /bin/sh -c "$RUN_ARGS"
+  else
+    exec gosu ${runAsUser}:${runAsGroup} ${SCRIPTS:-/}start-configuration "$@"
+  fi
 else
-  exec ${SCRIPTS:-/}start-configuration "$@"
+  if [[ -n "$RUN_ARGS" ]]; then
+    exec /bin/sh -c "$RUN_ARGS"
+  else
+    exec ${SCRIPTS:-/}start-configuration "$@"
+  fi
 fi

--- a/scripts/start-finalExec
+++ b/scripts/start-finalExec
@@ -349,8 +349,18 @@ else
     "$@" $EXTRA_ARGS
   )
 
+  JAVA_RUNARGS="java ${finalArgs[*]}"
+  MCSERVER_RUNARGS="mc-server-runner ${bootstrapArgs} ${mcServerRunnerArgs[*]} java ${finalArgs[*]}"
+
   if isTrue ${SETUP_ONLY:=false}; then
     echo "SETUP_ONLY: java ${finalArgs[*]}"
+    if isTrue "${SAVE_RUNARGS:=false}"; then
+      if isTrue "${EXEC_DIRECTLY:-false}"; then
+        echo "${JAVA_RUNARGS}" > /data/runargs.txt
+      else
+        echo "${MCSERVER_RUNARGS}" > /data/runargs.txt
+      fi
+    fi
     exit
   fi
 
@@ -359,9 +369,9 @@ else
   fi
 
   if isTrue "${EXEC_DIRECTLY:-false}"; then
-    exec java "${finalArgs[@]}"
+    exec "${JAVA_RUNARGS}"
   else
-    exec mc-server-runner ${bootstrapArgs} "${mcServerRunnerArgs[@]}" java "${finalArgs[@]}"
+    exec "${MCSERVER_RUNARGS}"
   fi
 fi
 


### PR DESCRIPTION
This helps building dependencies and running the server itself separately.

At first I thought `EXEC_DIRECTLY` and `SETUP_ONLY` were made for this purpose, but it only works if you copy stdout into your custom script.

With this changes, running `SETUP_ONLY` and `SAVE_RUNARGS` will create a `/data/runargs.txt` file that will be readed later by the same `/start` script if existing and if `RUN_FROM_ARGSFILE` is true.. skipping the whole script process and just run the server.

With this method we went from ~2 minutes server upgrade to just 10 seconds, because the whole dependency flow has been done by an initializer.

I am not sure how to merge everything into java8 and other branches to test it out, too many conflicts that I'm unaware of, so any guidance would be nice.

This also gives a bit of extra security, at least in our deployments because don't inject ENV variables anymore into our running server, those are sent to the initializer and then pruned because don't need them anymore until the next deploy.