### PR TITLE
Adding 'run.sh' as a variant for FTBA server types

### DIFF
--- a/scripts/start-deployFTBA
+++ b/scripts/start-deployFTBA
@@ -67,6 +67,7 @@ variants=(
   forge-${mcVersion}-${forgeVersion}-universal.jar
   forge-${mcVersion}-${forgeVersion}-${mcVersion}-universal.jar
   fabric-${mcVersion}-${fabricVersion}-server-launch.jar
+  run.sh
 )
 for f in "${variants[@]}"; do
   if [ -f $f ]; then


### PR DESCRIPTION
Adding `run.sh` as a server variant allows the code to find the `run.sh` file instead of a server jar. This allows for all script execution to occur, and the finally, `run.sh` itself is used to start the server.

Fixes #1492