### PR TITLE
Add remove old files feature, deprecate remove old files

### DIFF
--- a/README.md
+++ b/README.md
@@ -681,11 +681,11 @@ There are optional volume paths that can be attached to supply content to be cop
 
 By default, the [environment variable processing](#replacing-variables-inside-configs) is performed on synchronized files that match the expected suffixes in `REPLACE_ENV_SUFFIXES` (by default "yml,yaml,txt,cfg,conf,properties,hjson,json,tml,toml") and are not excluded by `REPLACE_ENV_VARIABLES_EXCLUDES` and `REPLACE_ENV_VARIABLES_EXCLUDE_PATHS`. This processing can be disabled by setting `REPLACE_ENV_DURING_SYNC` to `false`.
 
-If you want old mods/plugins to be removed before the content is brought over from those attach points, then add `-e REMOVE_OLD_MODS=TRUE`. You can fine tune the removal process by specifying the `REMOVE_OLD_MODS_INCLUDE` and `REMOVE_OLD_MODS_EXCLUDE` variables, which are comma separated lists of file glob patterns. If a directory is excluded, then it and all of its contents are excluded. By default, only jars are removed. 
+If you want old files to be removed before the content is brought over from those attach points or generic packs, then add `-e REMOVE_OLD_FILES=TRUE`. You can fine tune the removal process by specifying the `REMOVE_OLD_FILES_INCLUDE` and `REMOVE_OLD_FILES_EXCLUDE` variables, which are comma separated lists of [file glob patterns](https://docs.oracle.com/javase/7/docs/api/java/nio/file/FileSystem.html#getPathMatcher%28java.lang.String%29). If a directory is excluded, then it and all of its contents are excluded. By default, only jars in `plugins/` and `/mods` are removed. 
 
-You can also specify the `REMOVE_OLD_MODS_DEPTH` (default is 16) variable to only delete files up to a certain level.
+You can also specify the `REMOVE_OLD_FILES_DEPTH` (default is 16) variable to only delete files up to a certain level.
 
-For example: `-e REMOVE_OLD_MODS=TRUE -e REMOVE_OLD_MODS_INCLUDE="*.jar" -e REMOVE_OLD_MODS_DEPTH=1` will remove all old jar files that are directly inside the `plugins/` or `mods/` directory.
+For example: `-e REMOVE_OLD_FILES=TRUE -e REMOVE_OLD_FILES_INCLUDE="{plugins,mods}/*.jar" -e REMOVE_OLD_FILES_DEPTH=2` will remove all old jar files that are directly inside the `plugins/` or `mods/` directory.
 
 These paths work well if you want to have a common set of modules in a separate location, but still have multiple worlds with different server requirements in either persistent volumes or a downloadable archive.
 
@@ -839,16 +839,16 @@ https://edge.forgecdn.net/files/2871/647/ToastControl-1.15.2-3.0.1.jar
 
 > [This compose file](examples/docker-compose-mods-file.yml) shows another example of using this feature.
 
-> It is recommended to combine this option with `REMOVE_OLD_MODS=TRUE` to ensure the mods/plugins remain consistent with the file's listing.
+> It is recommended to combine this option with `REMOVE_OLD_FILES=TRUE` to ensure the mods/plugins remain consistent with the file's listing.
 
 ### Remove old mods/plugins
 
 When the option above is specified (`MODPACK`) you can also instruct script to
 delete old mods/plugins prior to installing new ones. This behaviour is desirable
 in case you want to upgrade mods/plugins from downloaded zip file.
-To use this option pass the environment variable `REMOVE_OLD_MODS=TRUE`, such as
+To use this option pass the environment variable `REMOVE_OLD_FILES=TRUE`, such as
 
-    docker run -d -e REMOVE_OLD_MODS=TRUE -e MODPACK=http://www.example.com/mods/modpack.zip ...
+    docker run -d -e REMOVE_OLD_FILES=TRUE -e MODPACK=http://www.example.com/mods/modpack.zip ...
 
 **WARNING:** All content of the `mods` or `plugins` directory will be deleted
 before unpacking new content from the MODPACK or MODS.

--- a/examples/docker-compose-generic-pack.yml
+++ b/examples/docker-compose-generic-pack.yml
@@ -13,7 +13,7 @@ services:
       VERSION: ${VERSION:-1.17.1}
       FORGE_VERSION: ${FORGE_VERSION:-37.0.90}
       GENERIC_PACK: /modpacks/${MODPACK:-Server-Files-0.0.21.zip}
-      REMOVE_OLD_MODS: "${REMOVE_OLD_MODS:-false}"
+      REMOVE_OLD_FILES: "${REMOVE_OLD_FILES:-false}"
     ports:
       - "25565:25565"
 

--- a/examples/docker-compose-mods-file.yml
+++ b/examples/docker-compose-mods-file.yml
@@ -8,7 +8,7 @@ services:
       TYPE: FORGE
       VERSION: 1.15.2
       MODS_FILE: /extras/mods.txt
-      REMOVE_OLD_MODS: "true"
+      REMOVE_OLD_FILES: "true"
     ports:
       - 25565:25565
     volumes:

--- a/examples/docker-compose-spiget.yml
+++ b/examples/docker-compose-spiget.yml
@@ -12,7 +12,7 @@ services:
       TYPE: SPIGOT
 #      SPIGET_RESOURCES: 34315,3836
       SPIGET_RESOURCES: ""
-      REMOVE_OLD_MODS: "true"
+      REMOVE_OLD_FILES: "true"
     volumes:
       - data:/data
 

--- a/scripts/start-setupForgeApiMods
+++ b/scripts/start-setupForgeApiMods
@@ -9,6 +9,8 @@ set -e -o pipefail
 : "${MODS_FORGEAPI_RELEASES:=RELEASE}"
 : "${MODS_FORGEAPI_DOWNLOAD_DEPENDENCIES:=false}"
 : "${MODS_FORGEAPI_IGNORE_GAMETYPE:=false}"
+: "${REMOVE_OLD_FILES_DEPTH:=2} "
+: "${REMOVE_OLD_FILES_INCLUDE:=mods/*.jar,mods/*-version.json}"
 : "${REMOVE_OLD_MODS_DEPTH:=1} "
 : "${REMOVE_OLD_MODS_INCLUDE:=*.jar,*-version.json}"
 
@@ -24,9 +26,13 @@ out_dir=/data/mods
 . "${SCRIPTS:-/}start-utils"
 isDebugging && set -x
 
-# Remove old mods/plugins
-if isTrue "${REMOVE_OLD_FORGEAPI_MODS}"; then
-  removeOldMods "/data/mods"
+# Remove old files
+if isTrue "${REMOVE_OLD_FILES}"; then
+  removeOldFiles "/data"
+elif isTrue "${REMOVE_OLD_FORGEAPI_MODS}"; then
+  REMOVE_OLD_FILES_DEPTH=$REMOVE_OLD_MODS_DEPTH
+  REMOVE_OLD_FILES_INCLUDE=$REMOVE_OLD_MODS_INCLUDE
+  removeOldFiles "/data/mods"
 fi
 
 # Family filter is on by default for Forge, Fabric, and Bukkit

--- a/scripts/start-setupModpack
+++ b/scripts/start-setupModpack
@@ -2,8 +2,11 @@
 
 set -e -o pipefail
 
-: "${REMOVE_OLD_MODS:=false}"
 : "${MODS_FILE:=}"
+: "${REMOVE_OLD_FILES:=false}"
+: "${REMOVE_OLD_FILES_DEPTH:=2} "
+: "${REMOVE_OLD_FILES_INCLUDE:={plugins,mods\}/*.jar,{plugins,mods\}/*-version.json}"
+: "${REMOVE_OLD_MODS:=false}"
 : "${REMOVE_OLD_MODS_DEPTH:=1} "
 : "${REMOVE_OLD_MODS_INCLUDE:=*.jar,*-version.json}"
 sum_file=/data/.generic_pack.sum
@@ -15,10 +18,14 @@ isDebugging && set -x
 #  CURSE_URL_BASE used in manifest downloads below
 CURSE_URL_BASE=${CURSE_URL_BASE:-https://minecraft.curseforge.com/projects}
 
-# Remove old mods/plugins
-if isTrue "${REMOVE_OLD_MODS}" && [ -z "${MODS_FILE}" ]; then
-  removeOldMods /data/mods
-  removeOldMods /data/plugins
+# Remove old files
+if isTrue "${REMOVE_OLD_FILES}" && [ -z "${MODS_FILE}" ]; then
+  removeOldFiles /data
+elif isTrue "${REMOVE_OLD_MODS}" && [ -z "${MODS_FILE}" ]; then
+  REMOVE_OLD_FILES_DEPTH=$REMOVE_OLD_MODS_DEPTH
+  REMOVE_OLD_FILES_INCLUDE=$REMOVE_OLD_MODS_INCLUDE
+  removeOldFiles /data/mods
+  removeOldFiles /data/plugins
   rm -f "$sum_file"
 fi
 

--- a/scripts/start-spiget
+++ b/scripts/start-spiget
@@ -8,6 +8,7 @@ handleDebugMode
 
 : "${SPIGET_RESOURCES:=}"
 : "${SPIGET_DOWNLOAD_TOLERANCE:=5}" # in minutes
+: "${REMOVE_OLD_FILES_INCLUDE:=plugins/*.jar,plugins/*-version.json}"
 : "${REMOVE_OLD_MODS_INCLUDE:=*.jar,*-version.json}"
 
 acceptArgs=(--accept application/zip --accept application/java-archive --accept application/octet-stream)
@@ -58,7 +59,7 @@ getResourceFromSpiget() {
         exit 2
       fi
 
-      if isTrue "${REMOVE_OLD_MODS:-false}"; then
+      if isTrue "${REMOVE_OLD_MODS:-false}" || isTrue "${REMOVE_OLD_FILES:-false}"; then
         installedVersion=0.0.0
       else
         installedVersion=$(jq -r '.name' $versionfile)
@@ -122,8 +123,12 @@ downloadResourceFromSpiget() {
 }
 
 if [[ ${SPIGET_RESOURCES} ]]; then
-  if isTrue "${REMOVE_OLD_MODS:-false}"; then
-    removeOldMods /data/plugins
+  if isTrue "${REMOVE_OLD_FILES:-false}"; then
+    removeOldFiles /data
+    REMOVE_OLD_FILES=false
+  elif isTrue "${REMOVE_OLD_MODS:-false}"; then
+    REMOVE_OLD_FILES_INCLUDE=$REMOVE_OLD_MODS_INCLUDE
+    removeOldFiles /data/plugins
     REMOVE_OLD_MODS=false
   fi
 

--- a/scripts/start-utils
+++ b/scripts/start-utils
@@ -205,15 +205,15 @@ eula=${EULA,,}
   fi
 }
 
-function removeOldMods {
+function removeOldFiles {
   if [ -d "$1" ]; then
-    log "Removing old mods including:${REMOVE_OLD_MODS_INCLUDE} excluding:${REMOVE_OLD_MODS_EXCLUDE}"
+    log "Removing old files in $1 including:${REMOVE_OLD_FILES_INCLUDE} excluding:${REMOVE_OLD_FILES_EXCLUDE}"
     mc-image-helper find \
       --delete \
       --type file,directory \
-      --min-depth=1 --max-depth "${REMOVE_OLD_MODS_DEPTH:-16}" \
-      --name "${REMOVE_OLD_MODS_INCLUDE:-*}" \
-      --exclude-name "${REMOVE_OLD_MODS_EXCLUDE:-}" \
+      --min-depth=1 --max-depth "${REMOVE_OLD_FILES_DEPTH:-16}" \
+      --name "${REMOVE_OLD_FILES_INCLUDE:-*}" \
+      --exclude-name "${REMOVE_OLD_FILES_EXCLUDE:-}" \
       --quiet \
       "$1"
   fi


### PR DESCRIPTION
This PR mutates the existing `REMOVE_OLD_MODS` feature into a generic `REMOVE_OLD_FILES` utility.

To mitigate disruption, the former variables are deprecated and adapted for feature parity.

> **Warning**
> Needs testing - marked as a draft until the feature is validated

_Closes #1817_