### PR TITLE
Default -> default in limbo world name

### DIFF
--- a/scripts/start-deployLimbo
+++ b/scripts/start-deployLimbo
@@ -8,7 +8,7 @@ isDebugging && set -x
 : ${LIMBO_BUILD:=LATEST}
 : ${FORCE_REDOWNLOAD:=false}
 : ${LIMBO_SCHEMA_FILENAME:=default.schem}
-: ${LEVEL:=Default;${LIMBO_SCHEMA_FILENAME}}
+: ${LEVEL:=default;${LIMBO_SCHEMA_FILENAME}}
 # defaults to localhost, if this is not set
 : ${SERVER_IP:=0.0.0.0}
 


### PR DESCRIPTION
See #994 - Limbo will pass along the world name verbatim, but Minecraft (doesn't appear to) allow uppercase letters in world names.