### PR TITLE
Allow skipping autopause/autostop using a file

### DIFF
--- a/docs/misc/autopause-autostop/autopause.md
+++ b/docs/misc/autopause-autostop/autopause.md
@@ -14,6 +14,8 @@ The utility used to wake the server (`knock(d)`) works at network interface leve
 
 A file called `.paused` is created in `/data` directory when the server is paused and removed when the server is resumed. Other services may check for this file's existence before waking the server.
 
+A `.skip-pause` file can be created in the `/data` directory to make the server skip autopausing, for as long as the file is present. The autopause timer will also be reset.
+
 A starting, example compose file has been provided in [examples/docker-compose-autopause.yml](https://github.com/itzg/docker-minecraft-server/blob/master/examples/docker-compose-autopause.yml).
 
 Auto-pause is not compatible with `EXEC_DIRECTLY=true` and the two cannot be set together.

--- a/docs/misc/autopause-autostop/autostop.md
+++ b/docs/misc/autopause-autostop/autostop.md
@@ -6,6 +6,8 @@ An option to stop the server after a specified time has been added for niche app
 
     the docker container variables have to be set accordingly (restart policy set to "no") and that the container has to be manually restarted.
 
+A `.skip-stop` file can be created in the `/data` directory to make the server skip autostopping, for as long as the file is present. The autostop timer will also be reset.
+
 A starting, example compose file has been provided in [examples/docker-compose-autostop.yml](https://github.com/itzg/docker-minecraft-server/blob/master/examples/docker-compose-autostop.yml).
 
 Enable the Autostop functionality by setting:

--- a/files/auto/autopause-daemon.sh
+++ b/files/auto/autopause-daemon.sh
@@ -64,7 +64,7 @@ do
       TIME_THRESH=$(($(current_uptime)+$AUTOPAUSE_TIMEOUT_INIT))
 
       if [ -e /data/.skip-pause ] ; then
-        logAutopause "`/data/.skip-pause` file is present - skipping pausing"
+        logAutopause "'/data/.skip-pause' file is present - skipping pausing"
       else
         logAutopause "MC Server listening for connections - pausing in $AUTOPAUSE_TIMEOUT_INIT seconds"
       fi
@@ -78,7 +78,7 @@ do
       logAutopause "Client connected - waiting for disconnect"
       STATE=E
     elif [ -e /data/.skip-pause ] ; then
-      logAutopause "`/data/.skip-pause` file is present - skipping pausing"
+      logAutopause "'/data/.skip-pause' file is present - skipping pausing"
       STATE=E
     else
       if [[ $(current_uptime) -ge $TIME_THRESH ]] ; then
@@ -103,7 +103,7 @@ do
       STATE=E
     elif [ -e /data/.skip-pause ] ; then
       TIME_THRESH=$(($(current_uptime)+$AUTOPAUSE_TIMEOUT_EST))
-      logAutopause "`/data/.skip-pause` file is present - skipping pausing"
+      logAutopause "'/data/.skip-pause' file is present - skipping pausing"
       STATE=E
     else
       if [[ $(current_uptime) -ge $TIME_THRESH ]] ; then

--- a/files/auto/autostop-daemon.sh
+++ b/files/auto/autostop-daemon.sh
@@ -29,10 +29,11 @@ do
     if mc_server_listening ; then
       TIME_THRESH=$(($(current_uptime)+AUTOSTOP_TIMEOUT_INIT))
 
-      if -e /data/.skip-stop ; then
+      if [ -e /data/.skip-stop ] ; then
         logAutostop "`/data/.skip-stop` file is present - skipping stopping"
       else
         logAutostop "MC Server listening for connections - stopping in $AUTOSTOP_TIMEOUT_INIT seconds"
+      fi
 
       STATE=II
     fi
@@ -42,11 +43,9 @@ do
     if java_clients_connected ; then
       logAutostop "Client connected - waiting for disconnect"
       STATE=E
-    else
-      if -e /data/.skip-stop ; then
-        logAutostop "`/data/.skip-stop` file is present - skipping stopping"
-        STATE=E
-      fi
+    elif [ -e /data/.skip-stop ] ; then
+      logAutostop "`/data/.skip-stop` file is present - skipping stopping"
+      STATE=E
     else
       if [[ $(current_uptime) -ge $TIME_THRESH ]] ; then
         logAutostop "No client connected since startup - stopping server"
@@ -57,7 +56,7 @@ do
     ;;
   XE)
     # Established
-    if -e /data/.skip-stop ; then
+    if [ -e /data/.skip-stop ] ; then
       TIME_THRESH=$(($(current_uptime)+$AUTOSTOP_TIMEOUT_EST))
       logAutostop "`/data/.skip-stop` file is present - skipping stopping"
       STATE=E
@@ -74,12 +73,10 @@ do
     if java_clients_connected ; then
       logAutostop "Client reconnected - waiting for disconnect"
       STATE=E
-    else
-      if -e /data/.skip-stop ; then
-        TIME_THRESH=$(($(current_uptime)+$AUTOSTOP_TIMEOUT_EST))
-        logAutostop "`/data/.skip-stop` file is present - skipping stopping"
-        STATE=E
-      fi
+    elif [ -e /data/.skip-stop ] ; then
+      TIME_THRESH=$(($(current_uptime)+$AUTOSTOP_TIMEOUT_EST))
+      logAutostop "`/data/.skip-stop` file is present - skipping stopping"
+      STATE=E
     else
       if [[ $(current_uptime) -ge $TIME_THRESH ]] ; then
         logAutostop "No client reconnected - stopping"

--- a/files/auto/autostop-daemon.sh
+++ b/files/auto/autostop-daemon.sh
@@ -30,7 +30,7 @@ do
       TIME_THRESH=$(($(current_uptime)+AUTOSTOP_TIMEOUT_INIT))
 
       if [ -e /data/.skip-stop ] ; then
-        logAutostop "`/data/.skip-stop` file is present - skipping stopping"
+        logAutostop "'/data/.skip-stop' file is present - skipping stopping"
       else
         logAutostop "MC Server listening for connections - stopping in $AUTOSTOP_TIMEOUT_INIT seconds"
       fi
@@ -44,7 +44,7 @@ do
       logAutostop "Client connected - waiting for disconnect"
       STATE=E
     elif [ -e /data/.skip-stop ] ; then
-      logAutostop "`/data/.skip-stop` file is present - skipping stopping"
+      logAutostop "'/data/.skip-stop' file is present - skipping stopping"
       STATE=E
     else
       if [[ $(current_uptime) -ge $TIME_THRESH ]] ; then
@@ -56,16 +56,10 @@ do
     ;;
   XE)
     # Established
