### PR TITLE
adding major version for pufferfish

### DIFF
--- a/scripts/start-configuration
+++ b/scripts/start-configuration
@@ -116,7 +116,9 @@ case "X$VERSION" in
   ;;
 esac
 export VANILLA_VERSION
-log "Resolved version given ${VERSION} into ${VANILLA_VERSION}"
+MAJOR_VANILLA_VERSION=$(get_major_version "$VANILLA_VERSION")
+export MAJOR_VANILLA_VERSION
+log "Resolved version given ${VERSION} into ${VANILLA_VERSION} and major version ${MAJOR_VANILLA_VERSION}"
 
 cd /data || exit 1
 

--- a/scripts/start-deployPufferfish
+++ b/scripts/start-deployPufferfish
@@ -8,14 +8,14 @@ isDebugging && set -x
 
 IFS=$'\n\t'
 
-if [[ "${VANILLA_VERSION}" != "1.18" ]] && [[ "${VANILLA_VERSION}" != "1.17" ]]; then
+if [[ "${MAJOR_VANILLA_VERSION}" != "1.18" ]] && [[ "${MAJOR_VANILLA_VERSION}" != "1.17" ]]; then
   log "ERROR: Pufferfish server type only supports versions 1.18 or 1.17, use PUFFERFISH_BUILD to select the the correct build 47 => 1.18.1, 50 => 1.18.2 etc"
   exit 1
 fi
 
 : "${PUFFERFISH_BUILD:=lastSuccessfulBuild}"
 
-PUFFERFISH_BUILD_JSON=$(curl -X GET -s "https://ci.pufferfish.host/job/Pufferfish-${VANILLA_VERSION}/${PUFFERFISH_BUILD}/api/json")
+PUFFERFISH_BUILD_JSON=$(curl -X GET -s "https://ci.pufferfish.host/job/Pufferfish-${MAJOR_VANILLA_VERSION}/${PUFFERFISH_BUILD}/api/json")
 # Example: "url": "https://ci.pufferfish.host/job/Pufferfish-1.18/50/",
 PUFFERFISH_BUILD_URL=$(jq -n "$PUFFERFISH_BUILD_JSON" | jq -jc '.url // empty' )
 # Example: "fileName": "pufferfish-paperclip-1.18.2-R0.1-SNAPSHOT-reobf.jar",

--- a/scripts/start-utils
+++ b/scripts/start-utils
@@ -8,6 +8,26 @@ function join_by() {
   printf "%s" "${@/#/$d}"
 }
 
+function split_by () {
+    string=$1
+    separator=$2
+
+    tmp=${string//"$separator"/$'\2'}
+    IFS=$'\2' read -a arr <<< "$tmp"
+    for substr in "${arr[@]}" ; do
+        echo "$substr"
+    done
+    echo
+}
+
+function get_major_version() {
+  version=$1
+  split_verison=$(split_by "$version" ".")
+  array_version=("${split_verison[0]}")
+  # Do not quote arrays as it will break the join by function.
+  join_by "." ${array_version[0]} ${array_version[1]}
+}
+
 function isURL() {
   local value=$1
 

--- a/scripts/start-utils
+++ b/scripts/start-utils
@@ -23,8 +23,8 @@ function split_by () {
 function get_major_version() {
   version=$1
   split_verison=$(split_by "$version" ".")
-  array_version=("${split_verison[0]}")
   # Do not quote arrays as it will break the join by function.
+  array_version=(${split_verison[0]})
   join_by "." ${array_version[0]} ${array_version[1]}
 }
 

--- a/scripts/start-utils
+++ b/scripts/start-utils
@@ -8,24 +8,9 @@ function join_by() {
   printf "%s" "${@/#/$d}"
 }
 
-function split_by () {
-    string=$1
-    separator=$2
-
-    tmp=${string//"$separator"/$'\2'}
-    IFS=$'\2' read -a arr <<< "$tmp"
-    for substr in "${arr[@]}" ; do
-        echo "$substr"
-    done
-    echo
-}
-
 function get_major_version() {
   version=$1
-  split_verison=$(split_by "$version" ".")
-  # Do not quote arrays as it will break the join by function.
-  array_version=(${split_verison[0]})
-  join_by "." ${array_version[0]} ${array_version[1]}
+  echo "$version" | cut -d. -f 1-2
 }
 
 function isURL() {

--- a/tests/setuponlytests/pufferfish/docker-compose.yml
+++ b/tests/setuponlytests/pufferfish/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       EULA: "TRUE"
       SETUP_ONLY: "TRUE"
       TYPE: PUFFERFISH
-      VERSION: 1.18
+      VERSION: ${MINECRAFT_VERSION:-LATEST}
       PUFFERFISH_BUILD: 50
     volumes:
       - ./data:/data


### PR DESCRIPTION
Major version is used by many third party functions such as Forge API. Would be nice to have a major version split for wide spread use. 

Added new export of MAJOR_VANILLA_VERSION for widespread use.