### PR TITLE
Adding notifications for on close, reopen, and delete

### DIFF
--- a/.github/workflows/issue-label.yml
+++ b/.github/workflows/issue-label.yml
@@ -2,7 +2,7 @@ name: Issue labels
 
 on:
   issues:
-    types: [labeled]
+    types: [labeled, reopened, closed, deleted]
 
 env:
   DISCORD_WEBHOOK: ${{ secrets.DISCORD_ISSUES_WEBHOOK }}
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: notify
+      - name: notify on label
         if: > 
           github.event.label.name == 'enhancement' 
           || github.event.label.name == 'bug' 
@@ -23,3 +23,11 @@ jobs:
         uses: Ilshidur/action-discord@master
         with:
           args: "[${{ github.event.issue.title }} (#${{ github.event.issue.number }})](<${{ github.event.issue.html_url }}>) added `${{ github.event.label.name }}` label"
+      - name: notify on action change
+        if: > 
+          github.event.action == 'closed'
+          || github.event.action == 'reopened'
+          || github.event.action == 'deleted'
+        uses: Ilshidur/action-discord@master
+        with:
+          args: "[${{ github.event.issue.title }} (#${{ github.event.issue.number }})](<${{ github.event.issue.html_url }}>) has been `${{ github.event.action }}` by `${{ github.event.sender.login }}`"


### PR DESCRIPTION
Adding notifications to help keep track of Open issues by showing which were closed or reopened. Added Deleted because that is another possible path to "close" a request without notificaiton.

[Related to Issue 1353](https://github.com/itzg/docker-minecraft-server/issues/1353)
