### PR TITLE
Fix GraalVM images error on AArch64 systems

### DIFF
--- a/build/ol/install-gosu.sh
+++ b/build/ol/install-gosu.sh
@@ -8,4 +8,5 @@ elif [[ $(uname -m) == "x86_64" ]]; then
     chmod +x /bin/gosu
 else
     echo "Not supported!"
+    exit 1
 fi  

--- a/build/ol/install-gosu.sh
+++ b/build/ol/install-gosu.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
 
-[[ $(uname -m) == "aarch64" ]] && curl -sL -o /bin/gosu https://github.com/tianon/gosu/releases/download/1.14/gosu-arm64 && chmod +x /bin/gosu || echo "not aarch64"
-[[ $(uname -m) == "x86_64" ]] && curl -sL -o /bin/gosu https://github.com/tianon/gosu/releases/download/1.14/gosu-amd64 && chmod +x /bin/gosu || echo "not x86_64"
+if [[ $(uname -m) == "aarch64" ]]; then 
+    curl -sL -o /bin/gosu https://github.com/tianon/gosu/releases/download/1.14/gosu-arm64
+    chmod +x /bin/gosu
+elif [[ $(uname -m) == "x86_64" ]]; then 
+    curl -sL -o /bin/gosu https://github.com/tianon/gosu/releases/download/1.14/gosu-amd64
+    chmod +x /bin/gosu
+else
+    echo "Not supported!"
+fi  

--- a/build/ol/install-gosu.sh
+++ b/build/ol/install-gosu.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 
-[[ $(uname -m) == "aarch64" ]] && curl -sL -o /bin/gosu https://github.com/tianon/gosu/releases/download/1.14/gosu-arm64 && chmod +x /bin/gosu
-[[ $(uname -m) == "x86_64" ]] && curl -sL -o /bin/gosu https://github.com/tianon/gosu/releases/download/1.14/gosu-amd64 && chmod +x /bin/gosu
-
+[[ $(uname -m) == "aarch64" ]] && curl -sL -o /bin/gosu https://github.com/tianon/gosu/releases/download/1.14/gosu-arm64 && chmod +x /bin/gosu || echo "not aarch64"
+[[ $(uname -m) == "x86_64" ]] && curl -sL -o /bin/gosu https://github.com/tianon/gosu/releases/download/1.14/gosu-amd64 && chmod +x /bin/gosu || echo "not x86_64"


### PR DESCRIPTION
This one trick makes it build on AArch64 systems, tested on Oracle Cloud A1.Flex instance.