### PR TITLE
Add .paused file when server is paused

### DIFF
--- a/README.md
+++ b/README.md
@@ -1720,6 +1720,8 @@ On startup the `server.properties` file is checked and, if applicable, a warning
 
 The utility used to wake the server (`knock(d)`) works at network interface level. So the correct interface has to be set using the `AUTOPAUSE_KNOCK_INTERFACE` variable when using non-default networking environments (e.g. host-networking, Portainer oder NAS solutions). See the description of the variable below.
 
+A file called `.paused` is created in `/data` directory when the server is paused and removed when the server is resumed. Other services may check for this file's existence before waking the server.
+
 A starting, example compose file has been provided in [examples/docker-compose-autopause.yml](examples/docker-compose-autopause.yml).
 
 ### Enabling Autopause

--- a/files/auto/pause.sh
+++ b/files/auto/pause.sh
@@ -21,4 +21,7 @@ if [[ $( ps -ax -o stat,comm | grep 'java' | awk '{ print $1 }') =~ ^S.*$ ]] ; t
   # finally pause the process
   logAutopauseAction "Pausing Java process"
   pkill -STOP java
+
+  # create .paused file in data directory
+  touch /data/.paused
 fi

--- a/files/auto/resume.sh
+++ b/files/auto/resume.sh
@@ -9,4 +9,7 @@ if [[ $( ps -ax -o stat,comm | grep 'java' | awk '{ print $1 }') =~ ^T.*$ ]] ; t
   logAutopauseAction "Knocked from $1, resuming Java process"
   echo "$1" > /var/log/knocked-source
   pkill -CONT java
+
+  # remove .paused file from data directory
+  rm -f /data/.paused
 fi


### PR DESCRIPTION
Implements the suggestion from docker-mc-backup [issue #43](https://github.com/itzg/docker-mc-backup/issues/43#issuecomment-1087984202) to add a `.paused` file when the server is paused so it doesn't get woken up to check the player count. I'll be opening another PR in docker-mc-backup to add a check for the file.

I believe this closes issue #1113 as well.