### PR TITLE
Add Oracle GraalVM to images

### DIFF
--- a/.github/workflows/build-multiarch.yml
+++ b/.github/workflows/build-multiarch.yml
@@ -43,6 +43,10 @@ jobs:
             baseImage: eclipse-temurin:20-jre-alpine
             platforms: linux/amd64
             mcVersion: 1.19.3
+          - variant: java20-oracle-graalvm
+            baseImage: container-registry.oracle.com/graalvm/jdk:20-ol8
+            platforms: linux/amd64,linux/arm64
+            mcVersion: 1.19.3
         # JAVA 17:
           - variant: java17
             # jammy doesn't work until minecraft updates to https://github.com/netty/netty/issues/12343
@@ -51,6 +55,10 @@ jobs:
             mcVersion: 1.18.2
           - variant: java17-graalvm-ce
             baseImage: ghcr.io/graalvm/graalvm-ce:ol8-java17
+            platforms: linux/amd64,linux/arm64
+            mcVersion: 1.18.2
+          - variant: java17-oracle-graalvm
+            baseImage: container-registry.oracle.com/graalvm/jdk:17-ol8
             platforms: linux/amd64,linux/arm64
             mcVersion: 1.18.2
           - variant: java17-jdk

--- a/.github/workflows/build-multiarch.yml
+++ b/.github/workflows/build-multiarch.yml
@@ -20,8 +20,10 @@ jobs:
         variant:
           - java20
           - java20-alpine
+          - java20-oracle-graalvm
           - java17
           - java17-graalvm-ce
+          - java17-oracle-graalvm
           - java17-jdk
           - java17-openj9
           - java17-alpine

--- a/.github/workflows/build-multiarch.yml
+++ b/.github/workflows/build-multiarch.yml
@@ -20,10 +20,9 @@ jobs:
         variant:
           - java20
           - java20-alpine
-          - java20-oracle-graalvm
+          - java20-graalvm
           - java17
-          - java17-graalvm-ce
-          - java17-oracle-graalvm
+          - java17-graalvm
           - java17-jdk
           - java17-openj9
           - java17-alpine
@@ -45,7 +44,7 @@ jobs:
             baseImage: eclipse-temurin:20-jre-alpine
             platforms: linux/amd64
             mcVersion: 1.19.3
-          - variant: java20-oracle-graalvm
+          - variant: java20-graalvm
             baseImage: container-registry.oracle.com/graalvm/jdk:20-ol8
             platforms: linux/amd64,linux/arm64
             mcVersion: 1.19.3
@@ -55,11 +54,7 @@ jobs:
             baseImage: eclipse-temurin:17-jre-focal
             platforms: linux/amd64,linux/arm/v7,linux/arm64
             mcVersion: 1.18.2
-          - variant: java17-graalvm-ce
-            baseImage: ghcr.io/graalvm/graalvm-ce:ol8-java17
-            platforms: linux/amd64,linux/arm64
-            mcVersion: 1.18.2
-          - variant: java17-oracle-graalvm
+          - variant: java17-graalvm
             baseImage: container-registry.oracle.com/graalvm/jdk:17-ol8
             platforms: linux/amd64,linux/arm64
             mcVersion: 1.18.2

--- a/build/ol/install-gosu.sh
+++ b/build/ol/install-gosu.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 if [[ $(uname -m) == "aarch64" ]]; then 
-    curl -sL -o /bin/gosu https://github.com/tianon/gosu/releases/download/1.14/gosu-arm64
+    curl -sL -o /bin/gosu https://github.com/tianon/gosu/releases/download/1.16/gosu-arm64
     chmod +x /bin/gosu
 elif [[ $(uname -m) == "x86_64" ]]; then 
-    curl -sL -o /bin/gosu https://github.com/tianon/gosu/releases/download/1.14/gosu-amd64
+    curl -sL -o /bin/gosu https://github.com/tianon/gosu/releases/download/1.16/gosu-amd64
     chmod +x /bin/gosu
 else
     echo "Not supported!"

--- a/build/ol/install-packages.sh
+++ b/build/ol/install-packages.sh
@@ -36,7 +36,9 @@ dnf install -y ImageMagick \
   zstd \
   lbzip2 \
   libpcap \
-  libwebp
+  libwebp \
+  findutils \
+  which
 
 bash /build/ol/install-gosu.sh
 

