### PR TITLE
Install procps-ng on Oracle Linux-based images for autopause

### DIFF
--- a/build/ol/install-packages.sh
+++ b/build/ol/install-packages.sh
@@ -26,6 +26,7 @@ dnf install -y ImageMagick \
   jq \
   dos2unix \
   mysql \
+  procps-ng \
   tzdata \
   rsync \
   nano \


### PR DESCRIPTION
I haven't tested autopause so this issue went missing. Installing `procps-ng` will fix this issue.