### PR TITLE
Update Airplane download URL, clarify version support

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,10 +481,9 @@ An [Airplane](https://airplane.gg) server, which is "a stable, optimized, well s
 
     -e TYPE=AIRPLANE
 
-> NOTE: The `VERSION` variable is used to select an Airplane branch to download from. The available options are "LATEST" "1.17" and "PURPUR"
+> NOTE: The `VERSION` variable is used to select an Airplane type to download. The available options are "LATEST" and "PURPUR", both 1.17.1. Airplane does not support 1.18 -- use Paper/Pufferfish/Purpur.
 
 Extra variables:
-- `AIRPLANE_BUILD=lastSuccessfulBuild` : set a specific Airplane build to use
 - `FORCE_REDOWNLOAD=false` : set to true to force the located server jar to be re-downloaded
 - `USE_FLARE_FLAGS=false` : set to true to add appropriate flags for the built-in [Flare](https://blog.airplane.gg/flare) profiler
 

--- a/scripts/start-deployAirplane
+++ b/scripts/start-deployAirplane
@@ -6,35 +6,33 @@ isDebugging && set -x
 
 IFS=$'\n\t'
 
-if [ "${VERSION}" != "LATEST" ] && [ "${VERSION}" != "1.17" ] && [ "${VERSION}" != "PURPUR" ] ; then
-  log "ERROR: Airplane server type only supports VERSION=LATEST, VERSION=1.17, VERSION=PURPUR. Note that these are branches, not #.#.# versions."
+if [ "${VERSION}" != "LATEST" ] && [ "${VERSION}" != "PURPUR" ] ; then
+  log "ERROR: Airplane server type only supports VERSION=LATEST, VERSION=PURPUR."
   exit 1
 fi
 
-: ${AIRPLANE_BUILD:=lastSuccessfulBuild}
 : ${AIRPLANE_TYPE:=airplane}
 
-if [ "${VERSION}" = "LATEST" ] || [ "${VERSION}" = "1.17" ]; then
-  AIRPLANE_BRANCH="1.17"
+if [ "${VERSION}" = "LATEST" ] ; then
+  AIRPLANE_TYPE="airplane"
 fi
 
 if [ "${VERSION}" = "PURPUR" ]; then
-  AIRPLANE_BRANCH="Purpur-1.17"
   AIRPLANE_TYPE="airplanepurpur"
 fi
 
-log "Using Airplane-${AIRPLANE_BRANCH} branch"
+log "Using ${AIRPLANE_TYPE} 1.17.1 (1.18 unsupported - use Paper/Pufferfish/Purpur for newer versions)"
 
-export SERVER=airplane-${AIRPLANE_BRANCH}-${AIRPLANE_BUILD}.jar
+export SERVER=${AIRPLANE_TYPE}-1.17.1.jar
 
 log "Removing old Airplane versions ..."
 shopt -s nullglob
-for f in airplane-*.jar; do
+for f in airplane*.jar; do
   [[ $f != $SERVER ]] && rm $f
 done
 
 if [ ! -f "$SERVER" ] || isTrue "${FORCE_REDOWNLOAD:-false}"; then
-    downloadUrl="https://ci.tivy.ca/job/Airplane-${AIRPLANE_BRANCH}/${AIRPLANE_BUILD}/artifact/launcher-${AIRPLANE_TYPE}.jar"
+    downloadUrl="https://airplane.gg/dl/launcher-${AIRPLANE_TYPE}1.17.1.jar"
     log "Downloading Airplane from $downloadUrl ..."
     if ! get -o "$SERVER" "$downloadUrl"; then
       log "ERROR: failed to download from $downloadUrl (status=$?)"


### PR DESCRIPTION
This PR updates the Airplane download URL, closing #1295. Also clarifies lack of support for versions >1.17.1. Should be gtg, but please sanity check.