### PR TITLE
Correcting and extending vanillatweaks example

### DIFF
--- a/examples/vanilla-tweaks/docker-compose.yml
+++ b/examples/vanilla-tweaks/docker-compose.yml
@@ -25,3 +25,19 @@ services:
       VERSION: ${MINECRAFT_VERSION:-LATEST}
       VANILLATWEAKS_SHARECODE: MGr52E
       REMOVE_OLD_VANILLATWEAKS: "TRUE"
+  vanillatweaks_file_datapacks_and_resourcepacks_and_craftingtweaks:
+    # port is set to 25567 to not conflict with vanillatweaks_file example
+    restart: "no"
+    image: itzg/minecraft-server
+    ports:
+      - "25567:25565/tcp"
+    environment:
+      EULA: "TRUE"
+      VERSION: ${MINECRAFT_VERSION:-LATEST}
+      VANILLATWEAKS_FILE: /config/vanillatweaks-datapacks.json,/config/vanillatweaks-resourcepacks.json,/config/vanillatweaks-craftingtweaks.json
+      REMOVE_OLD_VANILLATWEAKS: "TRUE"
+    volumes:
+      - data:/data
+      - ./vanillatweaks-datapacks.json:/config/vanillatweaks-datapacks.json:ro
+      - ./vanillatweaks-resourcepacks.json:/config/vanillatweaks-resourcepacks.json:ro
+      - ./vanillatweaks-craftingtweaks.json:/config/vanillatweaks-craftingtweaks.json:ro

--- a/examples/vanilla-tweaks/vanillatweaks-craftingtweaks.json
+++ b/examples/vanilla-tweaks/vanillatweaks-craftingtweaks.json
@@ -1,0 +1,12 @@
+{
+    "type": "craftingtweaks",
+    "version": "1.18",
+    "packs": {
+        "quality of life": [
+            "dropper to dispenser",
+            "double slabs",
+            "back to blocks"
+        ]
+    },
+    "result": "ok"
+}

--- a/examples/vanilla-tweaks/vanillatweaks-datapacks.json
+++ b/examples/vanilla-tweaks/vanillatweaks-datapacks.json
@@ -1,4 +1,5 @@
 {
+    "type": "datapacks",
     "version": "1.18",
     "packs": {
         "survival": [
@@ -11,5 +12,6 @@
             "coordinates hud"
         ],
         "items": ["armored elytra"]
-    }
+    },
+    "result": "ok"
 }

--- a/examples/vanilla-tweaks/vanillatweaks-resourcepacks.json
+++ b/examples/vanilla-tweaks/vanillatweaks-resourcepacks.json
@@ -1,0 +1,8 @@
+{
+    "type": "resourcepacks",
+    "version": "1.18",
+    "packs": {
+        "aesthetic": ["CherryPicking", "BlackNetherBricks", "AlternateBlockDestruction"]
+    },
+    "result": "ok"
+}


### PR DESCRIPTION
The vanillatweaks example didn´t work, I got the following error:

mc_1  | [mc-image-helper] 12:41:54.892 ERROR : 'vanillatweaks' command failed. Version is 1.25.12
mc_1  | java.lang.NullPointerException: Cannot invoke "me.itzg.helpers.vanillatweaks.model.Type.toString()" because the return value of "me.itzg.helpers.vanillatweaks.model.PackDefinition.getType()" is null

When I checked the tests under tests/setuponlytests/vanillatweaks_file I noticed there were two missing entries in the JSON file.
I corrected this and added the examples for resourcepacks and craftingtweaks as well.

See also https://github.com/itzg/mc-image-helper/issues/163