### PR TITLE
added Loliserver support

### DIFF
--- a/README.md
+++ b/README.md
@@ -600,6 +600,8 @@ A [Loliserver](https://github.com/Loli-Server/LoliServer) type server can be use
 
 > **NOTE** Loliserver only provides a single release stream, so `VERSION` is ignored
 
+> **Disclaimer** The retrieval of the serverjar is not bulletproof. It can and probably will change in the future.
+
 ### Running a Canyon server
 
 [Canyon](https://github.com/canyonmodded/canyon) is a fork of CraftBukkit for Minecraft Beta 1.7.3. It includes multiple enhancements whilst also retaining compatibility with old Bukkit plugins and mods as much as possible.

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ By default, the container will download the latest version of the "vanilla" [Min
       * [Running a Magma server](#running-a-magma-server)
       * [Running a Mohist server](#running-a-mohist-server)
       * [Running a Catserver type server](#running-a-catserver-type-server)
+      * [Running a Loliserver type server](#running-a-loliserver-type-server)
       * [Running a Canyon server](#running-a-canyon-server)
       * [Running a SpongeVanilla server](#running-a-spongevanilla-server)
       * [Running a Limbo server](#running-a-limbo-server)
@@ -590,6 +591,14 @@ A [Catserver](http://catserver.moe/) type server can be used with
     -e TYPE=CATSERVER
 
 > **NOTE** Catserver only provides a single release stream, so `VERSION` is ignored
+
+### Running a Loliserver type server
+
+A [Loliserver](https://github.com/Loli-Server/LoliServer) type server can be used with
+
+    -e TYPE=LOLISERVER
+
+> **NOTE** Loliserver only provides a single release stream, so `VERSION` is ignored
 
 ### Running a Canyon server
 

--- a/scripts/start-configuration
+++ b/scripts/start-configuration
@@ -214,6 +214,11 @@ case "${TYPE^^}" in
     exec "${SCRIPTS:-/}start-deployCatserver" "$@"
   ;;
 
+  LOLISERVER)
+    evaluateJavaCompatibilityForForge
+    exec "${SCRIPTS:-/}start-deployLoliserver" "$@"
+  ;;
+
   PURPUR)
     exec "${SCRIPTS:-/}start-deployPurpur" "$@"
   ;;
@@ -248,7 +253,7 @@ case "${TYPE^^}" in
       log "Invalid type: '$TYPE'"
       log "Must be: VANILLA, FORGE, BUKKIT, SPIGOT, PAPER, FTBA (multiarch-only),"
       log "         CURSEFORGE, SPONGEVANILLA, PURPUR, CUSTOM,"
-      log "         MAGMA, MOHIST, CATSERVER, AIRPLANE, PUFFERFISH, CANYON, LIMBO, CRUCIBLE"
+      log "         MAGMA, MOHIST, CATSERVER, LOLISERVER, AIRPLANE, PUFFERFISH, CANYON, LIMBO, CRUCIBLE"
       exit 1
   ;;
 

--- a/scripts/start-deployLoliserver
+++ b/scripts/start-deployLoliserver
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# shellcheck source=start-utils
+. "${SCRIPTS:-/}start-utils"
+set -o pipefail
+set -e
+
+latestAsset=$(
+  curl -fsSL https://cdn.ci.loliidc.cn:30011/job/LoliServer-1.16.5/lastSuccessfulBuild/artifact/projects/LoliServer/build/libs | \
+    jq '.assets[] | select(.name | match(".*-server.jar"))'
+)
+
+if [[ -z "${latestAsset}" ]]; then
+  log "ERROR: latest release of Loliserver is missing server.jar asset"
+  exit 1
+fi
+
+isDebugging && log "Latest asset ${latestAsset}"
+latestJarName=$(echo ${latestAsset} | jq --raw-output '.name')
+latestJarId=$(echo ${latestAsset} | jq --raw-output '.id')
+
+
+export SERVER="/data/${latestJarName}"
+
+if [ ! -f ${SERVER} ]; then
+  log "Downloading ${latestJarName}"
+  curl -H "Accept:application/octet-stream" -o "$SERVER" -fsSL https://cdn.ci.loliidc.cn:30011/job/LoliServer-1.16.5/lastSuccessfulBuild/artifact/projects/LoliServer/build/libs/${latestJarId}
+fi
+
+export FAMILY=HYBRID
+
+exec "${SCRIPTS:-/}start-setupWorld" "$@"

--- a/tests/setuponlytests/loliserver/docker-compose.yml
+++ b/tests/setuponlytests/loliserver/docker-compose.yml
@@ -1,0 +1,13 @@
+version: "3"
+
+services:
+  mc:
+    restart: "no"
+    image: ${IMAGE_TO_TEST:-itzg/minecraft-server}
+    environment:
+      EULA: "TRUE"
+      SETUP_ONLY: "TRUE"
+      TYPE: LOLISERVER
+      VERSION: ${MINECRAFT_VERSION:-LATEST}
+    volumes:
+      - ./data:/data

--- a/tests/setuponlytests/loliserver/require.sh
+++ b/tests/setuponlytests/loliserver/require.sh
@@ -1,0 +1,1 @@
+[[ $MINECRAFT_VERSION == 1.16.5 ]] || exit 1

--- a/tests/setuponlytests/loliserver/verify.sh
+++ b/tests/setuponlytests/loliserver/verify.sh
@@ -1,0 +1,1 @@
+mc-image-helper assert fileExists "/data/LoliServer-*.jar"


### PR DESCRIPTION
This PR adds support for the more recent hybrid server type LoliServer.
I am not very happy with how releases or updates are handled.
Built jars are just available on a jenkins server which the `lastSuccessfulBuild` gets `curl`ed and used.

In advance iam not sure if all necessary changes are made so i would be thankful for a review/test. 