### PR TITLE
ForgeAPI: Random failure fix

### DIFF
--- a/.github/workflows/build-multiarch.yml
+++ b/.github/workflows/build-multiarch.yml
@@ -56,7 +56,7 @@ jobs:
             baseImage: ibm-semeru-runtimes:open-11-jre
             platforms: linux/amd64,linux/arm64
             mcVersion: 1.16.5
-        # JAVA 8: NOTE: Unable to go past 8u312 because of Forge https://github.com/MultiMC/Launcher/issues/447
+        # JAVA 8: NOTE: Unable to go past 8u312 because of Forge dependencies
           - variant: java8
             baseImage: openjdk:8-jre-alpine3.9
             platforms: linux/amd64

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /.idea/
 *.iml
 /gh-md-toc
+personal-build-and-develop.*

--- a/scripts/start-setupForgeApiMods
+++ b/scripts/start-setupForgeApiMods
@@ -24,8 +24,8 @@ out_dir=/data/mods
 isDebugging && set -x
 
 # Remove old mods/plugins
-if isTrue "${REMOVE_OLD_FORGEAPI_MODS}" && [ -z "${MODS_FORGEAPI_KEY}" ]; then
-  removeOldMods /data/mods
+if isTrue "${REMOVE_OLD_FORGEAPI_MODS}"; then
+  removeOldMods "/data/mods"
 fi
 
 # Family filter is on by default for Forge, Fabric, and Bukkit
