### PR TITLE
Add GraalVM CE support

### DIFF
--- a/.github/workflows/build-multiarch.yml
+++ b/.github/workflows/build-multiarch.yml
@@ -18,10 +18,12 @@ jobs:
       matrix:
         variant:
           - java17
+          - java17-graalvm-ce
           - java17-jdk
           - java17-openj9
           - java17-alpine
           - java8
+          - java8-graalvm-ce
           - java8-multiarch
           - java8-openj9
           - java8-jdk
@@ -34,6 +36,10 @@ jobs:
             # jammy doesn't work until minecraft updates to https://github.com/netty/netty/issues/12343
             baseImage: eclipse-temurin:17-jre-focal
             platforms: linux/amd64,linux/arm/v7,linux/arm64
+            mcVersion: 1.18.2
+          - variant: java17-graalvm-ce
+            baseImage: ghcr.io/graalvm/graalvm-ce:ol8-java17
+            platforms: linux/amd64,linux/arm64
             mcVersion: 1.18.2
           - variant: java17-jdk
             baseImage: eclipse-temurin:17-focal
@@ -63,6 +69,10 @@ jobs:
         # JAVA 8: NOTE: Unable to go past 8u312 because of Forge dependencies
           - variant: java8
             baseImage: openjdk:8-jre-alpine3.9
+            platforms: linux/amd64
+            mcVersion: 1.12.2
+          - variant: java8-graalvm-ce
+            baseImage: ghcr.io/graalvm/graalvm-ce:java8
             platforms: linux/amd64
             mcVersion: 1.12.2
           - variant: java8-multiarch

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 # syntax = docker/dockerfile:1.3
 
-FROM ghcr.io/graalvm/graalvm-ce:ol8-java17
+ARG BASE_IMAGE=eclipse-temurin:17-jre-focal
+FROM ${BASE_IMAGE}
 
 # CI system should set this to a hash or git revision of the build directory and it's contents to
 # ensure consistent cache updates.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 # syntax = docker/dockerfile:1.3
 
-ARG BASE_IMAGE=eclipse-temurin:17-jre-focal
-FROM ${BASE_IMAGE}
+FROM ghcr.io/graalvm/graalvm-ce:ol8-java17
 
 # CI system should set this to a hash or git revision of the build directory and it's contents to
 # ensure consistent cache updates.

--- a/README.md
+++ b/README.md
@@ -168,16 +168,18 @@ the server jar remain in the `/data` directory. It is safe to remove those._
 When using the image `itzg:/minecraft-server` without a tag, the `latest` image tag is implied from the table below. To use a different version of Java, please use an alternate tag to run your Minecraft server container.
 
 | Tag name        | Java version | Linux  | JVM Type | Architecture      |
-|-----------------|-------------|--------|----------|-------------------|
-| latest          | 17          | Debian | Hotspot  | amd64,arm64,armv7 |
-| java8           | 8           | Alpine | Hotspot  | amd64             |
-| java8-multiarch | 8           | Debian | Hotspot  | amd64,arm64,armv7 |
-| java8-openj9    | 8           | Debian | OpenJ9   | amd64             |
-| java11          | 11          | Debian | Hotspot  | amd64,arm64,armv7 |
-| java11-openj9   | 11          | Debian | OpenJ9   | amd64             |
-| java17          | 17          | Ubuntu | Hotspot  | amd64,arm64,armv7 |
-| java17-openj9   | 17          | Debian | OpenJ9   | amd64             |
-| java17-alpine   | 17          | Alpine | Hotspot  | amd64             |
+|-------------------|-------------|--------|------------|-------------------|
+| latest            | 17          | Debian | Hotspot    | amd64,arm64,armv7 |
+| java8             | 8           | Alpine | Hotspot    | amd64             |
+| java8-multiarch   | 8           | Debian | Hotspot    | amd64,arm64,armv7 |
+| java8-openj9      | 8           | Debian | OpenJ9     | amd64             |
+| java8-graalvm-ce  | 8           | Oracle | GraalVM CE | amd64             |
+| java11            | 11          | Debian | Hotspot    | amd64,arm64,armv7 |
+| java11-openj9     | 11          | Debian | OpenJ9     | amd64             |
+| java17            | 17          | Ubuntu | Hotspot    | amd64,arm64,armv7 |
+| java17-openj9     | 17          | Debian | OpenJ9     | amd64             |
+| java17-graalvm-ce | 17          | Oracle | GraalVM CE | amd64,arm64       |
+| java17-alpine     | 17          | Alpine | Hotspot    | amd64             |
 
 For example, to use Java version 8 on any supported architecture:
 

