### PR TITLE
Fix game name matching in setupForgeApiMods

### DIFF
--- a/scripts/start-setupForgeApiMods
+++ b/scripts/start-setupForgeApiMods
@@ -67,7 +67,7 @@ retrieveVersionTypeNumber(){
     exit 2
   fi
 
-  TYPE_ID=$(jq -n "$minecraft_types" | jq --arg VERSION_NAME "$VERSION_NAME" -jc '
+  TYPE_ID=$(jq -n "$minecraft_types" | jq --arg VERSION_NAME "Minecraft $VERSION_NAME" -jc '
       .data[]? | select(.name==$VERSION_NAME) | .id')
 
   if [ ! "$TYPE_ID" ]; then


### PR DESCRIPTION
Not sure how long this has been the case, but the response from the `version-types` endpoint of the CF API looks like this:

``` json5
{
  "data": [
    {
      "id": 73242,
      "gameId": 432,
      "name": "Minecraft 1.17",
      "slug": "minecraft-1-17"
    },
    {
      "id": 628,
      "gameId": 432,
      "name": "Minecraft 1.12",
      "slug": "minecraft-1-12"
    },
    // ...
}
```