### PR TITLE
Include Log4jPatcher

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,6 +70,8 @@ COPY --chmod=644 files/log4j2.xml /image/log4j2.xml
 COPY --chmod=644 files/cf-exclude-include.json /image/cf-exclude-include.json
 COPY --chmod=755 files/auto /auto
 
+RUN curl -fsSL -o /image/Log4jPatcher.jar https://github.com/CreeperHost/Log4jPatcher/releases/download/v1.0.1/Log4jPatcher-1.0.1.jar
+
 RUN dos2unix /start* /auto/*
 
 ENTRYPOINT [ "/start" ]

--- a/scripts/start-finalExec
+++ b/scripts/start-finalExec
@@ -77,6 +77,16 @@ if ${useFallbackJvmFlag}; then
   JVM_OPTS="-Dlog4j2.formatMsgNoLookups=true ${JVM_OPTS}"
 fi
 
+if versionLessThan 1.7; then
+  : # No patch required here.
+elif versionLessThan 1.18.1; then
+  if isTrue ${SKIP_LOG4J_PATCHER:-false}; then
+    log "Skipping Log4jPatcher, make sure you are not affected"
+  else
+    JVM_OPTS="-javaagent:/image/Log4jPatcher.jar ${JVM_OPTS}"
+  fi
+fi
+
 if isTrue ${ENABLE_ROLLING_LOGS:-false}; then
   if ! ${canUseRollingLogs}; then
     log "ERROR: Using rolling logs is currently not possible in the selected version due to CVE-2021-44228"


### PR DESCRIPTION
Use [CreeperHost/Log4jPatcher](https://github.com/CreeperHost/Log4jPatcher) to patch the Log4Shell vulnerability for server types and versions that are not covered by existing measures. See [#2101](https://github.com/itzg/docker-minecraft-server/issues/2101#issuecomment-1523396342) for some of the affected versions.

The patcher is being applied for all server types between Minecraft version 1.7 - 1.18.0 (inclusive), even though server types VANILLA and PURPUR are already covered by their patched log4j configurations.
Alternatively it could be set up to only cover server types excluding unaffected server types, however in my limited testing the additional patching does not appear to cause any side effects.

As requested a `SKIP_LOG4J_PATCHER` environment variable has been introduced to skip the patching, it will default to false if not specified. This should probably be added to the documentation.

fixes #2101 