### PR TITLE
Setup MEMORY variables earlier to allow use in Spigot build

### DIFF
--- a/scripts/start-configuration
+++ b/scripts/start-configuration
@@ -20,6 +20,11 @@ IFS=$'\n\t'
 : "${RCON_PORT:=25575}"
 export RCON_PASSWORD RCON_PORT
 
+: "${MEMORY=1G}"
+: "${INIT_MEMORY=${MEMORY}}"
+: "${MAX_MEMORY=${MEMORY}}"
+export MEMORY INIT_MEMORY MAX_MEMORY
+
 shopt -s nullglob
 
 isDebugging && set -x

--- a/scripts/start-finalExec
+++ b/scripts/start-finalExec
@@ -113,10 +113,6 @@ if [[ ${GUI,,} = false ]]; then
   EXTRA_ARGS+=" nogui"
 fi
 
-: "${MEMORY=1G}"
-: "${INIT_MEMORY=${MEMORY}}"
-: "${MAX_MEMORY=${MEMORY}}"
-
 expandedDOpts=
 if [ -n "$JVM_DD_OPTS" ]; then
       for dopt in $JVM_DD_OPTS


### PR DESCRIPTION
Resolves #686 