### PR TITLE
add more rubidium mods

### DIFF
--- a/files/cf-exclude-include.json
+++ b/files/cf-exclude-include.json
@@ -4,6 +4,8 @@
     "extreme-sound-muffler",
     "entityculling",
     "rubidium",
+    "textrues-rubidium-options",
+    "rubidium-extra",
     "nekos-enchanted-books",
     "skin-layers-3d",
     "not-enough-animations",


### PR DESCRIPTION
The following mods can be used in conjunction with rubidium, as such they prevent the server from loading