### PR TITLE
Download Canyon from GitHub for final build

### DIFF
--- a/README.md
+++ b/README.md
@@ -541,9 +541,10 @@ A [Catserver](http://catserver.moe/) type server can be used with
 
 > **NOTE** only `VERSION=b1.7.3` is supported. Since that version pre-dates the health check mechanism used by this image, that will need to be disabled by setting `DISABLE_HEALTHCHECK=true`.
 
-By default, the latest build will be used; however, a specific build number can be selected by setting `CANYON_BUILD`, such as
+Canyon is on a temporary hiatus, so by default the final build from GitHub will be used; however, a specific build number can be selected in some instances by setting `CANYON_BUILD`, such as
 
-    -e CANYON_BUILD=11
+    -e CANYON_BUILD=6
+    -e CANYON_BUILD=26
 
 ### Running a SpongeVanilla server
 

--- a/scripts/start-deployCanyon
+++ b/scripts/start-deployCanyon
@@ -37,6 +37,12 @@ if [ ! -f "$SERVER" ]; then
     if [ "${CANYON_BUILD}" = "final" ]; then
         downloadUrl="https://github.com/KoboDev/SupplyAndDemand/releases/download/finalcanyon/canyon-server.jar"
         log "Downloading final Canyon build from $downloadUrl ..."
+    elif [ "${CANYON_BUILD}" = "6" ]; then
+        downloadUrl="https://github.com/KoboDev/SupplyAndDemand/releases/download/CanyonRelease/Canyon-Build-6.jar"
+        log "Downloading Canyon build 6 from $downloadUrl ..."
+    elif [ "${CANYON_BUILD}" = "26" ]; then
+        downloadUrl="https://github.com/KoboDev/SupplyAndDemand/releases/download/CanyonRelease/canyon-build-26.jar"
+        log "Downloading Canyon build 26 from $downloadUrl ..."
     else
         downloadUrl="${canyonJob}/${CANYON_BUILD}/artifact/${buildRelPath}"
         log "Downloading Canyon build ${buildNumber} from $downloadUrl ..."

--- a/scripts/start-deployCanyon
+++ b/scripts/start-deployCanyon
@@ -6,7 +6,7 @@ IFS=$'\n\t'
 . "${SCRIPTS:-/}start-utils"
 isDebugging && set -x
 
-: "${CANYON_BUILD:=lastSuccessfulBuild}"
+: "${CANYON_BUILD:=final}"
 
 if [ "${VERSION}" != "b1.7.3" ]; then
   log "ERROR: Canyon server type only supports VERSION=b1.7.3"
@@ -33,8 +33,14 @@ else
 fi
 
 if [ ! -f "$SERVER" ]; then
-    downloadUrl="${canyonJob}/${CANYON_BUILD}/artifact/${buildRelPath}"
-    log "Downloading Canyon build ${buildNumber} from $downloadUrl ..."
+    # If CANYON_BUILD is final, then download from GitHub
+    if [ "${CANYON_BUILD}" = "final" ]; then
+        downloadUrl="https://github.com/KoboDev/SupplyAndDemand/releases/download/finalcanyon/canyon-server.jar"
+        log "Downloading final Canyon build from $downloadUrl ..."
+    else
+        downloadUrl="${canyonJob}/${CANYON_BUILD}/artifact/${buildRelPath}"
+        log "Downloading Canyon build ${buildNumber} from $downloadUrl ..."
+    fi
     curl -fsSL -o "$SERVER" "$downloadUrl"
     if [ ! -f "$SERVER" ]; then
       log "ERROR: failed to download from $downloadUrl (status=$?)"


### PR DESCRIPTION
Canyon is on an indefinite hiatus, and a final build has been produced by @KoboDev for the meantime. This changes the default value for `CANYON_BUILD` to "final", and in the instance this is provided, we download this build from their GitHub provided build rather than the CI integration.

The CI server previously provided by Velocity is now 410 Gone, so individual build numbers are not available at present. A future PR may address this by them being made available by another provider, but for now I think this change is enough to keep Canyon servers functional for the meantime.