--- a/build/ol/install-gosu.sh
+++ b/build/ol/install-gosu.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+[[ $(uname -m) == "aarch64" ]] && curl -sL -o /bin/gosu https://github.com/tianon/gosu/releases/download/1.14/gosu-arm64 && chmod +x /bin/gosu
+[[ $(uname -m) == "x86_64" ]] && curl -sL -o /bin/gosu https://github.com/tianon/gosu/releases/download/1.14/gosu-amd64 && chmod +x /bin/gosu
+

--- a/build/ol/install-packages.sh
+++ b/build/ol/install-packages.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -e
+
+microdnf install dnf -y
+
+dnf install 'dnf-command(config-manager)' -y
+dnf config-manager --set-enabled ol8_codeready_builder
+tee /etc/yum.repos.d/ol8-epel.repo<<EOF
+[ol8_developer_EPEL]
+name= Oracle Linux \$releasever EPEL (\$basearch)
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL8/developer/EPEL/\$basearch/
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-oracle
+gpgcheck=1
+enabled=1
+EOF
+dnf update -y
+
+dnf install -y ImageMagick \
+  file \
+  sudo \
+  net-tools \
+  iputils \
+  curl \
+  git \
+  jq \
+  dos2unix \
+  mysql \
+  tzdata \
+  rsync \
+  nano \
+  unzip \
+  zstd \
+  lbzip2 \
+  knock
+
+bash /build/ol/install-gosu.sh

--- a/build/ol/setup-user.sh
+++ b/build/ol/setup-user.sh
@@ -1,0 +1,2 @@
+groupadd --gid 1000 minecraft
+useradd --system --shell /bin/false --uid 1000 -g minecraft --home /data minecraft

--- a/scripts/start-utils
+++ b/scripts/start-utils
@@ -288,6 +288,11 @@ function checkSum() {
     return 0
   elif [ "${distro}" == "alpine" ] && sha1sum -c "${sum_file}" -s 2> /dev/null; then
     return 0
+  elif [ "${distro}" == "ol" ] && sha256sum -c "${sum_file}" --status 2> /dev/null; then
+    return 0
+  else
+    return 1
+  fi
   else
     return 1
   fi

--- a/scripts/start-utils
+++ b/scripts/start-utils
@@ -288,7 +288,7 @@ function checkSum() {
     return 0
   elif [ "${distro}" == "alpine" ] && sha1sum -c "${sum_file}" -s 2> /dev/null; then
     return 0
-  elif [ "${distro}" == "ol" ] && sha256sum -c "${sum_file}" --status 2> /dev/null; then
+  elif [ "${distro}" == "ol" ] && sha1sum -c "${sum_file}" --status 2> /dev/null; then
     return 0
   else
     return 1

--- a/scripts/start-utils
+++ b/scripts/start-utils
@@ -293,7 +293,4 @@ function checkSum() {
   else
     return 1
   fi
-  else
-    return 1
-  fi
 }


### PR DESCRIPTION
Unfortunately, GraalVM EE needs complex setup to build (you need to register to Oracle Container Registry and log in) so only CE for now. Build tested.

RELATED: itzg/docker-minecraft-server#1252