### PR TITLE
Use modified knockd to set a cooldown on port 19132

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ RUN curl -fsSL ${MC_HELPER_BASE_URL}/mc-image-helper-${MC_HELPER_VERSION}.tgz \
   && ln -s /usr/share/mc-image-helper-${MC_HELPER_VERSION}/bin/mc-image-helper /usr/bin
 
 # Install modified knockd
-ADD https://github.com/Metalcape/knock/releases/download/0.8.1/knock-0.8.1-${TARGETARCH}.tar.gz /tmp/knock.tar.gz
+ADD https://github.com/Metalcape/knock/releases/download/0.8.1/knock-0.8.1-${TARGETARCH}${TARGETVARIANT}.tar.gz /tmp/knock.tar.gz
 RUN tar -xf /tmp/knock.tar.gz -C /usr/local/ && rm /tmp/knock.tar.gz
 RUN find /usr/lib -name 'libpcap.so.0.8' -execdir cp '{}' libpcap.so.1 \;
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,11 @@ RUN curl -fsSL ${MC_HELPER_BASE_URL}/mc-image-helper-${MC_HELPER_VERSION}.tgz \
   | tar -C /usr/share -zxf - \
   && ln -s /usr/share/mc-image-helper-${MC_HELPER_VERSION}/bin/mc-image-helper /usr/bin
 
+# Install modified knockd
+ADD https://github.com/Metalcape/knock/releases/download/0.8.1/knock-0.8.1-${TARGETARCH}.tar.gz /tmp/knock.tar.gz
+RUN tar -xf /tmp/knock.tar.gz -C /usr/local/ && rm /tmp/knock.tar.gz
+RUN find /usr/lib -name 'libpcap.so.0.8' -execdir cp '{}' libpcap.so.1 \;
+
 VOLUME ["/data"]
 WORKDIR /data
 

--- a/build/alpine/install-packages.sh
+++ b/build/alpine/install-packages.sh
@@ -21,7 +21,21 @@ apk add --no-cache -U \
     rsync \
     nano \
     sudo \
-    knock \
     tar \
     zstd \
-    nfs-utils
+    nfs-utils \
+    libpcap0.8 \
+    libpcap-dev \
+    autoconf \
+    make \
+    gcc
+
+# Install knockd from source
+
+git clone https://github.com/Metalcape/knock
+cd knock
+git checkout cooldown
+autoreconf -fi
+./configure --prefix=/usr/local
+make
+make install

--- a/build/alpine/install-packages.sh
+++ b/build/alpine/install-packages.sh
@@ -25,17 +25,3 @@ apk add --no-cache -U \
     zstd \
     nfs-utils \
     libpcap0.8 \
-    libpcap-dev \
-    autoconf \
-    make \
-    gcc
-
-# Install knockd from source
-
-git clone https://github.com/Metalcape/knock
-cd knock
-git checkout cooldown
-autoreconf -fi
-./configure --prefix=/usr/local
-make
-make install

--- a/build/alpine/install-packages.sh
+++ b/build/alpine/install-packages.sh
@@ -24,4 +24,4 @@ apk add --no-cache -U \
     tar \
     zstd \
     nfs-utils \
-    libpcap0.8 \
+    libpcap

--- a/build/ol/install-packages.sh
+++ b/build/ol/install-packages.sh
@@ -33,6 +33,20 @@ dnf install -y ImageMagick \
   unzip \
   zstd \
   lbzip2 \
-  knock
+  libpcap0.8 \
+  libpcap-dev \
+  autoconf \
+  make \
+  gcc
 
 bash /build/ol/install-gosu.sh
+
+# Install knockd from source
+
+git clone https://github.com/Metalcape/knock
+cd knock
+git checkout cooldown
+autoreconf -fi
+./configure --prefix=/usr/local
+make
+make install

--- a/build/ol/install-packages.sh
+++ b/build/ol/install-packages.sh
@@ -34,9 +34,5 @@ dnf install -y ImageMagick \
   zstd \
   lbzip2 \
   libpcap0.8 \
-  libpcap-dev \
-  autoconf \
-  make \
-  gcc
 
 bash /build/ol/install-gosu.sh

--- a/build/ol/install-packages.sh
+++ b/build/ol/install-packages.sh
@@ -40,13 +40,3 @@ dnf install -y ImageMagick \
   gcc
 
 bash /build/ol/install-gosu.sh
-
-# Install knockd from source
-
-git clone https://github.com/Metalcape/knock
-cd knock
-git checkout cooldown
-autoreconf -fi
-./configure --prefix=/usr/local
-make
-make install