--- a/docs/versions/java.md
+++ b/docs/versions/java.md
@@ -13,27 +13,26 @@
 
 When using the image `itzg/minecraft-server` without a tag, the `latest` image tag is implied from the table below. To use a different version of Java, please use an alternate tag to run your Minecraft server container. The `stable` tag is similar to `latest`; however, it tracks [the most recent repository release/tag](https://github.com/itzg/docker-minecraft-server/releases/latest).
 
-| Tag name              | Java version | Linux  | JVM Type       | Architecture      |
-|-----------------------|--------------|--------|----------------|-------------------|
-| latest                | 17           | Ubuntu | Hotspot        | amd64,arm64,armv7 |
-| stable                | 17           | Ubuntu | Hotspot        | amd64,arm64,armv7 |
-| java8                 | 8            | Alpine | Hotspot        | amd64             |
-| java8-jdk             | 8            | Ubuntu | Hotspot+JDK    | amd64             |
-| java8-multiarch       | 8            | Ubuntu | Hotspot        | amd64,arm64,armv7 |
-| java8-openj9          | 8            | Debian | OpenJ9         | amd64             |
-| java8-graalvm-ce      | 8            | Oracle | GraalVM CE     | amd64             |
-| java11                | 11           | Ubuntu | Hotspot        | amd64,arm64,armv7 |
-| java11-jdk            | 11           | Ubuntu | Hotspot+JDK    | amd64,arm64,armv7 |
-| java11-openj9         | 11           | Debian | OpenJ9         | amd64             |
-| java17                | 17           | Ubuntu | Hotspot        | amd64,arm64,armv7 |
-| java17-jdk            | 17           | Ubuntu | Hotspot+JDK    | amd64,arm64,armv7 |
-| java17-openj9         | 17           | Debian | OpenJ9         | amd64             |
-| java17-graalvm-ce     | 17           | Oracle | GraalVM CE     | amd64,arm64       |
-| java17-oracle-graalvm | 17           | Oracle | Oracle GraalVM | amd64,arm64       |   
-| java17-alpine         | 17           | Alpine | Hotspot        | amd64             |
-| java20-alpine         | 20           | Alpine | Hotspot        | amd64             |
-| java20                | 20           | Ubuntu | Hotspot        | amd64,arm64       |
-| java20-oracle-graalvm | 20           | Oracle | Oracle GraalVM | amd64,arm64       |   
+| Tag name         | Java version | Linux  | JVM Type       | Architecture      |
+|------------------|--------------|--------|----------------|-------------------|
+| latest           | 17           | Ubuntu | Hotspot        | amd64,arm64,armv7 |
+| stable           | 17           | Ubuntu | Hotspot        | amd64,arm64,armv7 |
+| java8            | 8            | Alpine | Hotspot        | amd64             |
+| java8-jdk        | 8            | Ubuntu | Hotspot+JDK    | amd64             |
+| java8-multiarch  | 8            | Ubuntu | Hotspot        | amd64,arm64,armv7 |
+| java8-openj9     | 8            | Debian | OpenJ9         | amd64             |
+| java8-graalvm-ce | 8            | Oracle | GraalVM CE     | amd64             |
+| java11           | 11           | Ubuntu | Hotspot        | amd64,arm64,armv7 |
+| java11-jdk       | 11           | Ubuntu | Hotspot+JDK    | amd64,arm64,armv7 |
+| java11-openj9    | 11           | Debian | OpenJ9         | amd64             |
+| java17           | 17           | Ubuntu | Hotspot        | amd64,arm64,armv7 |
+| java17-jdk       | 17           | Ubuntu | Hotspot+JDK    | amd64,arm64,armv7 |
+| java17-openj9    | 17           | Debian | OpenJ9         | amd64             |
+| java17-graalvm   | 17           | Oracle | Oracle GraalVM | amd64,arm64       |   
+| java17-alpine    | 17           | Alpine | Hotspot        | amd64             |
+| java20-alpine    | 20           | Alpine | Hotspot        | amd64             |
+| java20           | 20           | Ubuntu | Hotspot        | amd64,arm64       |
+| java20-graalvm   | 20           | Oracle | Oracle GraalVM | amd64,arm64       |   
 
 For example, to use Java version 8 on any supported architecture:
 
@@ -55,3 +54,4 @@ The following image tags have been deprecated and are no longer receiving update
 - openj9-nightly
 - multiarch-latest
 - java16/java16-openj9
+- java17-graalvm-ce

--- a/docs/versions/java.md
+++ b/docs/versions/java.md
@@ -13,25 +13,27 @@
 
 When using the image `itzg/minecraft-server` without a tag, the `latest` image tag is implied from the table below. To use a different version of Java, please use an alternate tag to run your Minecraft server container. The `stable` tag is similar to `latest`; however, it tracks [the most recent repository release/tag](https://github.com/itzg/docker-minecraft-server/releases/latest).
 
-| Tag name          | Java version | Linux  | JVM Type    | Architecture      |
-|-------------------|--------------|--------|-------------|-------------------|
-| latest            | 17           | Ubuntu | Hotspot     | amd64,arm64,armv7 |
-| stable            | 17           | Ubuntu | Hotspot     | amd64,arm64,armv7 |
-| java8             | 8            | Alpine | Hotspot     | amd64             |
-| java8-jdk         | 8            | Ubuntu | Hotspot+JDK | amd64             |
-| java8-multiarch   | 8            | Ubuntu | Hotspot     | amd64,arm64,armv7 |
-| java8-openj9      | 8            | Debian | OpenJ9      | amd64             |
-| java8-graalvm-ce  | 8            | Oracle | GraalVM CE  | amd64             |
-| java11            | 11           | Ubuntu | Hotspot     | amd64,arm64,armv7 |
-| java11-jdk        | 11           | Ubuntu | Hotspot+JDK | amd64,arm64,armv7 |
-| java11-openj9     | 11           | Debian | OpenJ9      | amd64             |
-| java17            | 17           | Ubuntu | Hotspot     | amd64,arm64,armv7 |
-| java17-jdk        | 17           | Ubuntu | Hotspot+JDK | amd64,arm64,armv7 |
-| java17-openj9     | 17           | Debian | OpenJ9      | amd64             |
-| java17-graalvm-ce | 17           | Oracle | GraalVM CE  | amd64,arm64       |
-| java17-alpine     | 17           | Alpine | Hotspot     | amd64             |
-| java20-alpine     | 20           | Alpine | Hotspot     | amd64             |
-| java20            | 20           | Ubuntu | Hotspot     | amd64,arm64       |
+| Tag name              | Java version | Linux  | JVM Type       | Architecture      |
+|-----------------------|--------------|--------|----------------|-------------------|
+| latest                | 17           | Ubuntu | Hotspot        | amd64,arm64,armv7 |
+| stable                | 17           | Ubuntu | Hotspot        | amd64,arm64,armv7 |
+| java8                 | 8            | Alpine | Hotspot        | amd64             |
+| java8-jdk             | 8            | Ubuntu | Hotspot+JDK    | amd64             |
+| java8-multiarch       | 8            | Ubuntu | Hotspot        | amd64,arm64,armv7 |
+| java8-openj9          | 8            | Debian | OpenJ9         | amd64             |
+| java8-graalvm-ce      | 8            | Oracle | GraalVM CE     | amd64             |
+| java11                | 11           | Ubuntu | Hotspot        | amd64,arm64,armv7 |
+| java11-jdk            | 11           | Ubuntu | Hotspot+JDK    | amd64,arm64,armv7 |
+| java11-openj9         | 11           | Debian | OpenJ9         | amd64             |
+| java17                | 17           | Ubuntu | Hotspot        | amd64,arm64,armv7 |
+| java17-jdk            | 17           | Ubuntu | Hotspot+JDK    | amd64,arm64,armv7 |
+| java17-openj9         | 17           | Debian | OpenJ9         | amd64             |
+| java17-graalvm-ce     | 17           | Oracle | GraalVM CE     | amd64,arm64       |
+| java17-oracle-graalvm | 17           | Oracle | Oracle GraalVM | amd64,arm64       |   
+| java17-alpine         | 17           | Alpine | Hotspot        | amd64             |
+| java20-alpine         | 20           | Alpine | Hotspot        | amd64             |
+| java20                | 20           | Ubuntu | Hotspot        | amd64,arm64       |
+| java20-oracle-graalvm | 20           | Oracle | Oracle GraalVM | amd64,arm64       |   
 
 For example, to use Java version 8 on any supported architecture:
 


### PR DESCRIPTION
Oracle GraalVM (formerly GraalVM Enterprise) offers better performance and feature. Since renaming Oracle is allowing free use for production, and redistribution without cost*, so it would be nice to have it as option.
Available versions are:
- `java17-graalvm` with Java 17
- `java20-graalvm` with Java 20

With this PR, this version is getting deprecated:
- `java17-graalvm-ce` with Java 17

Also, I'm planning to upgrade GraalVM images to Oracle Linux 9 in near future. (Possibly after Java 8 is deprecated, since AFAIK Java 8 GraalVM image only has OL 7 and 8 images)

[*]: https://www.oracle.com/java/technologies/javase/jdk-faqs.html#GraalVM-licensing and https://www.oracle.com/downloads/licenses/graal-free-license.html