@@ -131,8 +131,8 @@ modFileByProjectID(){
     if [ ! "$PROJECT_FILE" ]; then
       PROJECT_FILE=$current_project_file
     elif [ "$current_project_file" ]; then
-      current_project_file_id=$(jq -n "$current_project_file" | jq -jc '.id' )
-      PROJECT_FILE_ID=$(jq -n "$PROJECT_FILE" | jq -jc '.id' )
+      current_project_file_id=$(jq -n "$current_project_file" | jq -jc '.id // empty' )
+      PROJECT_FILE_ID=$(jq -n "$PROJECT_FILE" | jq -jc '.id // empty' )
       if (( current_project_file_id > PROJECT_FILE_ID )); then
         PROJECT_FILE=$current_project_file
       fi
@@ -157,19 +157,19 @@ downloadModPackfromModFile() {
     log "ERROR: Project File not found from the ForgeAPI"
     exit 2
   fi
-
-  # grabs needed values from our json return
-  unset file_name
-  unset download_url
-  file_name=$(jq -n "$PROJECT_FILE" | jq -jc '.fileName' )
-  download_url=$(jq -n "$PROJECT_FILE" | jq -jc '.downloadUrl' )
-  
   # trys to make the output directory incase it doesnt exist.
   mkdir -p "$out_dir"
-  echo "Downloading ${download_url}"
-  if ! get --skip-up-to-date -o "${out_dir}/${file_name}" "${download_url}"; then
-    log "ERROR: failed to download from ${download_url}"
-    exit 2
+
+  # grabs needed values from our json return
+  file_name=$(jq -n "$PROJECT_FILE" | jq -jc '.fileName // empty' )
+  download_url=$(jq -n "$PROJECT_FILE" | jq -jc '.downloadUrl // empty' )
+
+  if [ ! -f "${out_dir}/${file_name}" ]; then
+    echo "Downloading ${download_url}"
+    if ! get --skip-up-to-date -o "${out_dir}/${file_name}" "${download_url}"; then
+      log "ERROR: failed to download from ${download_url}"
+      exit 2
+    fi
   fi
 }
 

--- a/scripts/start-setupForgeApiMods
+++ b/scripts/start-setupForgeApiMods
@@ -17,6 +17,7 @@ FORGEAPI_BASE_URL=${FORGEAPI_BASE_URL:-https://api.curseforge.com/v1}
 RELEASE_NUMBER_FILTER=1
 MINECRAFT_GAME_ID=432
 FILTER_BY_FAMILY=false
+DOWNLOADED_MODIDS=()
 out_dir=/data/mods
 
 # shellcheck source=start-utils
@@ -163,9 +164,13 @@ downloadModPackfromModFile() {
   # grabs needed values from our json return
   file_name=$(jq -n "$PROJECT_FILE" | jq -jc '.fileName // empty' )
   download_url=$(jq -n "$PROJECT_FILE" | jq -jc '.downloadUrl // empty' )
+  mod_id=$(jq -n "$PROJECT_FILE" | jq -jc '.modId // empty' )
 
   if [ ! -f "${out_dir}/${file_name}" ]; then
     echo "Downloading ${download_url}"
+    # Track the mods we have downloaded.
+    DOWNLOADED_MODIDS+=("${mod_id}")
+    log "debug: ${mod_id} is in ${DOWNLOADED_MODIDS[*]}"
     if ! get --skip-up-to-date -o "${out_dir}/${file_name}" "${download_url}"; then
       log "ERROR: failed to download from ${download_url}"
       exit 2
@@ -181,8 +186,11 @@ downloadDependencies(){
     if [ "$required_dependencies" ]; then
       jq -n "$required_dependencies" | jq -c '.[]?' | while read current_dependency; do
         mod_id=$(jq -n "$current_dependency" | jq -jc '.modId' )
-        modFileByProjectID $mod_id "release"
-        downloadModPackfromModFile
+        # Validate we have not tried to download the mod yet.
+        if [[ ! "${DOWNLOADED_MODIDS[*]}" =~ "${mod_id}" ]]; then
+          modFileByProjectID $mod_id "release"
+          downloadModPackfromModFile
+        fi
       done
     fi
   fi
@@ -204,10 +212,13 @@ if [ "$MODS_FORGEAPI_FILE" ] && [ -z "$MODS_FORGEAPI_PROJECTIDS" ]; then
     current_release_type=$(jq -n "$current_project" | jq -r '.releaseType // empty' )
     current_file_name=$(jq -n "$current_project" | jq -r '.fileName // empty' )
 
-    modFileByProjectID $project_id $current_release_type $current_file_name
-    downloadModPackfromModFile
-    if isTrue "${MODS_FORGEAPI_DOWNLOAD_DEPENDENCIES}"; then
-      downloadDependencies
+    # Validate we have not tried to download the mod yet.
+    if [[ ! "${DOWNLOADED_MODIDS[*]}" =~ "${project_id}" ]]; then
+      modFileByProjectID $project_id $current_release_type $current_file_name
+      downloadModPackfromModFile
+      if isTrue "${MODS_FORGEAPI_DOWNLOAD_DEPENDENCIES}"; then
+        downloadDependencies
+      fi
     fi
   done
 fi
@@ -217,10 +228,13 @@ if [ "$MODS_FORGEAPI_PROJECTIDS" ] && [ -z "$MODS_FORGEAPI_FILE" ]; then
   ensureModKey
   updateFamilyFilter
   for project_id in ${MODS_FORGEAPI_PROJECTIDS//,/ }; do
-    modFileByProjectID $project_id 
-    downloadModPackfromModFile
-    if isTrue "${MODS_FORGEAPI_DOWNLOAD_DEPENDENCIES}"; then
-      downloadDependencies
+    # Validate we have not tried to download the mod yet.
+    if [[ ! "${DOWNLOADED_MODIDS[*]}" =~ "${project_id}" ]]; then
+      modFileByProjectID $project_id 
+      downloadModPackfromModFile
+      if isTrue "${MODS_FORGEAPI_DOWNLOAD_DEPENDENCIES}"; then
+        downloadDependencies
+      fi
     fi
   done
 fi

--- a/scripts/start-setupForgeApiMods
+++ b/scripts/start-setupForgeApiMods
@@ -105,8 +105,8 @@ modFileByProjectID(){
     total_count=$(jq -n "$project_files" | jq -c '.pagination.totalCount' )
 
     # Checking for a individual release type input, if not use global
-    if [ $project_id_release_type ]; then
-      updateReleaseNumber $project_id_release_type
+    if [ "$project_id_release_type" ]; then
+      updateReleaseNumber "$project_id_release_type"
       unset project_id_release_type 
     else
       updateReleaseNumber $MODS_FORGEAPI_RELEASES
@@ -114,7 +114,7 @@ modFileByProjectID(){
 
     # grabs the highest ID of the releaseTypes selected.
     # Default is 1 for Release, Beta is 2, and Alpha is 3. Using less than we can validate highest release.
-    if [ $project_id_file_name ]; then
+    if [ "$project_id_file_name" ]; then
       # Looks for file by name
       current_project_file=$(jq -n "$project_files" | jq --arg FILE_NAME "$project_id_file_name" -jc '
         .data | map(select(.fileName<=($FILE_NAME))) | .[0] // empty')
@@ -140,12 +140,12 @@ modFileByProjectID(){
     fi
     
     # check to see if we have gone to far or lost our index and exit with an error
-    if [ -z "$index" ] || [ -z "$total_count" ] || [ $index -ge $total_count ]; then
+    if [ -z "$index" ] || [ -z "$total_count" ] || [ $index -ge "$total_count" ]; then
       log "ERROR: Unable to retrieve any files for ${project_id} from ForgeAPI also Validate files have release type associated with no. ${RELEASE_NUMBER_FILTER}"
       exit 2
     fi
     # Increment start index to new set.
-    index=$(($index + $pageSize))
+    index=$((index + pageSize))
   done
   if [ ! "$PROJECT_FILE" ]; then
     log "ERROR: Unable to retrieve any files for ${project_id}, Release Type: ${RELEASE_NUMBER_FILTER}, FAMILY_TYPE: ${FAMILY,,}"
@@ -170,7 +170,6 @@ downloadModPackfromModFile() {
     echo "Downloading ${download_url}"
     # Track the mods we have downloaded.
     DOWNLOADED_MODIDS+=("${mod_id}")
-    log "debug: ${mod_id} is in ${DOWNLOADED_MODIDS[*]}"
     if ! get --skip-up-to-date -o "${out_dir}/${file_name}" "${download_url}"; then
       log "ERROR: failed to download from ${download_url}"
       exit 2
@@ -184,14 +183,15 @@ downloadDependencies(){
     required_dependencies=$(jq -n "$dependencies" | jq --arg REQUIRED_FILTER "3" -jc '
       map(select(.relationType==($REQUIRED_FILTER|tonumber)))')
     if [ "$required_dependencies" ]; then
-      jq -n "$required_dependencies" | jq -c '.[]?' | while read current_dependency; do
+      while read -r current_dependency; do
         mod_id=$(jq -n "$current_dependency" | jq -jc '.modId' )
         # Validate we have not tried to download the mod yet.
-        if [[ ! "${DOWNLOADED_MODIDS[*]}" =~ "${mod_id}" ]]; then
-          modFileByProjectID $mod_id "release"
+        if [[ ! "${DOWNLOADED_MODIDS[*]}" =~ $mod_id ]]; then
+          modFileByProjectID "$mod_id" "release"
           downloadModPackfromModFile
         fi
-      done
+      # needs to be piped in to keep look in main process
+      done < <(jq -n "$required_dependencies" | jq -c '.[]?')
     fi
   fi
 }
@@ -206,21 +206,22 @@ if [ "$MODS_FORGEAPI_FILE" ] && [ -z "$MODS_FORGEAPI_PROJECTIDS" ]; then
   fi
 
   # Needs loop here to look up release types befor calling download.
-  jq -c '.[]?' $MODS_FORGEAPI_FILE | while read current_project; do
+  while read -r current_project; do
     # Per stack overflow we can use //empty to return empty string that works with -z
     project_id=$(jq -n "$current_project" | jq -r '.projectId // empty' )
     current_release_type=$(jq -n "$current_project" | jq -r '.releaseType // empty' )
     current_file_name=$(jq -n "$current_project" | jq -r '.fileName // empty' )
 
     # Validate we have not tried to download the mod yet.
-    if [[ ! "${DOWNLOADED_MODIDS[*]}" =~ "${project_id}" ]]; then
-      modFileByProjectID $project_id $current_release_type $current_file_name
+    if [[ ! "${DOWNLOADED_MODIDS[*]}" =~ $project_id ]]; then
+      modFileByProjectID "$project_id" "$current_release_type" "$current_file_name"
       downloadModPackfromModFile
       if isTrue "${MODS_FORGEAPI_DOWNLOAD_DEPENDENCIES}"; then
         downloadDependencies
       fi
     fi
-  done
+  # needs to be piped in to keep look in main process
+  done < <(jq -c '.[]?' $MODS_FORGEAPI_FILE)
 fi
 
 # Use only project ids and global release data.
@@ -229,7 +230,7 @@ if [ "$MODS_FORGEAPI_PROJECTIDS" ] && [ -z "$MODS_FORGEAPI_FILE" ]; then
   updateFamilyFilter
   for project_id in ${MODS_FORGEAPI_PROJECTIDS//,/ }; do
     # Validate we have not tried to download the mod yet.
-    if [[ ! "${DOWNLOADED_MODIDS[*]}" =~ "${project_id}" ]]; then
+    if [[ ! "${DOWNLOADED_MODIDS[*]}" =~ $project_id ]]; then
       modFileByProjectID $project_id 
       downloadModPackfromModFile
       if isTrue "${MODS_FORGEAPI_DOWNLOAD_DEPENDENCIES}"; then

--- a/tests/setuponlytests/forgeapimods_projectids/verify.sh
+++ b/tests/setuponlytests/forgeapimods_projectids/verify.sh
@@ -1,4 +1,5 @@
+# No family filter applied, DO NOT use Fabric or Forge specific name validation as it may cause random breakage.
 mc-image-helper assert fileExists "/data/mods/BiomesOPlenty*"
 mc-image-helper assert fileExists "/data/mods/TerraBlender*"
-mc-image-helper assert fileExists "/data/mods/voicechat-fabric*"
+mc-image-helper assert fileExists "/data/mods/voicechat*"
 mc-image-helper assert fileExists "/data/mods/fabric-api*"


### PR DESCRIPTION
AC: Tests no longer randomly fail for forgeapi projectids
AC: ForgeAPI no longer attempts to redownload downloaded packages. 

Changes:
* Allowed remove old mods to work.
* Using // empty over unset
* Added downloaded modid array to prevent recheck and download of mods.
* Added file check in front of download. (I know '--skip-up-to-date' does this, but messaging is key here I think)
* Added personal build script to gitignore
