### PR TITLE
Add 1.19 server properties

### DIFF
--- a/scripts/start-setupServerProperties
+++ b/scripts/start-setupServerProperties
@@ -116,6 +116,8 @@ function customizeServerProps {
   setServerProp "prevent-proxy-connections" PREVENT_PROXY_CONNECTIONS
   setServerProp "use-native-transport" USE_NATIVE_TRANSPORT
   setServerProp "simulation-distance" SIMULATION_DISTANCE
+  setServerProp "previews-chat" PREVIEWS_CHAT
+  setServerProp "enforce-secure-profile" ENFORCE_SECURE_PROFILE
   setServerPropValue "motd" "$(echo "$MOTD" | mc-image-helper asciify)"
   [[ $LEVEL_TYPE ]] && setServerPropValue "level-type" "${LEVEL_TYPE^^}"
 


### PR DESCRIPTION
1.19 introduced two new server.properties entries, `previews-chat` and `enforce-secured-profile` full details can be found on the full change log at [minecraft.net/en-us/article/the-wild-update-out-today-java](https://www.minecraft.net/en-us/article/the-wild-update-out-today-java)