### PR TITLE
Auto-manage server properties by default

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -2,3 +2,16 @@ changelog:
   exclude:
     authors:
       - dependabot
+  categories:
+    - title: Enhancements
+      labels:
+        - enhancement
+    - title: Bug Fixes
+      labels:
+        - bug
+    - title: Documentation
+      labels:
+        - documentation
+    - title: Other Changes
+      labels:
+        - "*"

--- a/README.md
+++ b/README.md
@@ -960,13 +960,7 @@ CraftingTweaks Json:
 
 By default, the server configuration will be created and set based on the following environment variables, but only the first time the server is started. If the `server.properties` file already exists, the values in them will not be changed.
 
-If you would like to override the server configuration each time the container starts up, you can set the `OVERRIDE_SERVER_PROPERTIES` environment variable like:
-
-    docker run -d -e OVERRIDE_SERVER_PROPERTIES=true ...
-
-This will reset any manual configuration of the `server.properties` file, so if you want to make any persistent configuration changes you will need to make sure you have properly set the proper environment variables in your container configuration.
-
-In the opposite case, you can skip the startup script's creation of `server.properties`, by setting `SKIP_SERVER_PROPERTIES` to "true".
+If you prefer to manually manage the `server.properties` file, set `OVERRIDE_SERVER_PROPERTIES` to "false". Similarly, you can entirely skip the startup script's creation of `server.properties` by setting `SKIP_SERVER_PROPERTIES` to "true".
 
 > NOTE: to clear a server property, set the variable to an empty string, such as `-e RESOURCE_PACK=""`. A variables that maps to a server property that is unset, is ignored and the existing `server.property` is left unchanged. 
 

--- a/scripts/start-setupServerProperties
+++ b/scripts/start-setupServerProperties
@@ -5,6 +5,8 @@
 
 : "${SERVER_PROPERTIES:=/data/server.properties}"
 : "${ENABLE_RCON:=true}"
+: "${OVERRIDE_SERVER_PROPERTIES:=true}"
+: "${SKIP_SERVER_PROPERTIES:=false}"
 
 # FUNCTIONS
 function setServerPropValue {
@@ -208,22 +210,14 @@ if [[ ${TYPE} == "CURSEFORGE" ]]; then
   log "detected FTB, changing properties path to ${SERVER_PROPERTIES}"
 fi
 
-if ! isTrue "${SKIP_SERVER_PROPERTIES:-false}"; then
+if ! isTrue "${SKIP_SERVER_PROPERTIES}"; then
   if [ ! -e "$SERVER_PROPERTIES" ]; then
     log "Creating server properties in ${SERVER_PROPERTIES}"
     customizeServerProps
-  elif [ -n "${OVERRIDE_SERVER_PROPERTIES}" ]; then
-      case ${OVERRIDE_SERVER_PROPERTIES^^} in
-        TRUE|1)
-          log "Updating server properties in ${SERVER_PROPERTIES}"
-          customizeServerProps
-          ;;
-        *)
-          log "server.properties already created, skipping"
-          ;;
-      esac
+  elif isTrue "${OVERRIDE_SERVER_PROPERTIES}"; then
+    customizeServerProps
   else
-    log "server.properties already created, skipping"
+    log "server.properties already created and managed manually"
   fi
 else
   log "Skipping setup of server.properties"


### PR DESCRIPTION
Avoids confusion experienced by a lot of users where one would think that the container env variables would always be applied. Instead, the default was that they get applied the first time and ignored otherwise.

Resolves #1739 