--- a/build/ol/install-packages.sh
+++ b/build/ol/install-packages.sh
@@ -33,6 +33,6 @@ dnf install -y ImageMagick \
   unzip \
   zstd \
   lbzip2 \
-  libpcap0.8
+  libpcap
 
 bash /build/ol/install-gosu.sh

--- a/build/ol/install-packages.sh
+++ b/build/ol/install-packages.sh
@@ -33,6 +33,6 @@ dnf install -y ImageMagick \
   unzip \
   zstd \
   lbzip2 \
-  libpcap0.8 \
+  libpcap0.8
 
 bash /build/ol/install-gosu.sh

--- a/build/ubuntu/install-packages.sh
+++ b/build/ubuntu/install-packages.sh
@@ -23,7 +23,21 @@ apt-get install -y \
   unzip \
   zstd \
   lbzip2 \
-  knockd \
-  nfs-common
+  nfs-common \
+  libpcap0.8 \
+  libpcap-dev \
+  autoconf \
+  make \
+  gcc
 
 apt-get clean
+
+# Install knockd from source
+
+git clone https://github.com/Metalcape/knock
+cd knock
+git checkout cooldown
+autoreconf -fi
+./configure --prefix=/usr/local
+make
+make install

--- a/build/ubuntu/install-packages.sh
+++ b/build/ubuntu/install-packages.sh
@@ -25,19 +25,5 @@ apt-get install -y \
   lbzip2 \
   nfs-common \
   libpcap0.8 \
-  libpcap-dev \
-  autoconf \
-  make \
-  gcc
 
 apt-get clean
-
-# Install knockd from source
-
-git clone https://github.com/Metalcape/knock
-cd knock
-git checkout cooldown
-autoreconf -fi
-./configure --prefix=/usr/local
-make
-make install

--- a/build/ubuntu/install-packages.sh
+++ b/build/ubuntu/install-packages.sh
@@ -24,6 +24,6 @@ apt-get install -y \
   zstd \
   lbzip2 \
   nfs-common \
-  libpcap0.8 \
+  libpcap0.8
 
 apt-get clean

--- a/files/auto/autopause-daemon.sh
+++ b/files/auto/autopause-daemon.sh
@@ -45,7 +45,7 @@ if isTrue "${DEBUG_AUTOPAUSE}"; then
   knockdArgs+=(-D)
 fi
 
-sudo /usr/sbin/knockd "${knockdArgs[@]}"
+sudo /usr/local/sbin/knockd "${knockdArgs[@]}"
 if [ $? -ne 0 ] ; then
   logAutopause "Failed to start knockd daemon."
   logAutopause "Probable cause: Unable to attach to interface \"$AUTOPAUSE_KNOCK_INTERFACE\"."

--- a/files/auto/knockd-config.cfg
+++ b/files/auto/knockd-config.cfg
@@ -13,3 +13,4 @@
 [unpauseMCServer-bedrock]
  sequence = 19132:udp
  command = /auto/resume.sh %IP%
+ seq_cooldown = 60

--- a/files/sudoers-mc
+++ b/files/sudoers-mc
@@ -1,2 +1,2 @@
 minecraft ALL=(ALL) NOPASSWD:/usr/bin/pkill
-minecraft ALL=(ALL) NOPASSWD:/usr/sbin/knockd
+minecraft ALL=(ALL) NOPASSWD:/usr/local/sbin/knockd

--- a/scripts/start-autopause
+++ b/scripts/start-autopause
@@ -84,4 +84,9 @@ elif [[ -z "$MAX_TICK_TIME" ]] ; then
   export MAX_TICK_TIME
 fi
 
+# seq_cooldown cannot be larger than AUTOPAUSE_TIMEOUT_KN, otherwise the server may
+# become paused while knockd is still ignoring packets, preventing players from joining.
+let COOLDOWN=$AUTOPAUSE_TIMEOUT_KN/2
+sed -i "s/\(seq_cooldown *= *\).*/\1$COOLDOWN/" /tmp/knockd-config.cfg
+
 /auto/autopause-daemon.sh &


### PR DESCRIPTION
Fixes #1969.

There are a couple details that may need to be addressed:
- `seq_cooldown` can't be bigger than `AUTOPAUSE_TIMEOUT_KN` (see last commit). We might want to set a lower bound for both, or expose the cooldown timer as an environment variable.
- I have no idea if the libpcap package has the same name for dnf and alpine, I know that apt has `libpcap0.8` but the other scripts may have to be changed.