### PR TITLE
build: skip some of the setuponly tests by default

### DIFF
--- a/tests/setuponlytests/conflicting_world_for_spigot_server/require.sh
+++ b/tests/setuponlytests/conflicting_world_for_spigot_server/require.sh
@@ -1,0 +1,1 @@
+[[ $EXTENDED_TESTS ]] || exit 1

--- a/tests/setuponlytests/conflicting_world_for_vanilla_server/require.sh
+++ b/tests/setuponlytests/conflicting_world_for_vanilla_server/require.sh
@@ -1,0 +1,1 @@
+[[ $EXTENDED_TESTS ]] || exit 1

--- a/tests/setuponlytests/icon-file-exact/require.sh
+++ b/tests/setuponlytests/icon-file-exact/require.sh
@@ -1,0 +1,1 @@
+[[ $EXTENDED_TESTS ]] || exit 1

--- a/tests/setuponlytests/icon-gif-multiframe/require.sh
+++ b/tests/setuponlytests/icon-gif-multiframe/require.sh
@@ -1,0 +1,1 @@
+[[ $EXTENDED_TESTS ]] || exit 1

--- a/tests/setuponlytests/icon-png-atscale/require.sh
+++ b/tests/setuponlytests/icon-png-atscale/require.sh
@@ -1,0 +1,1 @@
+[[ $EXTENDED_TESTS ]] || exit 1

--- a/tests/setuponlytests/spigot_world_for_vanilla_server/require.sh
+++ b/tests/setuponlytests/spigot_world_for_vanilla_server/require.sh
@@ -1,0 +1,1 @@
+[[ $EXTENDED_TESTS ]] || exit 1

--- a/tests/setuponlytests/spongevanilla_version_compare/require.sh
+++ b/tests/setuponlytests/spongevanilla_version_compare/require.sh
@@ -1,0 +1,1 @@
+[[ $EXTENDED_TESTS ]] || exit 1

--- a/tests/setuponlytests/vanilla_world_for_spigot_server/require.sh
+++ b/tests/setuponlytests/vanilla_world_for_spigot_server/require.sh
@@ -1,0 +1,1 @@
+[[ $EXTENDED_TESTS ]] || exit 1

--- a/tests/setuponlytests/vanillatweaks_sharecode/require.sh
+++ b/tests/setuponlytests/vanillatweaks_sharecode/require.sh
@@ -1,0 +1,1 @@
+[[ $EXTENDED_TESTS ]] || exit 1

--- a/tests/setuponlytests/world_from_tar/require.sh
+++ b/tests/setuponlytests/world_from_tar/require.sh
@@ -1,0 +1,1 @@
+[[ $EXTENDED_TESTS ]] || exit 1

--- a/tests/setuponlytests/world_from_tarbz2/require.sh
+++ b/tests/setuponlytests/world_from_tarbz2/require.sh
@@ -1,0 +1,1 @@
+[[ $EXTENDED_TESTS ]] || exit 1

--- a/tests/setuponlytests/world_from_tarzst/require.sh
+++ b/tests/setuponlytests/world_from_tarzst/require.sh
@@ -1,0 +1,1 @@
+[[ $EXTENDED_TESTS ]] || exit 1


### PR DESCRIPTION
Some test runs are taking up to 11 minutes on Github Actions. I am adding a `require.sh` to the non-critical ones that check for the variable `EXTENDED_TESTS` to be set.