### PR TITLE
use user instead of group in sudoers file

### DIFF
--- a/files/sudoers-mc
+++ b/files/sudoers-mc
@@ -1,2 +1,2 @@
-%minecraft ALL=(ALL) NOPASSWD:/usr/bin/pkill
-%minecraft ALL=(ALL) NOPASSWD:/usr/sbin/knockd
+minecraft ALL=(ALL) NOPASSWD:/usr/bin/pkill
+minecraft ALL=(ALL) NOPASSWD:/usr/sbin/knockd


### PR DESCRIPTION
Fixes failing to start autopause when `GID` is set to `100` (id of existing `users` group)

Fixes #935 and #1233

Alpine branches might need an extra PR afterwards.