### PR TITLE
build: switch to matrix builds for Debian based variant builds

### DIFF
--- a/.github/workflows/build-multiarch.yml
+++ b/.github/workflows/build-multiarch.yml
@@ -116,7 +116,7 @@ jobs:
         uses: docker/build-push-action@v2.8.0
         with:
           platforms: ${{ matrix.platforms }}
-          push: false
+          push: ${{ github.ref_name == 'master' }}
           tags: ${{ steps.meta.outputs.tags }}
           # ensure latest base image is used
           pull: true

--- a/.github/workflows/build-multiarch.yml
+++ b/.github/workflows/build-multiarch.yml
@@ -29,26 +29,32 @@ jobs:
             baseImage: eclipse-temurin:17
             tagPrefix: java17-
             platforms: linux/amd64,linux/arm/v7,linux/arm64
+            mcVersion: LATEST
           - variant: java17-openj9
             baseImage: ibm-semeru-runtimes:open-17-jdk
             tagPrefix: java17-openj9-
             platforms: linux/amd64
+            mcVersion: LATEST
           - variant: java8-multiarch
             baseImage: eclipse-temurin:8-jdk
             tagPrefix: java8-
             platforms: linux/amd64,linux/arm/v7,linux/arm64
+            mcVersion: 1.12.2
           - variant: java8-openj9
             baseImage: adoptopenjdk:8-jdk-openj9
             tagPrefix: java8-openj9-
             platforms: linux/amd64
+            mcVersion: 1.12.2
           - variant: java11
             baseImage: adoptopenjdk:11-jdk-hotspot
             tagPrefix: java11-
             platforms: linux/amd64,linux/arm/v7,linux/arm64
+            mcVersion: 1.16.5
           - variant: java11-openj9
             baseImage: adoptopenjdk:11-jdk-openj9
             tagPrefix: java11-openj9-
             platforms: linux/amd64
+            mcVersion: 1.16.5
     env:
       IMAGE_TO_TEST: itzg/minecraft-server:test-${{ matrix.variant }}-${{ github.run_id }}
     runs-on: ubuntu-20.04
@@ -96,6 +102,8 @@ jobs:
           # no cache-to to avoid cross-cache update from next build step
 
       - name: Run tests
+        env:
+          MINECRAFT_VERSION: ${{ matrix.mcVersion }}
         run: |
           tests/test.sh
 

--- a/.github/workflows/build-multiarch.yml
+++ b/.github/workflows/build-multiarch.yml
@@ -3,29 +3,58 @@ on:
   push:
     branches:
       - master
