### PR TITLE
Shortcut: Make container work for Feed The Beast (FTB) Modpacks

### DIFF
--- a/scripts/start-deployFTBA
+++ b/scripts/start-deployFTBA
@@ -62,4 +62,5 @@ forgeVersion=$(jq -r '.targets|unique[] | select(.name == "forge") | .version' v
 fabricVersion=$(jq -r '.targets|unique[] | select(.name == "fabric") | .version' version.json)
 mcVersion=$(jq -r '.targets|unique[] | select(.name == "minecraft") | .version' version.json)
 
+echo "Executing run script"
 exec "/data/run.sh"

--- a/scripts/start-deployFTBA
+++ b/scripts/start-deployFTBA
@@ -62,4 +62,4 @@ forgeVersion=$(jq -r '.targets|unique[] | select(.name == "forge") | .version' v
 fabricVersion=$(jq -r '.targets|unique[] | select(.name == "fabric") | .version' version.json)
 mcVersion=$(jq -r '.targets|unique[] | select(.name == "minecraft") | .version' version.json)
 
-echo "Use console to manually start server"
+exec ./run.sh

--- a/scripts/start-deployFTBA
+++ b/scripts/start-deployFTBA
@@ -62,4 +62,4 @@ forgeVersion=$(jq -r '.targets|unique[] | select(.name == "forge") | .version' v
 fabricVersion=$(jq -r '.targets|unique[] | select(.name == "fabric") | .version' version.json)
 mcVersion=$(jq -r '.targets|unique[] | select(.name == "minecraft") | .version' version.json)
 
-exec ./run.sh
+exec "./run.sh"

--- a/scripts/start-deployFTBA
+++ b/scripts/start-deployFTBA
@@ -62,4 +62,4 @@ forgeVersion=$(jq -r '.targets|unique[] | select(.name == "forge") | .version' v
 fabricVersion=$(jq -r '.targets|unique[] | select(.name == "fabric") | .version' version.json)
 mcVersion=$(jq -r '.targets|unique[] | select(.name == "minecraft") | .version' version.json)
 
-exec "./run.sh"
+exec "/data/run.sh"

--- a/scripts/start-deployFTBA
+++ b/scripts/start-deployFTBA
@@ -63,4 +63,4 @@ fabricVersion=$(jq -r '.targets|unique[] | select(.name == "fabric") | .version'
 mcVersion=$(jq -r '.targets|unique[] | select(.name == "minecraft") | .version' version.json)
 
 echo "Executing run script"
-exec "/data/run.sh"
+exec "/data/run.sh" "$@"

--- a/scripts/start-deployFTBA
+++ b/scripts/start-deployFTBA
@@ -62,24 +62,4 @@ forgeVersion=$(jq -r '.targets|unique[] | select(.name == "forge") | .version' v
 fabricVersion=$(jq -r '.targets|unique[] | select(.name == "fabric") | .version' version.json)
 mcVersion=$(jq -r '.targets|unique[] | select(.name == "minecraft") | .version' version.json)
 
-variants=(
-  forge-${mcVersion}-${forgeVersion}.jar
-  forge-${mcVersion}-${forgeVersion}-universal.jar
-  forge-${mcVersion}-${forgeVersion}-${mcVersion}-universal.jar
-  fabric-${mcVersion}-${fabricVersion}-server-launch.jar
-)
-for f in "${variants[@]}"; do
-  if [ -f $f ]; then
-    export SERVER=$f
-    break
-  fi
-done
-if ! [ -v SERVER ]; then
-  log "ERROR unable to locate the installed FTB server jar"
-  ls *.jar
-  exit 2
-fi
-
-export FAMILY=FORGE
-
-exec ${SCRIPTS:-/}start-setupWorld $@
+echo "Use console to manually start server"


### PR DESCRIPTION
This bypasses the `start-setupWorld` script and just runs FTB's `run.sh` file directly.

There are likely consequences to that bypass which I don't understand. But at least this makes it possible to run an FTB container.

Fixes #1492 