### PR TITLE
Probably quote content passed to mc-send-to-console

### DIFF
--- a/bin/mc-send-to-console
+++ b/bin/mc-send-to-console
@@ -14,9 +14,9 @@ fi
 
 if [ "$(id -u)" = 0 ]; then
   if [[ $(getDistro) == alpine ]]; then
-    exec su-exec minecraft bash -c "echo $* > '${CONSOLE_IN_NAMED_PIPE:-/tmp/minecraft-console-in}'"
+    exec su-exec minecraft bash -c "echo '$*' > '${CONSOLE_IN_NAMED_PIPE:-/tmp/minecraft-console-in}'"
   else
-    exec gosu minecraft bash -c "echo $* > '${CONSOLE_IN_NAMED_PIPE:-/tmp/minecraft-console-in}'"
+    exec gosu minecraft bash -c "echo '$*' > '${CONSOLE_IN_NAMED_PIPE:-/tmp/minecraft-console-in}'"
   fi
 else
   echo "$@" >"${CONSOLE_IN_NAMED_PIPE:-/tmp/minecraft-console-in}"


### PR DESCRIPTION
Resolves #2090 

Example from reported issue logged as:

```
[17:24:59] [Server thread/INFO]: [Not Secure] [Server] text1 text2 &acoloredText3
[17:25:18] [Server thread/INFO]: [Not Secure] [Server] text1 text2 > text3
```