### PR TITLE
Added ARMv7 build for java8-multiarch

### DIFF
--- a/.github/workflows/build-multiarch.yml
+++ b/.github/workflows/build-multiarch.yml
@@ -77,7 +77,7 @@ jobs:
             mcVersion: 1.12.2
           - variant: java8-multiarch
             baseImage: eclipse-temurin:8u312-b07-jre-focal
-            platforms: linux/amd64,linux/arm64
+            platforms: linux/amd64,linux/arm/v7,linux/arm64
             mcVersion: 1.12.2
           - variant: java8-jdk
             baseImage: eclipse-temurin:8u312-b07-jdk-focal


### PR DESCRIPTION
Discovered it was missing via https://github.com/itzg/docker-minecraft-server/discussions/1764