### PR TITLE
Add option to skip generic pack checksum

### DIFF
--- a/README.md
+++ b/README.md
@@ -815,7 +815,9 @@ GENERIC_PACKS_SUFFIX=.zip
 
 would expand to `https://cdn.example.org/configs-v9.0.1.zip,https://cdn.example.org/mods-v4.3.6.zip`.
 
-If applying large generic packs, the update check can be time-consuming since a SHA1 checksum is compared. To skip the update check set `SKIP_GENERIC_PACK_UPDATE_CHECK` to "true". Conversely, the generic pack(s) can be forced to be applied without comparing the checksum by setting `FORCE_GENERIC_PACK_UPDATE` to "true".
+If applying large generic packs, the update can be time-consuming. To skip the update set `SKIP_GENERIC_PACK_UPDATE_CHECK` to "true". Conversely, the generic pack(s) can be forced to be applied by setting `FORCE_GENERIC_PACK_UPDATE` to "true".
+
+The most time consuming portion of the generic pack update is generating and comparing the SHA1 checksum. To skip the checksum generation, set `SKIP_GENERIC_PACK_CHECKSUM` to "true.
 
 ### Mod/Plugin URL Listing File 
 

--- a/scripts/start-setupModpack
+++ b/scripts/start-setupModpack
@@ -254,10 +254,14 @@ function genericPacks() {
       cp -R -f "${base_dir}"/* /data
       rm -rf $original_base_dir
 
-      log "Saving generic pack(s) checksum"
-      sha1sum "${packFiles[@]}" > "${sum_file}"
-      if isDebugging; then
-        cat "$sum_file"
+      if isTrue "${SKIP_GENERIC_PACK_CHECKSUM:-false}"; then
+        log "Skipping generic pack(s) checksum"
+      else
+        log "Saving generic pack(s) checksum"
+        sha1sum "${packFiles[@]}" > "${sum_file}"
+        if isDebugging; then
+          cat "$sum_file"
+        fi
       fi
     fi
   fi


### PR DESCRIPTION
Currently, there is an option `SKIP_GENERIC_PACK_UPDATE_CHECK`. The documentation alludes to this reducing time due to the lengthy SHA1 checksum process; however, the option just skips the generic pack being applied entirely.

In the spirit of backward compatibility, I've left that option as-is while adding a new option `SKIP_GENERIC_PACK_CHECKSUM` that simply skips the checksum.

--

As a side note, I'm not seeing where the checksum is actually used now. The function appears to apply the pack regardless of the sum file contents.