### PR TITLE
Update cf-exclude-include.json

### DIFF
--- a/files/cf-exclude-include.json
+++ b/files/cf-exclude-include.json
@@ -12,6 +12,7 @@
     "oculus",
     "rubidium",
     "rubidium-extra",
+    "magnesium-extras",
     "skin-layers-3d",
     "textrues-rubidium-options",
     "torohealth-damage-indicators"


### PR DESCRIPTION
Updated include/exclude defaults to include "Magnesium/Rubidium Extras" by teamdeusvult.
AllTheMods8 v1.0.11 (All the Mods 8-1.0.11.zip) won't start without blacklisting the mod, as it's client only.