### PR TITLE
Fixed format as code for MOTD newline escape

### DIFF
--- a/README.md
+++ b/README.md
@@ -1004,7 +1004,7 @@ renders
 
 To produce a multi-line MOTD, you will need to double escape the newline such as
 
-  -e MOTD="Line one\\nLine two"
+    -e MOTD="Line one\\nLine two"
 
 ### Difficulty
 


### PR DESCRIPTION
There was a wrong indentation in the description on how to create a multiline MOTD. This way, the displayed was actually `\n` instead of `\\n`.