### PR TITLE
Migrate Fabric server to launcher method

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,7 +419,7 @@ In both of the cases above, there is no need for the `VERSION` or `FORGEVERSION`
 
 ### Running a Fabric Server
 
-Enable [Fabric server](https://fabricmc.net/) mode by adding a `-e TYPE=FABRIC` to your command-line. By default, the container will install the latest [fabric-loader](https://fabricmc.net/wiki/documentation:fabric_loader) using the latest [fabric-installer](https://fabricmc.net/use/), against the minecraft server version you have defined with `VERSION` (defaulting to the latest vanilla release of the game).
+Enable [Fabric server](https://fabricmc.net/) mode by adding a `-e TYPE=FABRIC` to your command-line.
 
 ```
 docker run -d -v /path/on/host:/data \
@@ -427,19 +427,22 @@ docker run -d -v /path/on/host:/data \
     -p 25565:25565 -e EULA=TRUE --name mc itzg/minecraft-server
 ```
 
-See the [Working with mods and plugins](#working-with-mods-and-plugins) section to set up Fabric mods and configuration.
+By default, the container will install the latest [fabric server launcher](https://fabricmc.net/use/server/), using the latest [fabric-loader](https://fabricmc.net/wiki/documentation:fabric_loader) against the minecraft version you have defined with `VERSION` (defaulting to the latest vanilla release of the game).
 
-A specific loader version other than the latest can be requested using `FABRIC_LOADER_VERSION`, such as:
+A specific loader or launcher version other than the latest can be requested using `FABRIC_LOADER_VERSION` and `FABRIC_LAUNCHER_VERSION` respectively, such as:
 
 ```
 docker run -d -v /path/on/host:/data ... \
-    -e FABRIC_LOADER_VERSION=0.12.8
+    -e TYPE=FABRIC \
+    -e FABRIC_LAUNCHER_VERSION=0.10.2 \
+    -e FABRIC_LOADER_VERSION=0.13.1
 ```
 
-If you wish to use an alternative installer you can:
-* Specify an alternative version using `FABRIC_INSTALLER_VERSION` (such as `-e FABRIC_INSTALLER_VERSION=0.10.2`)
-* Provide the path to a custom installer jar available to the container with `FABRIC_INSTALLER`, relative to `/data` (such as `-e FABRIC_INSTALLER=fabric-installer-0.5.0.32.jar`)
-* Provide the URL to a custom installer jar with `FABRIC_INSTALLER_URL` (such as `-e FABRIC_INSTALLER_URL=http://HOST/fabric-installer-0.5.0.32.jar`)
+> If you wish to use an alternative launcher you can:
+> * Provide the path to a custom launcher jar available to the container with `FABRIC_LAUNCHER`, relative to `/data` (such as `-e FABRIC_LAUNCHER=fabric-server-custom.jar`)
+> * Provide the URL to a custom launcher jar with `FABRIC_LAUNCHER_URL` (such as `-e FABRIC_LAUNCHER_URL=http://HOST/fabric-server-custom.jar`)
+
+See the [Working with mods and plugins](#working-with-mods-and-plugins) section to set up Fabric mods and configuration.
 
 ### Running a Bukkit/Spigot server
 

--- a/scripts/start-deployFabric
+++ b/scripts/start-deployFabric
@@ -6,76 +6,45 @@ set -eu
 
 requireVar VANILLA_VERSION
 export TYPE=FABRIC
-: "${FABRIC_INSTALLER_VERSION:=${FABRICVERSION:-LATEST}}"
-: "${FABRIC_INSTALLER:=}"
-: "${FABRIC_INSTALLER_URL:=}"
+: "${FABRIC_LAUNCHER_VERSION:=${FABRIC_INSTALLER_VERSION:-LATEST}}"
+: "${FABRIC_LAUNCHER:=}"
+: "${FABRIC_LAUNCHER_URL:=}"
 : "${FABRIC_LOADER_VERSION:=LATEST}"
 
 isDebugging && set -x
 
-log "Checking Fabric version information."
-if [[ $FABRIC_INSTALLER ]]; then
-  FABRIC_INSTALLER_VERSION=$(echo -n "$FABRIC_INSTALLER" | mc-image-helper hash)
-elif [[ $FABRIC_INSTALLER_URL ]]; then
-  FABRIC_INSTALLER_VERSION=$(echo -n "$FABRIC_INSTALLER_URL" | mc-image-helper hash)
-elif [[ ${FABRIC_INSTALLER_VERSION^^} = LATEST ]]; then
-  FABRIC_INSTALLER_VERSION=$(maven-metadata-release https://maven.fabricmc.net/net/fabricmc/fabric-installer/maven-metadata.xml)
-fi
-
-export SERVER=fabric-server-${VANILLA_VERSION}-${FABRIC_INSTALLER_VERSION}.jar
-
-if [ ! \( -e ${SERVER} -a -e "server-${VANILLA_VERSION}.jar" \) ]; then
-
-  if [[ -z $FABRIC_INSTALLER && -z $FABRIC_INSTALLER_URL ]]; then
-    FABRIC_INSTALLER="fabric-installer-${FABRIC_INSTALLER_VERSION}.jar"
-    FABRIC_INSTALLER_URL="https://maven.fabricmc.net/net/fabricmc/fabric-installer/${FABRIC_INSTALLER_VERSION}/fabric-installer-${FABRIC_INSTALLER_VERSION}.jar"
-  elif [[ -z $FABRIC_INSTALLER ]]; then
-    FABRIC_INSTALLER="fabric-installer.jar"
-  elif [[ ! -e $FABRIC_INSTALLER ]]; then
-    log "ERROR: the given Fabric installer doesn't exist : $FABRIC_INSTALLER"
-    exit 2
+# Custom fabric jar
+if [[ $FABRIC_LAUNCHER ]]; then
+  export SERVER=${FABRIC_LAUNCHER}
+# Custom fabric jar url
+elif [[ $FABRIC_LAUNCHER_URL ]]; then
+  export SERVER=fabric-server-$(echo -n "$FABRIC_LAUNCHER_URL" | mc-image-helper hash)
+# Official fabric launcher
+else
+  if [[ ${FABRIC_LAUNCHER_VERSION^^} = LATEST ]]; then
+    log "Checking Fabric Launcher version information."
+    FABRIC_LAUNCHER_VERSION=$(maven-metadata-release https://maven.fabricmc.net/net/fabricmc/fabric-installer/maven-metadata.xml)
   fi
-
-  if [[ -z $FABRIC_LOADER_VERSION || ${FABRIC_LOADER_VERSION^^} = LATEST ]]; then
+  if [[ ${FABRIC_LOADER_VERSION^^} = LATEST ]]; then
     log "Checking Fabric Loader version information."
-
     FABRIC_LOADER_VERSION=$(maven-metadata-release https://maven.fabricmc.net/net/fabricmc/fabric-loader/maven-metadata.xml)
   fi
-
-  if [[ ! -e $FABRIC_INSTALLER ]]; then
-    log "Downloading $FABRIC_INSTALLER_URL ..."
-    if ! get -o "$FABRIC_INSTALLER" "$FABRIC_INSTALLER_URL"; then
-      log "Failed to download from given location $FABRIC_INSTALLER_URL"
-      exit 2
-    fi
-  fi
-
-  log "Installing Fabric ${VANILLA_VERSION} using $FABRIC_INSTALLER with loader version $FABRIC_LOADER_VERSION"
-
-  tries=3
-  set +e
-  while ((--tries >= 0)); do
-    java -jar $FABRIC_INSTALLER server \
-      -mcversion $VANILLA_VERSION \
-      -loader $FABRIC_LOADER_VERSION \
-      -downloadMinecraft \
-      -dir /data
-    if [[ $? == 0 ]]; then
-      break
-    fi
-  done
-  set -e
-  if (($tries < 0)); then
-    log "Fabric failed to install after several tries." >&2
-    exit 10
-  fi
-
-  mv server.jar "server-${VANILLA_VERSION}.jar"
-  mv fabric-server-launch.jar "${SERVER}"
+  export SERVER=fabric-server-mc.${VANILLA_VERSION}-loader.${FABRIC_LOADER_VERSION}-launcher.${FABRIC_LAUNCHER_VERSION}.jar
+  export FABRIC_LAUNCHER_URL="https://meta.fabricmc.net/v2/versions/loader/${VANILLA_VERSION}/${FABRIC_LOADER_VERSION}/${FABRIC_LAUNCHER_VERSION}/server/jar"
 fi
 
-# Specify which server jar to run
-echo "serverJar=server-${VANILLA_VERSION}.jar" >  fabric-server-launcher.properties
+if [[ ! -e ${SERVER} && ! -z ${FABRIC_LAUNCHER_URL} ]]; then
+  log "Downloading $FABRIC_LAUNCHER_URL ..."
+  if ! get -o "$SERVER" "$FABRIC_LAUNCHER_URL"; then
+    log "Failed to download from given location $FABRIC_LAUNCHER_URL"
+    exit 2
+  fi
+fi
+
+if [[ ! -e ${SERVER} ]]; then
+  log "$SERVER does not exist, cannot launch server!"
+  exit 1
+fi
 
 export FAMILY=FABRIC
 exec "${SCRIPTS:-/}start-setupWorld" "$@"


### PR DESCRIPTION
The Fabric team have improved the server launch methodology to be more in line with other server types - a launcher specifying the Minecraft, Fabric Launcher, and Fabric Loader versions to use.

https://fabricmc.net/use/server/

This allows for cleaner auto-updates, and fixes #1350 by using the naming convention Fabric use for launcher jar files.

Documentation has been updated to reflect this change, and support for existing configurations is maintained, with the exception of `FABRIC_INSTALLER` and `FABRIC_INSTALLER_URL` (as the installer is no longer
used). These have been replaced by `FABRIC_LAUNCHER` and `FABRIC_LAUNCHER_URL` respectively, to define a custom jar or URL for the launcher as opposed to the installer.