### PR TITLE
Add jarfile options and custom worlds directory path (Multiverse) to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1446,6 +1446,10 @@ environment variable. The JVM requires `-XX` options to precede `-X` options, so
 For some cases, if e.g. after removing mods, it could be necessary to startup minecraft with an additional `-D` parameter like `-Dfml.queryResult=confirm`. To address this you can use the environment variable `JVM_DD_OPTS`, which builds the params from a given list of values separated by space, but without the `-D` prefix. To make things running under systems (e.g. Plesk), which doesn't allow `=` inside values, a `:` (colon) could be used instead. The upper example would look like this:
 `JVM_DD_OPTS=fml.queryResult:confirm`, and will be converted to `-Dfml.queryResult=confirm`.
 
+### Jarfile Options
+Options that would usually be passed to the jar file (those which are written after the filename) can be passed via the `EXTRA_ARGS` environment variable.
+See [Custom worlds directory path](#custom-worlds-directory-path) for an example.
+
 ### Interactive and Color Console
 
 If you would like to `docker attach` to the Minecraft server console with color and interactive capabilities, then add

--- a/README.md
+++ b/README.md
@@ -834,6 +834,13 @@ The following diagram shows how this option can be used in a compose deployment 
 ### Overwrite world on start
 The world will only be downloaded or copied if it doesn't exist already. Set `FORCE_WORLD_COPY=TRUE` to force overwrite the world on every server start.
 
+### Custom worlds directory path
+To set a custom worlds directory for the Multiverse plugin on a baremetal server, you'd pass the `--world-dir` argument after the jar file.
+In order to accomplish the same in a containerized server, set the `EXTRA_ARGS` environment variable in your command line or docker compose yaml.
+```
+docker run -d -e EXTRA_ARGS='--world-dir ./worlds/'
+```
+
 ### Datapacks
 Datapacks can be installed in a similar manner to mods/plugins. There are many environment variables which function in the same way they do for [mods](#working-with-mods-and-plugins): 
 * `DATAPACKS`

--- a/README.md
+++ b/README.md
@@ -840,6 +840,7 @@ In order to accomplish the same in a containerized server, set the `EXTRA_ARGS` 
 ```
 docker run -d -e EXTRA_ARGS='--world-dir ./worlds/'
 ```
+`--world-container`, `-W`, and `--universe` are aliases to `--world-dir` and can also be used.
 
 ### Datapacks
 Datapacks can be installed in a similar manner to mods/plugins. There are many environment variables which function in the same way they do for [mods](#working-with-mods-and-plugins): 

--- a/README.md
+++ b/README.md
@@ -836,7 +836,7 @@ The world will only be downloaded or copied if it doesn't exist already. Set `FO
 
 ### Custom worlds directory path
 To set a custom worlds directory for the Multiverse plugin on a baremetal server, you'd pass the `--world-dir` argument after the jar file.
-In order to accomplish the same in a containerized server, set the `EXTRA_ARGS` environment variable in your command line or docker compose yaml.
+In order to accomplish the same in a containerized server, set the `EXTRA_ARGS` environment variable in your command line or docker compose yaml to the same argument string. For example:
 ```
 docker run -d -e EXTRA_ARGS='--world-dir ./worlds/'
 ```


### PR DESCRIPTION
This PR aims to make it easier for users to find documentation on setting a Multiverse/other multi-world plugin's worlds directory path.

I couldn't find a built-in option to set a worlds directory that Multiverse would actually respect and use, so this seems to be the solution. I also added a section on jar file options and pointed it at the aforementioned worlds dir section as an example. 

If this would be more fitting for the [working-with-world-data](https://github.com/itzg/docker-minecraft-server#working-with-world-data) or [working-with-mods-and-plugins](https://github.com/itzg/docker-minecraft-server#working-with-mods-and-plugins) section, I'm happy to update the PR.