### PR TITLE
Distro aware checksum

### DIFF
--- a/scripts/start-setupModpack
+++ b/scripts/start-setupModpack
@@ -215,7 +215,7 @@ if [[ "${GENERIC_PACKS}" ]]; then
   log "Checking if generic packs are up to date"
   if isTrue "${SKIP_GENERIC_PACK_UPDATE_CHECK:-false}" && [ -f "$sum_file" ]; then
     log "Skipping generic pack update check"
-  elif isTrue "${FORCE_GENERIC_PACK_UPDATE}" || ! sha1sum -c "${sum_file}" --status 2> /dev/null; then
+  elif isTrue "${FORCE_GENERIC_PACK_UPDATE}" || ! checkSum "${sum_file}"; then
     log "Generic pack(s) are out of date. Re-applying..."
 
     base_dir=/tmp/generic_pack_base

--- a/scripts/start-utils
+++ b/scripts/start-utils
@@ -236,3 +236,20 @@ function extract() {
       ;;
   esac
 }
+
+function checkSum() {
+  local sum_file=${1?}
+
+  # Get distro
+  distro=$(cat /etc/os-release | grep -E "^ID=" | cut -d= -f2 | sed -e 's/"//g')
+  
+  if [ "${distro}" == "debian" ] && sha1sum -c "${sum_file}" --status 2> /dev/null; then
+    return 0
+  elif [ "${distro}" == "ubuntu" ] && sha1sum -c "${sum_file}" --status 2> /dev/null; then
+    return 0
+  elif [ "${distro}" == "alpine" ] && sha1sum -c "${sum_file}" -s 2> /dev/null; then
+    return 0
+  else
+    return 1
+  fi
+}


### PR DESCRIPTION
This fixes the first problem described in issue #1342. Otherwise the checksum would always be failing on Alpine