### PR TITLE
fix: Set default MOTD if unset

### DIFF
--- a/scripts/start-setupServerProperties
+++ b/scripts/start-setupServerProperties
@@ -48,7 +48,7 @@ function customizeServerProps {
 
   # If not provided, generate a reasonable default message-of-the-day,
   # which shows up in the server listing in the client
-  if ! [ -v "$MOTD" ]; then
+  if [ -v "$MOTD" ]; then
     # snapshot is the odd case where we have to look at version to identify that label
     if [[ ${ORIGINAL_TYPE} == "VANILLA" && ${VERSION} == "SNAPSHOT" ]]; then
       label=SNAPSHOT

--- a/scripts/start-setupServerProperties
+++ b/scripts/start-setupServerProperties
@@ -48,7 +48,7 @@ function customizeServerProps {
 
   # If not provided, generate a reasonable default message-of-the-day,
   # which shows up in the server listing in the client
-  if [ -v "$MOTD" ]; then
+  if ! [ -v MOTD ]; then
     # snapshot is the odd case where we have to look at version to identify that label
     if [[ ${ORIGINAL_TYPE} == "VANILLA" && ${VERSION} == "SNAPSHOT" ]]; then
       label=SNAPSHOT


### PR DESCRIPTION
Fixes #1261 

`-v "$MOTD"` is used to check if a environment variable is unset, and returns 0 (FALSE) if the value is set.

Thank you to @Stealthii for identifying this issue.