### PR TITLE
Added a syntax example for JVM_OPTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1487,6 +1487,9 @@ To let the JVM calculate the heap size from the container declared memory limit,
 
 General JVM options can be passed to the Minecraft Server invocation by passing a `JVM_OPTS`
 environment variable. The JVM requires `-XX` options to precede `-X` options, so those can be declared in `JVM_XX_OPTS`. Both variables are space-delimited, raw JVM arguments.
+```
+-e JVM_OPTS="-someJVMOption someJVMOptionValue"
+```
 
 For some cases, if e.g. after removing mods, it could be necessary to startup minecraft with an additional `-D` parameter like `-Dfml.queryResult=confirm`. To address this you can use the environment variable `JVM_DD_OPTS`, which builds the params from a given list of values separated by space, but without the `-D` prefix. To make things running under systems (e.g. Plesk), which doesn't allow `=` inside values, a `:` (colon) could be used instead. The upper example would look like this:
 `JVM_DD_OPTS=fml.queryResult:confirm`, and will be converted to `-Dfml.queryResult=confirm`.


### PR DESCRIPTION
I clarified the use of the JVM_OPTS parameter with an example, since I myself first struggled to figure the correct syntax out. After researching for a bit, I found issue https://github.com/itzg/docker-minecraft-server/issues/943 where an example was provided. I thought it could be helpful for everyone stumbling upon the same problem in the future if an example for correct usage is directly within the documentation.