### PR TITLE
Fix memory env vars being overridden if set to ""

### DIFF
--- a/scripts/start-finalExec
+++ b/scripts/start-finalExec
@@ -110,9 +110,9 @@ if [[ ${GUI,,} = false ]]; then
   EXTRA_ARGS+=" nogui"
 fi
 
-: "${MEMORY:=1G}"
-: "${INIT_MEMORY:=${MEMORY}}"
-: "${MAX_MEMORY:=${MEMORY}}"
+: "${MEMORY=1G}"
+: "${INIT_MEMORY=${MEMORY}}"
+: "${MAX_MEMORY=${MEMORY}}"
 
 expandedDOpts=
 if [ -n "$JVM_DD_OPTS" ]; then


### PR DESCRIPTION
This commit ensures expected behaviour when trying out the example below, detailed in the README.

> To let the JVM calculate the heap size from the container declared memory limit, unset MEMORY with an empty value, such as -e MEMORY="". By default, the JVM will use 25% of the container memory limit as the heap limit; however, as an example the following would tell the JVM to use 75% of the container limit of 2GB of memory:
>  `-e MEMORY="" -e JVM_XX_OPTS="-XX:MaxRAMPercentage=75" -m 2000M`