-      - java8-multiarch
-      - java8-openj9
-      - java11*
-      - java16*
-      - java17*
       - test/**
     tags:
       - "[0-9]+.[0-9]+.[0-9]+"
-      - "[0-9]+.[0-9]+.[0-9]+-java8-multiarch"
-      - "[0-9]+.[0-9]+.[0-9]+-java8-openj9"
-      - "[0-9]+.[0-9]+.[0-9]+-java11*"
-      - "[0-9]+.[0-9]+.[0-9]+-java16*"
     paths-ignore:
       - "*.md"
       - "docs/**"
       - "examples/**"
 
-env:
-  IMAGE_TO_TEST: itzg/minecraft-server:test-${{ github.repository_owner }}-${{ github.run_id }}
-
 jobs:
   build:
     if: github.repository == 'itzg/docker-minecraft-server'
+    strategy:
+      matrix:
+        variant:
+          - latest
+          - java17
+          - java17-openj9
+          - java8-multiarch
+          - java8-openj9
+          - java11
+          - java11-openj9
+        include:
+          - variant: latest
+            baseImage: eclipse-temurin:17
+            tagPrefix: ""
+            platforms: linux/amd64,linux/arm/v7,linux/arm64
+          - variant: java17
+            baseImage: eclipse-temurin:17
+            tagPrefix: java17-
+            platforms: linux/amd64,linux/arm/v7,linux/arm64
+          - variant: java17-openj9
+            baseImage: ibm-semeru-runtimes:open-17-jdk
+            tagPrefix: java17-openj9-
+            platforms: linux/amd64
+          - variant: java8-multiarch
+            baseImage: eclipse-temurin:8-jdk
+            tagPrefix: java8-
+            platforms: linux/amd64,linux/arm/v7,linux/arm64
+          - variant: java8-openj9
+            baseImage: eclipse-temurin:8-jdk
+            tagPrefix: java8-openj9-
+            platforms: linux/amd64
+          - variant: java11
+            baseImage: adoptopenjdk:11-jdk-hotspot
+            tagPrefix: java11-
+            platforms: linux/amd64,linux/arm/v7,linux/arm64
+          - variant: java11-openj9
+            baseImage: adoptopenjdk:11-jdk-openj9
+            tagPrefix: java11-openj9-
+            platforms: linux/amd64
+    env:
+      IMAGE_TO_TEST: itzg/minecraft-server:test-${{ matrix.variant }}-${{ github.run_id }}
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
@@ -38,10 +67,11 @@ jobs:
           images: |
             itzg/minecraft-server
           tags: |
-            type=ref,event=branch
-            type=ref,event=tag
+            type=ref,event=tag,enable=${{ matrix.variant == 'java17' }}
+            type=ref,event=tag,prefix=${{ matrix.variant }}-
+            type=raw,value=${{ matrix.variant }}
           flavor: |
-            latest=${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+            latest=${{ matrix.variant == 'java17' }}
 
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v1
@@ -57,9 +87,7 @@ jobs:
 
       - name: Build for test
         uses: docker/build-push-action@v2.8.0
-        if: github.ref_name == 'master' || startsWith(github.ref_name, 'test/')
         with:
-          context: .
           platforms: linux/amd64
           tags: ${{ env.IMAGE_TO_TEST }}
           # ensure latest base image is used
@@ -70,8 +98,6 @@ jobs:
           # no cache-to to avoid cross-cache update from next build step
 
       - name: Run tests
-        # It is assumed that image variants are merged from master and tested there
-        if: github.ref_name == 'master' || startsWith(github.ref_name, 'test/')
         run: |
           tests/test.sh
 
@@ -79,15 +105,13 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v2.8.0
         with:
-          context: .
-          platforms: linux/amd64,linux/arm/v7,linux/arm64
-          push: true
+          platforms: ${{ matrix.platforms }}
+          push: false
           tags: ${{ steps.meta.outputs.tags }}
           # ensure latest base image is used
           pull: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
           labels: ${{ steps.meta.outputs.labels }}
-
-      - name: Image digest
-        run: echo ${{ steps.docker_build.outputs.digest }}
+          build-args: |
+            BASE_IMAGE=${{ matrix.baseImage }}
+          cache-from: type=gha,scope=${{ matrix.variant }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.variant }}

--- a/.github/workflows/build-multiarch.yml
+++ b/.github/workflows/build-multiarch.yml
@@ -17,7 +17,6 @@ jobs:
     strategy:
       matrix:
         variant:
-          - latest
           - java17
           - java17-openj9
           - java8-multiarch
@@ -25,10 +24,6 @@ jobs:
           - java11
           - java11-openj9
         include:
-          - variant: latest
-            baseImage: eclipse-temurin:17
-            tagPrefix: ""
-            platforms: linux/amd64,linux/arm/v7,linux/arm64
           - variant: java17
             baseImage: eclipse-temurin:17
             tagPrefix: java17-

--- a/.github/workflows/build-multiarch.yml
+++ b/.github/workflows/build-multiarch.yml
@@ -42,7 +42,7 @@ jobs:
             platforms: linux/amd64,linux/arm/v7,linux/arm64
             mcVersion: 1.12.2
           - variant: java8-openj9
-            baseImage: adoptopenjdk:8-jdk-openj9
+            baseImage: ibm-semeru-runtimes:open-8-jdk
             tagPrefix: java8-openj9-
             platforms: linux/amd64
             mcVersion: 1.12.2
@@ -52,7 +52,7 @@ jobs:
             platforms: linux/amd64,linux/arm/v7,linux/arm64
             mcVersion: 1.16.5
           - variant: java11-openj9
-            baseImage: adoptopenjdk:11-jdk-openj9
+            baseImage: ibm-semeru-runtimes:open-11-jdk
             tagPrefix: java11-openj9-
             platforms: linux/amd64
             mcVersion: 1.16.5

--- a/.github/workflows/build-multiarch.yml
+++ b/.github/workflows/build-multiarch.yml
@@ -90,7 +90,9 @@ jobs:
           pull: true
           load: true
           push: false
-          cache-from: type=gha
+          build-args: |
+            BASE_IMAGE=${{ matrix.baseImage }}
+          cache-from: type=gha,scope=${{ matrix.variant }}
           # no cache-to to avoid cross-cache update from next build step
 
       - name: Run tests

--- a/.github/workflows/build-multiarch.yml
+++ b/.github/workflows/build-multiarch.yml
@@ -94,6 +94,7 @@ jobs:
           tags: ${{ env.IMAGE_TO_TEST }}
           # ensure latest base image is used
           pull: true
+          # load into daemon for test usage in next step
           load: true
           push: false
           build-args: |

--- a/.github/workflows/build-multiarch.yml
+++ b/.github/workflows/build-multiarch.yml
@@ -75,6 +75,8 @@ jobs:
             type=raw,value=${{ matrix.variant }}
           flavor: |
             latest=${{ matrix.variant == 'java17' }}
+          labels: |
+            org.opencontainers.image.authors=Geoff Bourne <itzgeoff@gmail.com>
 
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v1

--- a/.github/workflows/build-multiarch.yml
+++ b/.github/workflows/build-multiarch.yml
@@ -16,6 +16,7 @@ jobs:
   build:
     if: github.repository == 'itzg/docker-minecraft-server'
     strategy:
+      fail-fast: false
       matrix:
         variant:
           - java17

--- a/.github/workflows/build-multiarch.yml
+++ b/.github/workflows/build-multiarch.yml
@@ -34,7 +34,7 @@ jobs:
           - variant: java17-openj9
             baseImage: ibm-semeru-runtimes:open-17-jdk
             tagPrefix: java17-openj9-
-            platforms: linux/amd64
+            platforms: linux/amd64,linux/arm64
             mcVersion: LATEST
           - variant: java8-multiarch
             baseImage: eclipse-temurin:8-jdk
@@ -44,7 +44,7 @@ jobs:
           - variant: java8-openj9
             baseImage: ibm-semeru-runtimes:open-8-jdk
             tagPrefix: java8-openj9-
-            platforms: linux/amd64
+            platforms: linux/amd64,linux/arm64
             mcVersion: 1.12.2
           - variant: java11
             baseImage: adoptopenjdk:11-jdk-hotspot
@@ -54,7 +54,7 @@ jobs:
           - variant: java11-openj9
             baseImage: ibm-semeru-runtimes:open-11-jdk
             tagPrefix: java11-openj9-
-            platforms: linux/amd64
+            platforms: linux/amd64,linux/arm64
             mcVersion: 1.16.5
     env:
       IMAGE_TO_TEST: itzg/minecraft-server:test-${{ matrix.variant }}-${{ github.run_id }}

--- a/.github/workflows/build-multiarch.yml
+++ b/.github/workflows/build-multiarch.yml
@@ -6,6 +6,7 @@ on:
       - test/**
     tags:
       - "[0-9]+.[0-9]+.[0-9]+"
+      - "[0-9]+.[0-9]+.[0-9]+-*"
     paths-ignore:
       - "*.md"
       - "docs/**"
@@ -37,7 +38,7 @@ jobs:
             tagPrefix: java8-
             platforms: linux/amd64,linux/arm/v7,linux/arm64
           - variant: java8-openj9
-            baseImage: eclipse-temurin:8-jdk
+            baseImage: adoptopenjdk:8-jdk-openj9
             tagPrefix: java8-openj9-
             platforms: linux/amd64
           - variant: java11

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
 ARG BASE_IMAGE=eclipse-temurin:17-jdk
 FROM ${BASE_IMAGE}
 
-LABEL org.opencontainers.image.authors="Geoff Bourne <itzgeoff@gmail.com>"
-
 RUN apt-get update \
   && DEBIAN_FRONTEND=noninteractive \
   apt-get install -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM eclipse-temurin:17-jdk
+ARG BASE_IMAGE=eclipse-temurin:17-jdk
+FROM ${BASE_IMAGE}
 
 LABEL org.opencontainers.image.authors="Geoff Bourne <itzgeoff@gmail.com>"
 

--- a/docker-versions-create.sh
+++ b/docker-versions-create.sh
@@ -3,12 +3,6 @@
 # Use this variable to indicate a list of branches that docker hub is watching
 branches_list=(
   'java8'
-  'java8-multiarch'
-  'java8-openj9'
-  'java11'
-  'java11-openj9'
-  'java17'
-  'java17-openj9'
   )
 
 function TrapExit {

--- a/scripts/start-configuration
+++ b/scripts/start-configuration
@@ -116,39 +116,30 @@ fi
 log "Resolving type given ${TYPE}"
 case "${TYPE^^}" in
   *BUKKIT|SPIGOT)
-    exec ${SCRIPTS:-/}start-deployBukkitSpigot "$@"
+    exec "${SCRIPTS:-/}start-deployBukkitSpigot" "$@"
   ;;
 
   PAPER)
-    exec ${SCRIPTS:-/}start-deployPaper "$@"
+    exec "${SCRIPTS:-/}start-deployPaper" "$@"
   ;;
 
   FORGE)
-    if versionLessThan 1.17; then
-    log "**********************************************************************"
-    log "WARNING: The image tag itzg/minecraft-server:java8 is recommended"
-    log "         since some mods require Java 8"
-    log "         Exception traces reporting ClassCastException: class jdk.internal.loader.ClassLoaders\$AppClassLoader"
-    log "         can be fixed with java8"
-    log "**********************************************************************"
-    fi
-    exec ${SCRIPTS:-/}start-deployForge "$@"
+    evaluateJavaCompatibilityForForge
+    exec "${SCRIPTS:-/}start-deployForge" "$@"
   ;;
 
   FABRIC)
-    exec ${SCRIPTS:-/}start-deployFabric "$@"
+    exec "${SCRIPTS:-/}start-deployFabric" "$@"
   ;;
 
   FTBA)
-    exec ${SCRIPTS:-/}start-deployFTBA "$@"
+    evaluateJavaCompatibilityForForge
+    exec "${SCRIPTS:-/}start-deployFTBA" "$@"
   ;;
 
   FTB|CURSEFORGE)
-    log "**********************************************************************"
-    log "NOTE: Some mods and modpacks may require Java 8."
-    log "      If so, use itzg/minecraft-server:java8"
-    log "**********************************************************************"
-    exec ${SCRIPTS:-/}start-deployCF "$@"
+    evaluateJavaCompatibilityForForge
+    exec "${SCRIPTS:-/}start-deployCF" "$@"
   ;;
 
   VANILLA)
@@ -156,22 +147,26 @@ case "${TYPE^^}" in
   ;;
 
   SPONGEVANILLA)
-    exec ${SCRIPTS:-/}start-deploySpongeVanilla "$@"
+    exec "${SCRIPTS:-/}start-deploySpongeVanilla" "$@"
   ;;
 
   CUSTOM)
-    exec ${SCRIPTS:-/}start-deployCustom "$@"
+    evaluateJavaCompatibilityForForge
+    exec "${SCRIPTS:-/}start-deployCustom" "$@"
   ;;
 
   MAGMA)
-    exec ${SCRIPTS:-/}start-deployMagma "$@"
+    evaluateJavaCompatibilityForForge
+    exec "${SCRIPTS:-/}start-deployMagma" "$@"
   ;;
 
   MOHIST)
+    evaluateJavaCompatibilityForForge
     exec ${SCRIPTS:-/}start-deployMohist "$@"
   ;;
 
   CATSERVER)
+    evaluateJavaCompatibilityForForge
     exec ${SCRIPTS:-/}start-deployCatserver "$@"
   ;;
 

--- a/scripts/start-configuration
+++ b/scripts/start-configuration
@@ -66,9 +66,12 @@ if [[ $RCON_PASSWORD_FILE ]]; then
     log ""
 fi
 
+# Some Docker management UIs grab all the image declared variables and present them for configuration.
+# When upgrading images across Java versions, that creates a mismatch in PATH's expected by base image.
 if ! which java > /dev/null; then
-  log "Fixing PATH to include java"
-  PATH="${PATH}:/opt/java/openjdk/bin"
+  log "ERROR: PATH should not be explicitly passed into the container"
+  log "       Remove configuration of that variable."
+  exit 1
 fi
 
 export VERSIONS_JSON=https://launchermeta.mojang.com/mc/game/version_manifest.json

--- a/scripts/start-configuration
+++ b/scripts/start-configuration
@@ -165,32 +165,32 @@ case "${TYPE^^}" in
 
   MOHIST)
     evaluateJavaCompatibilityForForge
-    exec ${SCRIPTS:-/}start-deployMohist "$@"
+    exec "${SCRIPTS:-/}start-deployMohist" "$@"
   ;;
 
   CATSERVER)
     evaluateJavaCompatibilityForForge
-    exec ${SCRIPTS:-/}start-deployCatserver "$@"
+    exec "${SCRIPTS:-/}start-deployCatserver" "$@"
   ;;
 
   PURPUR)
-    exec ${SCRIPTS:-/}start-deployPurpur "$@"
+    exec "${SCRIPTS:-/}start-deployPurpur" "$@"
   ;;
 
   AIRPLANE)
-    exec ${SCRIPTS:-/}start-deployAirplane "$@"
+    exec "${SCRIPTS:-/}start-deployAirplane" "$@"
   ;;
 
   PUFFERFISH)
-    exec ${SCRIPTS:-/}start-deployPufferfish "$@"
+    exec "${SCRIPTS:-/}start-deployPufferfish" "$@"
   ;;
 
   CANYON)
-    exec ${SCRIPTS:-/}start-deployCanyon "$@"
+    exec "${SCRIPTS:-/}start-deployCanyon" "$@"
   ;;
 
   LIMBO)
-    exec ${SCRIPTS:-/}start-deployLimbo "$@"
+    exec "${SCRIPTS:-/}start-deployLimbo" "$@"
   ;;
 
   CRUCIBLE)

--- a/scripts/start-deployAirplane
+++ b/scripts/start-deployAirplane
@@ -42,6 +42,5 @@ fi
 
 # Normalize on Spigot for later operations
 export FAMILY=SPIGOT
-export SKIP_LOG4J_CONFIG=true
 
 exec "${SCRIPTS:-/}start-spiget" "$@"

--- a/scripts/start-deployBukkitSpigot
+++ b/scripts/start-deployBukkitSpigot
@@ -127,6 +127,5 @@ fi
 
 # Normalize on Spigot for operations below
 export FAMILY=SPIGOT
-export SKIP_LOG4J_CONFIG=true
 
 exec ${SCRIPTS:-/}start-spiget "$@"

--- a/scripts/start-deployCanyon
+++ b/scripts/start-deployCanyon
@@ -44,6 +44,5 @@ fi
 
 # Normalize on Spigot for later operations
 export FAMILY=SPIGOT
-export SKIP_LOG4J_CONFIG=true
 
 exec ${SCRIPTS:-/}start-spiget "$@"

--- a/scripts/start-deployCatserver
+++ b/scripts/start-deployCatserver
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-. ${SCRIPTS:-/}start-utils
+# shellcheck source=start-utils
+. "${SCRIPTS:-/}start-utils"
 set -o pipefail
 set -e
 
@@ -26,8 +27,6 @@ if [ ! -f ${SERVER} ]; then
   curl -H "Accept:application/octet-stream" -o "$SERVER" -fsSL https://api.github.com/repos/Luohuayu/CatServer/releases/assets/${latestJarId}
 fi
 
-export SKIP_LOG4J_CONFIG=true
-
 export FAMILY=HYBRID
-# Continue to Final Setup
-exec ${SCRIPTS:-/}start-setupWorld "$@"
+
+exec "${SCRIPTS:-/}start-setupWorld" "$@"

--- a/scripts/start-deployCrucible
+++ b/scripts/start-deployCrucible
@@ -55,7 +55,6 @@ if [ ! -d "$librariesDir" ]; then
 fi
 
 export SERVER
-export SKIP_LOG4J_CONFIG=true
 export FAMILY=HYBRID
 
 exec "${SCRIPTS:-$(dirname "$0")}/start-setupWorld" "$@"

--- a/scripts/start-deployCustom
+++ b/scripts/start-deployCustom
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-. ${SCRIPTS:-/}start-utils
+# shellcheck source=start-utils
+. "${SCRIPTS:-/}start-utils"
 isDebugging && set -x
 
 if isURL ${CUSTOM_SERVER}; then
@@ -30,6 +31,6 @@ else
 
 fi
 
-export SKIP_LOG4J_CONFIG=true
 export FAMILY=HYBRID
+
 exec ${SCRIPTS:-/}start-setupWorld $@

--- a/scripts/start-deployFTBA
+++ b/scripts/start-deployFTBA
@@ -2,7 +2,8 @@
 
 ftbInstallMarker=".ftb-installed"
 
-. ${SCRIPTS:-/}start-utils
+# shellcheck source=start-utils
+. "${SCRIPTS:-/}start-utils"
 isDebugging && set -x
 set -e
 
@@ -80,4 +81,5 @@ if ! [ -v SERVER ]; then
 fi
 
 export FAMILY=FORGE
+
 exec ${SCRIPTS:-/}start-setupWorld $@

--- a/scripts/start-deployForge
+++ b/scripts/start-deployForge
@@ -38,18 +38,23 @@ install() {
     get_installer "$normForgeVersion" "$shortForgeVersion"
   fi
 
-  log "Installing Forge $shortForgeVersion using $FORGE_INSTALLER"
+  log "Installing Forge $shortForgeVersion. This might take a minute or two..."
   mkdir -p mods
   tries=3
-  while ((--tries >= 0)); do
-    if java -jar "$FORGE_INSTALLER" --installServer; then
-      break
+  while true; do
+    if ! java -jar "$FORGE_INSTALLER" --installServer &> forge-installer.log; then
+      if ((--tries <= 0)); then
+        cat forge-installer.log
+        log "
+ERROR Forge failed to install after several tries.
+"
+        exit 1
+      fi
+      log "Install failed. Trying again..."
+    else
+      break # out of this loop
     fi
   done
-  if ((tries < 0)); then
-    log "Forge failed to install after several tries." >&2
-    exit 10
-  fi
   # NOTE $shortForgeVersion will be empty if installer location was given to us
   log "Finding installed server jar..."
   unset -v latest
@@ -148,4 +153,5 @@ else
 fi
 
 export FAMILY=FORGE
+
 exec "${SCRIPTS:-/}start-setupWorld" "$@"

--- a/scripts/start-deployLimbo
+++ b/scripts/start-deployLimbo
@@ -58,7 +58,5 @@ if [[ ${LEVEL} != *\;* ]]; then
 fi
 export LEVEL
 
-export SKIP_LOG4J_CONFIG=true
-
 export FAMILY=LIMBO
 exec ${SCRIPTS:-/}start-setupWorld $@

--- a/scripts/start-deployMagma
+++ b/scripts/start-deployMagma
@@ -1,13 +1,12 @@
 #!/bin/bash
 
-. ${SCRIPTS:-/}start-utils
-export SKIP_LOG4J_CONFIG=true
-
+# shellcheck source=start-utils
+. "${SCRIPTS:-/}start-utils"
 isDebugging && set -x
 
-: ${VANILLA_VERSION?}
+: "${VANILLA_VERSION?}"
 # stable, dev
-: ${MAGMA_CHANNEL:=stable}
+: "${MAGMA_CHANNEL:=stable}"
 
 
 magmaDownloadServer() {
@@ -90,4 +89,5 @@ else
 fi
 
 export FAMILY=HYBRID
-exec ${SCRIPTS:-/}start-setupWorld "$@"
+
+exec "${SCRIPTS:-/}start-setupWorld" "$@"

--- a/scripts/start-deployMohist
+++ b/scripts/start-deployMohist
@@ -38,7 +38,6 @@ if [ ! -f "${SERVER}" ]; then
   get -o "${SERVER}" "${mohistJob}${MOHIST_BUILD}/artifact/${buildRelPath}"
 fi
 
-export SKIP_LOG4J_CONFIG=true
-
 export FAMILY=HYBRID
+
 exec "${SCRIPTS:-$(dirname "$0")}/start-setupWorld" "$@"

--- a/scripts/start-deployPaper
+++ b/scripts/start-deployPaper
@@ -74,6 +74,5 @@ fi
 
 # Normalize on Spigot for downstream operations
 export FAMILY=SPIGOT
-export SKIP_LOG4J_CONFIG=true
 
 exec ${SCRIPTS:-/}start-spiget "$@"

--- a/scripts/start-deployPufferfish
+++ b/scripts/start-deployPufferfish
@@ -40,6 +40,5 @@ fi
 
 # Normalize on Spigot for later operations
 export FAMILY=SPIGOT
-export SKIP_LOG4J_CONFIG=true
 
 exec ${SCRIPTS:-/}start-spiget "$@"

--- a/scripts/start-deployPurpur
+++ b/scripts/start-deployPurpur
@@ -6,9 +6,9 @@ IFS=$'\n\t'
 . "${SCRIPTS:-/}start-utils"
 isDebugging && set -x
 
-: ${VANILLA_VERSION:?}
-: ${PURPUR_BUILD:=LATEST}
-: ${FORCE_REDOWNLOAD:=false}
+: "${VANILLA_VERSION:?}"
+: "${PURPUR_BUILD:=LATEST}"
+: "${FORCE_REDOWNLOAD:=false}"
 
 if [[ ${PURPUR_BUILD} == LATEST ]]; then
   if ! PURPUR_BUILD=$(get --json-path=".builds.latest" "https://api.purpurmc.org/v2/purpur/${VANILLA_VERSION}"); then
@@ -31,6 +31,5 @@ fi
 
 # Normalize on Spigot for later operations
 export FAMILY=SPIGOT
-export SKIP_LOG4J_CONFIG=true
 
 exec "${SCRIPTS:-/}start-spiget" "$@"

--- a/scripts/start-finalExec
+++ b/scripts/start-finalExec
@@ -243,6 +243,10 @@ EOF
 elif [[ $SERVER =~ run.sh ]]; then
   log "Using Forge supplied run.sh script..."
   echo $JVM_XX_OPTS $JVM_OPTS $expandedDOpts > user_jvm_args.txt
+  if isTrue ${SETUP_ONLY:=false}; then
+    echo "SETUP_ONLY: bash ${SERVER}"
+    exit
+  fi
   exec mc-server-runner "${mcServerRunnerArgs[@]}" --shell bash "${SERVER}"
 else
   # If we have a bootstrap.txt file... feed that in to the server stdin

--- a/scripts/start-utils
+++ b/scripts/start-utils
@@ -183,11 +183,23 @@ function isFamily() {
 }
 function isType() {
   for t in "${@}"; do
+    # shellcheck disable=SC2153
     if [[ $TYPE == "$t" ]]; then
       return 0
     fi
   done
   return 1
+}
+
+function evaluateJavaCompatibilityForForge() {
+  javaRelease=$(mc-image-helper java-release)
+  if versionLessThan 1.18 && (( javaRelease > 8 )); then
+    log "**********************************************************************"
+    log "WARNING: Some mods and modpacks may require Java 8."
+    log "         Please use itzg/minecraft-server:java8"
+    log "**********************************************************************"
+    sleep 5
+  fi
 }
 
 function extract() {


### PR DESCRIPTION
Will be able to streamline and improve robustness of build and test of all the Debian variants. That will cover all except the legacy Alpine build of `java8` and the upcoming GraalVM base image, which is RPM based.

cc @shotah 