### PR TITLE
Set container name in config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ version: "3.8"
 services:
   mc:
     image: itzg/minecraft-server
+    container_name: mc
     environment:
       EULA: "true"
     ports:


### PR DESCRIPTION
I propose naming the container directly in the configuration such that when docker-compose is generated, the name is "mc" and not "docker-minecraft-server_mc_1"