### PR TITLE
fix: changed packwiz url to reflect new repo address

### DIFF
--- a/scripts/start-setupModpack
+++ b/scripts/start-setupModpack
@@ -25,7 +25,7 @@ fi
 # If packwiz url passed, bootstrap packwiz and update mods before other modpack processing
 if [[ "${PACKWIZ_URL}" ]]; then
   # Ensure we have the latest packwiz bootstrap installer
-  latestPackwiz=$(curl -fsSL https://api.github.com/repos/comp500/packwiz-installer-bootstrap/releases/latest)
+  latestPackwiz=$(curl -fsSL https://api.github.com/repos/packwiz/packwiz-installer-bootstrap/releases/latest)
   if [[ -z "${latestPackwiz}" ]]; then
     log "WARNING: Could not retrieve Packwiz bootstrap installer release information"
   else


### PR DESCRIPTION
Was having issues with pulling the packwiz installer bootstrap and noticed that the repository has been changed from comp500/packwiz-installer-bootstrap to packwiz/packwiz-installer-bootstrap. Seems like it does redirect when calling the curl command but I was having issues with it not doing so and this fixed it.