### PR TITLE
Add AUTOSTOP_USE_PKILL option to use pkill instead of kill in autostop feature

### DIFF
--- a/files/autostop/stop.sh
+++ b/files/autostop/stop.sh
@@ -6,4 +6,8 @@ if isTrue "${DEBUG_AUTOSTOP}"; then
 fi
 
 logAutostopAction "Stopping Java process"
-kill -SIGTERM 1
+if isTrue "${AUTOSTOP_PKILL_USE_SUDO:-false}"; then
+  sudo pkill -f --signal SIGTERM mc-server-runner
+else
+  pkill -f --signal SIGTERM mc-server-runner
+fi


### PR DESCRIPTION
In some nonstandard environments (see fly.io for an example) that the
server itself will be PID 1 is not a given. By allowing the user to
choose to use pkill instead they can ensure the autostop feature will
work even in those environments.