### PR TITLE
Removing unused ttf-dejavu package

### DIFF
--- a/build/alpine/install-packages.sh
+++ b/build/alpine/install-packages.sh
@@ -22,6 +22,5 @@ apk add --no-cache -U \
     nano \
     sudo \
     knock \
-    ttf-dejavu \
     tar \
     zstd

--- a/build/ubuntu/install-packages.sh
+++ b/build/ubuntu/install-packages.sh
@@ -22,7 +22,6 @@ apt-get install -y \
   nano \
   unzip \
   zstd \
-  knockd \
-  ttf-dejavu
+  knockd
 
 apt-get clean


### PR DESCRIPTION
The package ttf-dejavu adds 17MB to the alpine images (and probably similar for Ubuntu). I unable to identify through source history why the package was added in the first place. Being a server environment, fonts are not typically applicable.