### PR TITLE
Allow for commas in mc-image-helper lists

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,9 +46,8 @@ RUN easy-add --var os=${TARGETOS} --var arch=${TARGETARCH}${TARGETVARIANT} \
   --var version=0.1.1 --var app=maven-metadata-release --file {{.app}} \
   --from https://github.com/itzg/{{.app}}/releases/download/{{.version}}/{{.app}}_{{.version}}_{{.os}}_{{.arch}}.tar.gz
 
-ARG MC_HELPER_VERSION=1.22.7
-ARG MC_HELPER_RELEASE=v${MC_HELPER_VERSION}
-ARG MC_HELPER_BASE_URL=https://github.com/itzg/mc-image-helper/releases/download/${MC_HELPER_RELEASE}
+ARG MC_HELPER_VERSION=1.22.8
+ARG MC_HELPER_BASE_URL=https://github.com/itzg/mc-image-helper/releases/download/${MC_HELPER_VERSION}
 RUN curl -fsSL ${MC_HELPER_BASE_URL}/mc-image-helper-${MC_HELPER_VERSION}.tgz \
   | tar -C /usr/share -zxf - \
   && ln -s /usr/share/mc-image-helper-${MC_HELPER_VERSION}/bin/mc-image-helper /usr/bin


### PR DESCRIPTION
Bumped mc-image-helper to 1.22.8

Bring in https://github.com/itzg/mc-image-helper/pull/65