### PR TITLE
Revert "modrinth: adapt version lookup to API changes (#1987)"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ RUN easy-add --var os=${TARGETOS} --var arch=${TARGETARCH}${TARGETVARIANT} \
   --var version=0.1.1 --var app=maven-metadata-release --file {{.app}} \
   --from https://github.com/itzg/{{.app}}/releases/download/{{.version}}/{{.app}}_{{.version}}_{{.os}}_{{.arch}}.tar.gz
 
-ARG MC_HELPER_VERSION=1.25.7
+ARG MC_HELPER_VERSION=1.25.6
 ARG MC_HELPER_BASE_URL=https://github.com/itzg/mc-image-helper/releases/download/${MC_HELPER_VERSION}
 RUN curl -fsSL ${MC_HELPER_BASE_URL}/mc-image-helper-${MC_HELPER_VERSION}.tgz \
   | tar -C /usr/share -zxf - \

--- a/scripts/start-setupModpack
+++ b/scripts/start-setupModpack
@@ -183,7 +183,7 @@ esac
 fi
 }
 
-function handleGenericPacks() {
+function genericPacks() {
   : "${GENERIC_PACKS:=${GENERIC_PACK}}"
   : "${GENERIC_PACKS_PREFIX:=}"
   : "${GENERIC_PACKS_SUFFIX:=}"
@@ -267,7 +267,7 @@ function handleGenericPacks() {
   fi
 }
 
-function handleModrinthProjects() {
+function modrinthProjects() {
   : "${MODRINTH_PROJECTS:=}"
   : "${MODRINTH_DOWNLOAD_OPTIONAL_DEPENDENCIES:=true}"
   : "${MODRINTH_ALLOWED_VERSION_TYPE:=release}"
@@ -294,8 +294,8 @@ handleModpackListOrFile
 
 handleCurseForgeManifest
 
-handleGenericPacks
+genericPacks
 
-handleModrinthProjects
+modrinthProjects
 
 exec "${SCRIPTS:-/}start-setupModconfig" "$@"


### PR DESCRIPTION
This reverts commit 3624dc02a34d54c0d7fc33afb8b4b64c78a7ac4c. / https://github.com/itzg/docker-minecraft-server/pull/1987

Discovered that it broke other Modrinth retrievals https://github.com/itzg/mc-image-helper/issues/152