-    if [ -e /data/.skip-stop ] ; then
+    if ! java_clients_connected ; then
       TIME_THRESH=$(($(current_uptime)+$AUTOSTOP_TIMEOUT_EST))
-      logAutostop "`/data/.skip-stop` file is present - skipping stopping"
-      STATE=E
-    else
-      if ! java_clients_connected ; then
-        TIME_THRESH=$(($(current_uptime)+$AUTOSTOP_TIMEOUT_EST))
-        logAutostop "All clients disconnected - stopping in $AUTOSTOP_TIMEOUT_EST seconds"
-        STATE=I
-      fi
+      logAutostop "All clients disconnected - stopping in $AUTOSTOP_TIMEOUT_EST seconds"
+      STATE=I
     fi
     ;;
   XI)
@@ -75,7 +69,7 @@ do
       STATE=E
     elif [ -e /data/.skip-stop ] ; then
       TIME_THRESH=$(($(current_uptime)+$AUTOSTOP_TIMEOUT_EST))
-      logAutostop "`/data/.skip-stop` file is present - skipping stopping"
+      logAutostop "'/data/.skip-stop' file is present - skipping stopping"
       STATE=E
     else
       if [[ $(current_uptime) -ge $TIME_THRESH ]] ; then


### PR DESCRIPTION
I've added a check to the autopause/autostop daemons to see if the `/data/.skip-pause` (`/data/.skip-stop` for autostop) file is present, and if so, prevent autopausing/autostopping.

I've also added notes about this to the docs.