### PR TITLE
Add Pufferfish support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ By default, the container will download the latest version of the "vanilla" [Min
       * [Running a Bukkit/Spigot server](#running-a-bukkitspigot-server)
       * [Running a Paper server](#running-a-paper-server)
       * [Running an Airplane server](#running-an-airplane-server)
+      * [Running a Pufferfish server](#running-a-pufferfish-server)
       * [Running a Purpur server](#running-a-purpur-server)
       * [Running a Magma server](#running-a-magma-server)
       * [Running a Mohist server](#running-a-mohist-server)
@@ -485,6 +486,18 @@ Extra variables:
 - `AIRPLANE_BUILD=lastSuccessfulBuild` : set a specific Airplane build to use
 - `FORCE_REDOWNLOAD=false` : set to true to force the located server jar to be re-downloaded
 - `USE_FLARE_FLAGS=false` : set to true to add appropriate flags for the [Flare](https://blog.airplane.gg/flare) profiler
+
+### Running a Pufferfish server
+
+A [Pufferfish](https://github.com/pufferfish-gg/Pufferfish) server, which is "a highly optimized Paper fork designed for large servers requiring both maximum performance, stability, and "enterprise" features."
+
+    -e TYPE=PUFFERFISH
+
+> NOTE: The `VERSION` variable is used to select a Pufferfish branch to download from. The available options are "LATEST" and "1.18"
+
+Extra variables:
+- `PUFFERFISH_BUILD=lastSuccessfulBuild` : set a specific Pufferfish build to use
+- `FORCE_REDOWNLOAD=false` : set to true to force the located server jar to be re-downloaded
 
 ### Running a Purpur server
 

--- a/scripts/start-configuration
+++ b/scripts/start-configuration
@@ -183,6 +183,10 @@ case "${TYPE^^}" in
     exec ${SCRIPTS:-/}start-deployAirplane "$@"
   ;;
 
+  PUFFERFISH)
+    exec ${SCRIPTS:-/}start-deployPufferfish "$@"
+  ;;
+
   CANYON)
     exec ${SCRIPTS:-/}start-deployCanyon "$@"
   ;;
@@ -205,7 +209,7 @@ case "${TYPE^^}" in
       log "Invalid type: '$TYPE'"
       log "Must be: VANILLA, FORGE, BUKKIT, SPIGOT, PAPER, FTBA (multiarch-only),"
       log "         CURSEFORGE, SPONGEVANILLA, PURPUR, CUSTOM,"
-      log "         MAGMA, MOHIST, CATSERVER, AIRPLANE, CANYON, LIMBO, CRUCIBLE"
+      log "         MAGMA, MOHIST, CATSERVER, AIRPLANE, PUFFERFISH, CANYON, LIMBO, CRUCIBLE"
       exit 1
   ;;
 

--- a/scripts/start-deployAirplane
+++ b/scripts/start-deployAirplane
@@ -14,7 +14,7 @@ fi
 : ${AIRPLANE_BUILD:=lastSuccessfulBuild}
 : ${AIRPLANE_TYPE:=airplane}
 
-if  [ "${VERSION}" = "LATEST" ] || [ "${VERSION}" = "1.17" ]; then
+if [ "${VERSION}" = "LATEST" ] || [ "${VERSION}" = "1.17" ]; then
   AIRPLANE_BRANCH="1.17"
 fi
 
@@ -36,8 +36,7 @@ done
 if [ ! -f "$SERVER" ] || isTrue "${FORCE_REDOWNLOAD:-false}"; then
     downloadUrl="https://ci.tivy.ca/job/Airplane-${AIRPLANE_BRANCH}/${AIRPLANE_BUILD}/artifact/launcher-${AIRPLANE_TYPE}.jar"
     log "Downloading Airplane from $downloadUrl ..."
-    curl -fsSL -o "$SERVER" "$downloadUrl"
-    if [ ! -f "$SERVER" ]; then
+    if ! get -o "$SERVER" "$downloadUrl"; then
       log "ERROR: failed to download from $downloadUrl (status=$?)"
       exit 3
     fi

--- a/scripts/start-deployPufferfish
+++ b/scripts/start-deployPufferfish
@@ -32,8 +32,7 @@ if [ ! -f "$SERVER" ] || isTrue "${FORCE_REDOWNLOAD:-false}"; then
     artifact="build/libs/pufferfish-paperclip-${PUFFERFISH_VERSION}-SNAPSHOT-reobf.jar"
     downloadUrl="https://ci.pufferfish.host/job/Pufferfish-${PUFFERFISH_BRANCH}/${PUFFERFISH_BUILD}/artifact/${artifact}"
     log "Downloading Pufferfish from $downloadUrl ..."
-    curl -fsSL -o "$SERVER" "$downloadUrl"
-    if [ ! -f "$SERVER" ]; then
+    if ! get -o "$SERVER" "$downloadUrl"; then
       log "ERROR: failed to download from $downloadUrl (status=$?)"
       exit 3
     fi

--- a/scripts/start-deployPufferfish
+++ b/scripts/start-deployPufferfish
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+. ${SCRIPTS:-/}start-utils
+set -euo pipefail
+isDebugging && set -x
+
+IFS=$'\n\t'
+
+if [ "${VERSION}" != "LATEST" ] && [ "${VERSION}" != "1.18" ] ; then
+  log "ERROR: Pufferfish server type only supports VERSION=LATEST, VERSION=1.18. Note that these are branches, not #.#.# versions."
+  exit 1
+fi
+
+: ${PUFFERFISH_BUILD:=lastSuccessfulBuild}
+
+if  [ "${VERSION}" = "LATEST" ] || [ "${VERSION}" = "1.18" ]; then
+  PUFFERFISH_BRANCH="1.18"
+  PUFFERFISH_VERSION="1.18.1-R0.1"
+fi
+
+log "Using Pufferfish-${PUFFERFISH_BRANCH} branch"
+
+export SERVER=pufferfish-${PUFFERFISH_BRANCH}-${PUFFERFISH_BUILD}.jar
+
+log "Removing old Pufferfish versions ..."
+shopt -s nullglob
+for f in pufferfish-*.jar; do
+  [[ $f != $SERVER ]] && rm $f
+done
+
+if [ ! -f "$SERVER" ] || isTrue "${FORCE_REDOWNLOAD:-false}"; then
+    artifact="build/libs/pufferfish-paperclip-${PUFFERFISH_VERSION}-SNAPSHOT-reobf.jar"
+    downloadUrl="https://ci.pufferfish.host/job/Pufferfish-${PUFFERFISH_BRANCH}/${PUFFERFISH_BUILD}/artifact/${artifact}"
+    log "Downloading Pufferfish from $downloadUrl ..."
+    curl -fsSL -o "$SERVER" "$downloadUrl"
+    if [ ! -f "$SERVER" ]; then
+      log "ERROR: failed to download from $downloadUrl (status=$?)"
+      exit 3
+    fi
+fi
+
+# Normalize on Spigot for later operations
+export TYPE=SPIGOT
+export FAMILY=SPIGOT
+export SKIP_LOG4J_CONFIG=true
+
+exec ${SCRIPTS:-/}start-spiget "$@"


### PR DESCRIPTION
I hope I didn't forget anything.

Tested it locally with this docker-compose and it all seems to work:

```yaml
version: '3'

services:
  mc:
    build: .
    environment:
      EULA: true
      TYPE: 'PUFFERFISH'
      VERSION: 'LATEST'
      PUFFERFISH_BUILD: '29'
```

I've also opened an issue on the Pufferfish repo to maybe clean up the .jar name a bit.

Closes #1226 