### PR TITLE
Removing chmod g+w at start to tighten security

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,16 @@
 version: 2
 updates:
-  # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: pip
+    directory: "/docs"
+    schedule:
+      interval: weekly
+    groups:
+      patches:
+        patterns:
+          - "*"
+        update-types:
+          - patch

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,9 +1,9 @@
-mkdocs
-mkdocs-material-extensions
-mkdocs-material
-mkdocs-autorefs
-mkdocstrings
-mkdocs-literate-nav
-mdx-gh-links
-mkdocs-click
-mkdocs-static-i18n
+mkdocs == 1.5.2
+mkdocs-material-extensions == 1.1.1
+mkdocs-material == 9.2.5
+mkdocs-autorefs == 0.5.0
+mkdocstrings == 0.22.0
+mkdocs-literate-nav == 0.6.0
+mdx-gh-links == 0.3.1
+mkdocs-click == 0.8.0
+mkdocs-static-i18n == 1.0.2

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,12 +1,13 @@
 ---
 site_name: Minecraft Server on Docker (Java Edition)
-site_url: https://docker-minecraft-server.readthedocs.io/
+site_url: https://docker-minecraft-server.readthedocs.io/en/latest/
 site_description: Documentation for Minecraft Server on Docker
 repo_url: https://github.com/itzg/docker-minecraft-server
 edit_uri: blob/master/docs/
 theme:
   name: material
   features:
+    - navigation.tracking
     - navigation.tabs
     - navigation.tabs.sticky
     - navigation.sections

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,7 +7,6 @@ edit_uri: blob/master/docs/
 theme:
   name: material
   features:
-    - navigation.instant
     - navigation.tracking
     - navigation.tabs
     - navigation.tabs.sticky
@@ -54,9 +53,6 @@ copyright: Copyright &copy; itzg 2023.
 plugins:
   - search
   - autorefs
-  - literate-nav:
-      nav_file: README.md
-      implicit_index: true
   - mkdocstrings:
       handlers:
         python:
@@ -68,8 +64,11 @@ plugins:
             show_signature_annotations: true
   # https://github.com/ultrabug/mkdocs-static-i18n
   - i18n:
-      default_language: en
       languages:
-        en:
+        - locale: en
           name: English
           build: true
+          default: true
+  - literate-nav:
+      nav_file: README.md
+      implicit_index: true

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,7 +7,6 @@ edit_uri: blob/master/docs/
 theme:
   name: material
   features:
-    - navigation.tracking
     - navigation.tabs
     - navigation.tabs.sticky
     - navigation.sections

--- a/scripts/start
+++ b/scripts/start
@@ -8,7 +8,6 @@
 : "${GID:=1000}"
 
 umask 0002
-chmod g+w /data
 
 if isTrue "${ENABLE_RCON:-true}" && ! [ -v RCON_PASSWORD ] && ! [ -v RCON_PASSWORD_FILE ]; then
   RCON_PASSWORD=$(openssl rand -hex 12)


### PR DESCRIPTION
It should be the responsibility/choice of the volume creator or orchestration layer, [such as kubernetes fsGroup](https://kubernetes.io/docs/tasks/configure-pod-container/security-context), to alter the group-writability of the `/data` volume.

The existing operation would have needed to further consider the initial user/group of the container rather than just assuming it was root. This was observed [in an issue reported in Discord](https://discord.com/channels/660567679458869252/660569641550217327/1146207314290933902).