### PR TITLE
fix(packwiz): provide side argument to packwiz

### DIFF
--- a/scripts/start-setupModpack
+++ b/scripts/start-setupModpack
@@ -34,7 +34,7 @@ function handlePackwiz() {
     fi
 
     log "Running packwiz installer against URL: ${PACKWIZ_URL}"
-    if ! java -cp "${packwizInstaller}" link.infra.packwiz.installer.Main "${PACKWIZ_URL}"; then
+    if ! java -cp "${packwizInstaller}" link.infra.packwiz.installer.Main -s server "${PACKWIZ_URL}"; then
       log "ERROR failed to run packwiz installer"
       exit 1
     fi


### PR DESCRIPTION
### Description

- Not providing the side argument causes packwiz to assume we're a client :3

### Related Commits

**Introduced here:** https://github.com/itzg/docker-minecraft-server/commit/fabe14db4985a5c8829f85ff9241b6532cf4b972