### PR TITLE
modrinth: provide dependencies download options

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN easy-add --var os=${TARGETOS} --var arch=${TARGETARCH}${TARGETVARIANT} \
   --var version=1.9.0 --var app=mc-server-runner --file {{.app}} \
   --from https://github.com/itzg/{{.app}}/releases/download/{{.version}}/{{.app}}_{{.version}}_{{.os}}_{{.arch}}.tar.gz
 
-ARG MC_HELPER_VERSION=1.35.1
+ARG MC_HELPER_VERSION=1.35.2
 ARG MC_HELPER_BASE_URL=https://github.com/itzg/mc-image-helper/releases/download/${MC_HELPER_VERSION}
 # used for cache busting local copy of mc-image-helper
 ARG MC_HELPER_REV=1

--- a/docs/misc/contributing/development.md
+++ b/docs/misc/contributing/development.md
@@ -83,6 +83,8 @@ cd build/distributions
 jwebserver -b 0.0.0.0 -p 8008
 ```
 
+If `jwebserver` is not available, try `java -m jdk.httpserver`
+
 ```shell
 --build-arg MC_HELPER_VERSION=1.8.1-SNAPSHOT \
 --build-arg MC_HELPER_BASE_URL=http://host.docker.internal:8008

--- a/docs/mods-and-plugins/modrinth.md
+++ b/docs/mods-and-plugins/modrinth.md
@@ -22,8 +22,8 @@
 
 ## Extra options
 
-`MODRINTH_DOWNLOAD_OPTIONAL_DEPENDENCIES`
-: Required dependencies of the project will _always_ be downloaded and optional dependencies can also be downloaded by setting this to `true`. The default is "true"
+`MODRINTH_DOWNLOAD_DEPENDENCIES`
+: Can be set to `none` (the default), `required`, or `optional` to download required and/or optional dependencies.
 
 `MODRINTH_ALLOWED_VERSION_TYPE`
 : The version type is used to determine the newest version to use from each project. The allowed values are `release` (default), `beta`, `alpha`.

--- a/scripts/start-setupModpack
+++ b/scripts/start-setupModpack
@@ -229,8 +229,12 @@ function handleGenericPacks() {
 
 function handleModrinthProjects() {
   : "${MODRINTH_PROJECTS:=}"
-  : "${MODRINTH_DOWNLOAD_OPTIONAL_DEPENDENCIES:=true}"
   : "${MODRINTH_ALLOWED_VERSION_TYPE:=release}"
+  : "${MODRINTH_DOWNLOAD_DEPENDENCIES:=none}"
+  if [[ -v MODRINTH_DOWNLOAD_OPTIONAL_DEPENDENCIES ]]; then
+    log "WARNING The variable MODRINTH_DOWNLOAD_OPTIONAL_DEPENDENCIES is removed."
+    log "        Use MODRINTH_DOWNLOAD_DEPENDENCIES=optional instead"
+  fi
 
   if [[ $MODRINTH_PROJECTS ]] && isFamily HYBRID FORGE FABRIC SPIGOT; then
     if isFamily HYBRID FORGE; then
@@ -246,7 +250,7 @@ function handleModrinthProjects() {
       --projects="${MODRINTH_PROJECTS}" \
       --game-version="${VERSION}" \
       --loader="$loader" \
-      --download-optional-dependencies="$MODRINTH_DOWNLOAD_OPTIONAL_DEPENDENCIES" \
+      --download-dependencies="$MODRINTH_DOWNLOAD_DEPENDENCIES" \
       --allowed-version-type="$MODRINTH_ALLOWED_VERSION_TYPE"
   fi
 }


### PR DESCRIPTION
Resolves #2356 

- Introduces `MODRINTH_DOWNLOAD_DEPENDENCIES` variable
- Deprecates `MODRINTH_DOWNLOAD_OPTIONAL_DEPENDENCIES`
- Pulls in https://github.com/itzg/mc-image-helper/pull/310