### PR TITLE
set REMOVE_OLD_MODS back to false after loop download plugin done

### DIFF
--- a/scripts/start-spiget
+++ b/scripts/start-spiget
@@ -124,7 +124,6 @@ downloadResourceFromSpiget() {
 if [[ ${SPIGET_RESOURCES} ]]; then
   if isTrue "${REMOVE_OLD_MODS:-false}"; then
     removeOldMods /data/plugins
-    REMOVE_OLD_MODS=false
   fi
 
   log "Getting plugins via Spiget"
@@ -132,6 +131,10 @@ if [[ ${SPIGET_RESOURCES} ]]; then
   for resource in "${resources[@]}"; do
     getResourceFromSpiget "${resource}"
   done
+
+  if isTrue "${REMOVE_OLD_MODS:-false}"; then
+    REMOVE_OLD_MODS=false
+  fi
 fi
 
 exec "${SCRIPTS:-/}start-setupWorld" "$@"


### PR DESCRIPTION
from this issue https://github.com/itzg/docker-minecraft-server/issues/1801#issue-1422104661
so i think after removeOldMods it set REMOVE_OLD_MODS back to false

https://github.com/itzg/docker-minecraft-server/blob/5e2553274fc8b733dda6cbf9f27b8c59f0e609dc/scripts/start-spiget#L124-L135

and when call function getResourceFromSpiget is not gonna redownload because of it

https://github.com/itzg/docker-minecraft-server/blob/5e2553274fc8b733dda6cbf9f27b8c59f0e609dc/scripts/start-spiget#L61-L75