### PR TITLE
Changed rcon password references from "minecraft" to randomly generated

### DIFF
--- a/docs/configuration/server-properties.md
+++ b/docs/configuration/server-properties.md
@@ -107,7 +107,7 @@ The server icon which has been set doesn't get overridden by default. It can be 
 
 RCON is **enabled by default** to allow for graceful shut down the server and coordination of save state during backups. RCON can be disabled by setting `ENABLE_RCON` to "false".
 
-The default password is "minecraft" but **change the password before deploying into production** by setting `RCON_PASSWORD`.
+The default password is randomly generated if `RCON_PASSWORD` has not been set.
 
 **DO NOT MAP THE RCON PORT EXTERNALLY** unless you aware of all the consequences and have set a **secure password** with `RCON_PASSWORD`. 
 

--- a/docs/variables/index.md
+++ b/docs/variables/index.md
@@ -541,7 +541,7 @@ alternatively, you can mount: <code>/etc/localtime:/etc/localtime:ro
         <tr>
             <td><code>RCON_PASSWORD</code></td>
             <td>You <strong>MUST</strong> change this value</td>
-            <td><code>minecraft</code></td>
+            <td><code>Randomly generated</code></td>
             <td>✅</td>
         </tr>
         <tr>


### PR DESCRIPTION
I was able to find two files which referenced "minecraft" as the default password. I have changed this to say randomly generated. 

Should fix #2180 