### PR TITLE
modrinth: allow installer to ignore missing files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN easy-add --var os=${TARGETOS} --var arch=${TARGETARCH}${TARGETVARIANT} \
   --var version=1.9.0 --var app=mc-server-runner --file {{.app}} \
   --from https://github.com/itzg/{{.app}}/releases/download/{{.version}}/{{.app}}_{{.version}}_{{.os}}_{{.arch}}.tar.gz
 
-ARG MC_HELPER_VERSION=1.34.3
+ARG MC_HELPER_VERSION=1.34.5
 ARG MC_HELPER_BASE_URL=https://github.com/itzg/mc-image-helper/releases/download/${MC_HELPER_VERSION}
 # used for cache busting local copy of mc-image-helper
 ARG MC_HELPER_REV=1

--- a/docs/mods-and-plugins/modrinth.md
+++ b/docs/mods-and-plugins/modrinth.md
@@ -2,17 +2,29 @@
 
 [Modrinth](https://modrinth.com/) is an open source modding platform with a clean, easy to use website for finding [Fabric and Forge mods](https://modrinth.com/mods). At startup, the container will automatically locate and download the newest versions of mod/plugin files that correspond to the `TYPE` and `VERSION` in use. Older file versions downloaded previously will automatically be cleaned up.
 
-- **MODRINTH_PROJECTS** : comma separated list of project slugs (short name) or IDs. The project ID can be located in the "Technical information" section. The slug is the part of the page URL that follows `/mod/`:
+- **MODRINTH_PROJECTS** : comma or newline separated list of project slugs (short name) or IDs. The project ID is located in the "Technical information" section. The slug is the part of the page URL that follows `/mod/`:
   ```
     https://modrinth.com/mod/fabric-api
                              ----------
                               |
                               +-- project slug
   ```
-  Also, specific version/type can be declared using colon symbol and version id/type after the project slug. The version id can be found at 'Metadata' section. Valid version types are `release`, `beta`, `alpha`. For instance:
-  ```
-    -e MODRINTH_PROJECTS=fabric-api,fabric-api:PbVeub96,fabric-api:beta
-  ```
-- **MODRINTH_DOWNLOAD_OPTIONAL_DEPENDENCIES**=true : required dependencies of the project will _always_ be downloaded and optional dependencies can also be downloaded by setting this to `true`
-- **MODRINTH_ALLOWED_VERSION_TYPE**=release : the version type is used to determine the newest version to use from each project. The allowed values are `release`, `beta`, `alpha`.
+  Also, a specific version/type can be declared using colon symbol and version id/type after the project slug. The version id can be found in the 'Metadata' section. Valid version types are `release`, `beta`, `alpha`.
+
+!!! example
+        
+    | Description                     | Example               |
+    |---------------------------------|-----------------------|
+    | Select latest version           | `fabric-api`          |
+    | Select specific version         | `fabric-api:PbVeub96` |
+    | Select latest beta version      | `fabric-api:beta`     |
+    | Latest version using project ID | `P7dR8mSH`            |
+
+## Extra options
+
+`MODRINTH_DOWNLOAD_OPTIONAL_DEPENDENCIES`
+: Required dependencies of the project will _always_ be downloaded and optional dependencies can also be downloaded by setting this to `true`. The default is "true"
+
+`MODRINTH_ALLOWED_VERSION_TYPE`
+: The version type is used to determine the newest version to use from each project. The allowed values are `release` (default), `beta`, `alpha`.
 

--- a/docs/types-and-platforms/mod-platforms/modrinth-modpacks.md
+++ b/docs/types-and-platforms/mod-platforms/modrinth-modpacks.md
@@ -2,6 +2,8 @@
 
 [Modrinth Modpacks](https://modrinth.com/modpacks) can automatically be installed along with the required mod loader (Forge or Fabric) by setting `MOD_PLATFORM` or `TYPE` to "MODRINTH". Upgrading (and downgrading) takes care of cleaning up old files and upgrading (and downgrading) the mod loader.
 
+## Modpack project
+
 The desired modpack project is specified with the `MODRINTH_MODPACK` environment variable and must be one of:
 
 - The project "slug", which is located in the URL shown here:
@@ -12,14 +14,30 @@ The desired modpack project is specified with the `MODRINTH_MODPACK` environment
   ![](../../img/modrinth-project-id.drawio.png)
 - The project page URL, such as <https://modrinth.com/modpack/cobblemon-fabric>. As described below, this can further be the page URL of a modpack's version page.
 
+## Modpack version
+
 The automatic modpack version resolving can be narrowed in a few ways:
 
 The latest release or beta version, respectively, of the Modrinth modpack is selected when `VERSION` is "LATEST" or "SNAPSHOT". That can be overridden by setting `MODRINTH_DEFAULT_VERSION_TYPE` to "release", "beta", or "alpha".
 
-Furthermore, the resolved modpack version can be narrowed by setting `VERSION` to a specific Minecraft version, such as "1.19.2".
+The resolved modpack version can be narrowed by setting `VERSION` to a specific Minecraft version, such as "1.19.2".
 
 The selected version can also be narrowed to a particular mod loader by setting `MODRINTH_LOADER` to either "forge", "fabric", or "quilt".
 
 Instead of auto resolving, a specific version of modpack file can be specified by passing the version's page URL to `MODRINTH_MODPACK`, such as <https://modrinth.com/modpack/cobblemon-fabric/version/1.3.2> or by setting `MODRINTH_VERSION` to the version ID or number located in the Metadata section, as shown here
 
 ![](../../img/modrinth-version-id.drawio.png)
+
+## Ignore missing files
+
+Some mods, such as [MCInstance Loader](https://modrinth.com/mod/mcinstance-loader), use temporary files from the modpack and delete them when finished. In order to avoid the installer from detecting the absent file(s) and re-installing, those files can be ignored by passing a comma or newline delimited list to `MODRINTH_IGNORE_MISSING_FILES`.
+
+!!! example
+
+    In a Compose file
+    ```yaml
+      environment:
+        MODRINTH_IGNORE_MISSING_FILES: |
+          config/mcinstanceloader/pack.mcinstance
+    ```
+

--- a/scripts/start-deployModrinth
+++ b/scripts/start-deployModrinth
@@ -9,6 +9,7 @@ resultsFile=/data/.install-modrinth.env
 : "${MODRINTH_MODPACK:=${MODRINTH_PROJECT:-}}"
 : "${MODRINTH_LOADER:=}"
 : "${MODRINTH_VERSION:=${MODRINTH_VERSION_ID:-}}"
+: "${MODRINTH_IGNORE_MISSING_FILES:=}"
 
 if [[ ! $MODRINTH_MODPACK ]]; then
   log "ERROR: MODRINTH_MODPACK must be set when using TYPE/MOD_PLATFORM of MODRINTH"
@@ -22,6 +23,10 @@ args=(
   --project="${MODRINTH_MODPACK}"
   --output-directory=/data
 )
+
+if [[ $MODRINTH_IGNORE_MISSING_FILES ]]; then
+  args+=(--ignore-missing-files "$MODRINTH_IGNORE_MISSING_FILES")
+fi
 
 case "${VERSION^^}" in
   LATEST)


### PR DESCRIPTION
Also
- Allow newline delimited (without commas) for MODRINTH_PROJECTS

- Resolves #2344
- Resolves #2351 by trimming whitespace around given whitelist/ops