### PR TITLE
Fix a typo in the variable portion of the docs

### DIFF
--- a/docs/variables/index.md
+++ b/docs/variables/index.md
@@ -48,7 +48,7 @@ alternatively, you can mount: <code>/etc/localtime:/etc/localtime:ro
 
 /etc/timezone:/etc/timezone:ro</code>
             </td>
-            <td><code>1G</code></td>
+            <td><code>UTC</code></td>
             <td>⬜️</td>
         </tr>
         <tr>


### PR DESCRIPTION
Change the 1G default in the TZ section to be UTC