### PR TITLE
Change versionLessThan to work in strict mode

### DIFF
--- a/scripts/start-utils
+++ b/scripts/start-utils
@@ -11,10 +11,10 @@ function get_from_gh() {
       log "ERROR: GH_TOKEN has permissions it doesn't need. Recreate or update this personal access token and disable ALL scopes."
       exit 1
     else
-      echo $(curl -fsSL -H "Authorization: token $GH_TOKEN" ${@:2} $1)
+      curl -fsSL -H "Authorization: token $GH_TOKEN" "${@:2}" "$1"
     fi
   else
-    echo $(curl -fsSL ${@:2} $1)
+    curl -fsSL "${@:2}" "$1"
   fi
 }
 
@@ -50,7 +50,7 @@ function isValidFileURL() {
 
 function resolveEffectiveUrl() {
   url="${1:?Missing required url argument}"
-  if ! curl -Ls -o /dev/null -w %{url_effective} "$url"; then
+  if ! curl -Ls -o /dev/null -w "%{url_effective}" "$url"; then
     log "ERROR failed to resolve effective URL from $url"
     exit 2
   fi
@@ -184,11 +184,16 @@ function normalizeMemSize() {
 }
 
 function versionLessThan() {
-  mc-image-helper compare-versions "${VANILLA_VERSION}" lt "${1?}"
+  # Use if-else since strict mode might be enabled
+  if mc-image-helper compare-versions "${VANILLA_VERSION}" lt "${1?}"; then
+    return 0
+  else
+    return 1
+  fi
 }
 
 requireVar() {
-  if [ ! -v $1 ]; then
+  if [ ! -v "$1" ]; then
     log "ERROR: $1 is required to be set"
     exit 1
   fi
@@ -202,8 +207,8 @@ requireEnum() {
   var=${1?}
   shift
 
-  for allowed in $*; do
-    if [[ ${!var} = $allowed ]]; then
+  for allowed in "$@"; do
+    if [[ ${!var} = "$allowed" ]]; then
       return 0
     fi
   done
@@ -301,7 +306,7 @@ function extract() {
 }
 
 function getDistro() {
-  cat /etc/os-release | grep -E "^ID=" | cut -d= -f2 | sed -e 's/"//g'
+  grep -E "^ID=" /etc/os-release | cut -d= -f2 | sed -e 's/"//g'
 }
 
 function checkSum() {


### PR DESCRIPTION
Even though I couldn't reproduce the issue, looking at the logs in https://github.com/itzg/docker-minecraft-server/discussions/1722#discussioncomment-3602484 it seems logical a bug would result from the combination of strict mode enabled at 

https://github.com/itzg/docker-minecraft-server/blob/a0a046f9f69943978838f8f1d3f1efff7a55d788/scripts/start-configuration#L2

where it would cause start-configuration to bail out.