### PR TITLE
Add launch.sh start script to support multiple classic Technic modpacks

### DIFF
--- a/scripts/start-deployCF
+++ b/scripts/start-deployCF
@@ -150,6 +150,7 @@ findStartScript() {
     -o -name StartServer.sh
     -o -name run.sh
     -o -name start.sh
+    -o -name launch.sh
   )
 
   if [ -d "${FTB_BASE_DIR}" ]; then


### PR DESCRIPTION
This PR should add support for (at least) the following modpacks:

- Tekkit Classic - mc 1.2.5 (tested)
- Attack of the B-Team - mc 1.6.4
- Big Dig - mc 1.5.2
- Hexxit - mc 1.5.2
- Tekkit - mc 1.6.4
- Tekkit Lite - mc 1.4.7
- Voltz - mc 1.5.2