### PR TITLE
Update Minecraft Wiki links to new domain after fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -585,7 +585,7 @@ Configuration options with defaults:
 
 NAME}"
 
-> NOTE: instead of using format codes in the MOTD, Limbo requires [JSON chat content](https://minecraft.fandom.com/wiki/Raw_JSON_text_format#Java_Edition). If a plain string is provided, which is the default, then it gets converted into the required JSON structure. 
+> NOTE: instead of using format codes in the MOTD, Limbo requires [JSON chat content](https://minecraft.wiki/w/Raw_JSON_text_format#Java_Edition). If a plain string is provided, which is the default, then it gets converted into the required JSON structure. 
 
 ### Running a Crucible server
 
@@ -1090,7 +1090,7 @@ If you leave it off, a default is computed from the server type and version, suc
 
 That way you can easily differentiate between several servers you may have started.
 
-The section symbol (§) and other unicode characters are automatically converted to allow [formatting codes](https://minecraft.fandom.com/wiki/Formatting_codes) to be used consistently with all server versions. For example,
+The section symbol (§) and other unicode characters are automatically converted to allow [formatting codes](https://minecraft.wiki/w/Formatting_codes) to be used consistently with all server versions. For example,
 
      -e MOTD="A §l§cMinecraft§r §nserver"
 
@@ -1122,7 +1122,7 @@ To whitelist players for your Minecraft server, you can:
 - Provide the url or path to a whitelist file via `WHITELIST_FILE` environment variable  
   `docker run -d -e WHITELIST_FILE=/extra/whitelist.json ...`
 
-When either is set, [whitelisting of connecting users](https://minecraft.fandom.com/wiki/Server.properties#white-list) is enabled . If managing the list manually, `ENABLE_WHITELIST` can be set to "true" to set the `white-list` property.
+When either is set, [whitelisting of connecting users](https://minecraft.wiki/w/Server.properties#white-list) is enabled . If managing the list manually, `ENABLE_WHITELIST` can be set to "true" to set the `white-list` property.
 
 If whitelist configuration already exists, `WHITELIST_FILE` will not be retrieved and any usernames in `WHITELIST` are **added** to the whitelist configuration. You can enforce regeneration of the whitelist on each server startup by setting `OVERRIDE_WHITELIST` to "true". This will delete the whitelist file before processing whitelist configuration.
 
@@ -1132,7 +1132,7 @@ If whitelist configuration already exists, `WHITELIST_FILE` will not be retrieve
 
 > If running Minecraft 1.7.5 or earlier, these variables will apply to `white-list.txt`, with 1.7.6 implementing support for `whitelist.json`. Make sure your `WHITELIST_FILE` is in the appropriate format.
 
-To [enforce the whitelist changes immediately](https://minecraft.fandom.com/wiki/Server.properties#enforce-whitelist) when whitelist commands are used , set `ENFORCE_WHITELIST` to "true".
+To [enforce the whitelist changes immediately](https://minecraft.wiki/w/Server.properties#enforce-whitelist) when whitelist commands are used , set `ENFORCE_WHITELIST` to "true".
 
 ### Op/Administrator Players
 
@@ -1325,9 +1325,9 @@ environment variable set to `false`, such as
 ### Level Type and Generator Settings
 
 By default, a standard world is generated with hills, valleys, water, etc. A different level type can
-be configured by setting `LEVEL_TYPE` to [an expected type listed here](https://minecraft.fandom.com/wiki/Server.properties#level-type).
+be configured by setting `LEVEL_TYPE` to [an expected type listed here](https://minecraft.wiki/w/Server.properties#level-type).
 
-For some of the level types, `GENERATOR_SETTINGS` can be used to further customize the world generation [as described here](https://minecraft.fandom.com/wiki/Server.properties#generator-settings).
+For some of the level types, `GENERATOR_SETTINGS` can be used to further customize the world generation [as described here](https://minecraft.wiki/w/Server.properties#generator-settings).
 
 ### Custom Server Resource Pack
 

--- a/README.md
+++ b/README.md
@@ -1303,7 +1303,7 @@ If using a negative value for the seed, make sure to quote the value such as:
 
 By default, Minecraft servers are configured to run in Survival mode. You can
 change the mode using `MODE` where you can either provide the [standard
-numerical values](http://minecraft.gamepedia.com/Game_mode#Game_modes) or the
+numerical values](http://minecraft.wiki/Game_mode#Game_modes) or the
 shortcut values:
 
 - creative

--- a/docs/configuration/server-properties.md
+++ b/docs/configuration/server-properties.md
@@ -16,7 +16,7 @@ If you leave it off, a default is computed from the server type and version, suc
 
 That way you can easily differentiate between several servers you may have started.
 
-The section symbol (§) and other unicode characters are automatically converted to allow [formatting codes](https://minecraft.fandom.com/wiki/Formatting_codes) to be used consistently with all server versions. For example,
+The section symbol (§) and other unicode characters are automatically converted to allow [formatting codes](https://minecraft.wiki/w/Formatting_codes) to be used consistently with all server versions. For example,
 
      -e MOTD="A §l§cMinecraft§r §nserver"
 
@@ -62,7 +62,7 @@ To whitelist players for your Minecraft server, you can:
             user3
     ```
 
-When either is set, [whitelisting of connecting users](https://minecraft.fandom.com/wiki/Server.properties#white-list) is enabled.
+When either is set, [whitelisting of connecting users](https://minecraft.wiki/w/Server.properties#white-list) is enabled.
 
 To change the behavior when the whitelist file already exists, set the variable `EXISTING_WHITELIST_FILE` to one of the following options:
 
@@ -82,7 +82,7 @@ To change the behavior when the whitelist file already exists, set the variable 
 
     For versions prior to 1.7.3, `white-list.txt` will be maintained instead. Only usernames are supported for those versions.
 
-To [enforce the whitelist changes immediately](https://minecraft.fandom.com/wiki/Server.properties#enforce-whitelist) when whitelist commands are used , set `ENFORCE_WHITELIST` to "true". If managing the whitelist file manually, `ENABLE_WHITELIST` can be set to "true" to set the `white-list` property.
+To [enforce the whitelist changes immediately](https://minecraft.wiki/w/Server.properties#enforce-whitelist) when whitelist commands are used , set `ENFORCE_WHITELIST` to "true". If managing the whitelist file manually, `ENABLE_WHITELIST` can be set to "true" to set the `white-list` property.
 
 ### Op/Administrator Players
 
@@ -301,9 +301,9 @@ environment variable set to `false`, such as
 ### Level Type and Generator Settings
 
 By default, a standard world is generated with hills, valleys, water, etc. A different level type can
-be configured by setting `LEVEL_TYPE` to [an expected type listed here](https://minecraft.fandom.com/wiki/Server.properties#level-type).
+be configured by setting `LEVEL_TYPE` to [an expected type listed here](https://minecraft.wiki/w/Server.properties#level-type).
 
-For some of the level types, `GENERATOR_SETTINGS` can be used to further customize the world generation [as described here](https://minecraft.fandom.com/wiki/Server.properties#generator-settings).
+For some of the level types, `GENERATOR_SETTINGS` can be used to further customize the world generation [as described here](https://minecraft.wiki/w/Server.properties#generator-settings).
 
 ### Custom Server Resource Pack
 

--- a/docs/configuration/server-properties.md
+++ b/docs/configuration/server-properties.md
@@ -279,7 +279,7 @@ If using a negative value for the seed, make sure to quote the value such as:
 
 By default, Minecraft servers are configured to run in Survival mode. You can
 change the mode using `MODE` where you can either provide the [standard
-numerical values](http://minecraft.gamepedia.com/Game_mode#Game_modes) or the
+numerical values](http://minecraft.wiki/Game_mode#Game_modes) or the
 shortcut values:
 
 - creative

--- a/docs/types-and-platforms/server-types/others.md
+++ b/docs/types-and-platforms/server-types/others.md
@@ -37,7 +37,7 @@ Configuration options with defaults:
 
 !!! note
 
-    Instead of using format codes in the MOTD, Limbo requires [JSON chat content](https://minecraft.fandom.com/wiki/Raw_JSON_text_format#Java_Edition). If a plain string is provided, which is the default, then it gets converted into the required JSON structure. 
+    Instead of using format codes in the MOTD, Limbo requires [JSON chat content](https://minecraft.wiki/w/Raw_JSON_text_format#Java_Edition). If a plain string is provided, which is the default, then it gets converted into the required JSON structure. 
 
 ## Crucible
 

--- a/docs/variables/index.md
+++ b/docs/variables/index.md
@@ -260,7 +260,7 @@ alternatively, you can mount: <code>/etc/localtime:/etc/localtime:ro
         </tr>
         <tr>
             <td><code>MODE</code></td>
-            <td>Minecraft servers are configured to run in Survival mode by default. You can change the mode using MODE where you can either provide the <a href="http://minecraft.gamepedia.com/Game_mode#Game_modes">standard numerical values</a> or the shortcut values:<br />
+            <td>Minecraft servers are configured to run in Survival mode by default. You can change the mode using MODE where you can either provide the <a href="http://minecraft.wiki/Game_mode#Game_modes">standard numerical values</a> or the shortcut values:<br />
             <ul>
                 <li>creative</li>
                 <li>survival</li>

--- a/docs/variables/index.md
+++ b/docs/variables/index.md
@@ -278,14 +278,14 @@ alternatively, you can mount: <code>/etc/localtime:/etc/localtime:ro
         </tr>
         <tr>
             <td><code>LEVEL_TYPE</code></td>
-            <td>By default, a standard world is generated with hills, valleys, water, etc. A different level type can be configured by setting LEVEL_TYPE to <a href="https://minecraft.fandom.com/wiki/Server.properties#level-type">an expected type listed here</a>.
+            <td>By default, a standard world is generated with hills, valleys, water, etc. A different level type can be configured by setting LEVEL_TYPE to <a href="https://minecraft.wiki/w/Server.properties#level-type">an expected type listed here</a>.
             </td>
             <td><code>minecraft:default</code></td>
             <td>⬜️</td>
         </tr>
         <tr>
             <td><code>GENERATOR_SETTINGS</code></td>
-            <td>For some of the level types, <code>GENERATOR_SETTINGS</code> can be used to further customize the world generation <a href="https://minecraft.fandom.com/wiki/Server.properties#generator-settings">as described here</a>.</td>
+            <td>For some of the level types, <code>GENERATOR_SETTINGS</code> can be used to further customize the world generation <a href="https://minecraft.wiki/w/Server.properties#generator-settings">as described here</a>.</td>
             <td><code></code></td>
             <td>⬜️</td>
         </tr>

--- a/examples/multi-project/servers/mc-plugins/LuckPerms/config.yml
+++ b/examples/multi-project/servers/mc-plugins/LuckPerms/config.yml
@@ -706,5 +706,5 @@ update-client-command-list: true
 register-command-list-data: true
 
 # If LuckPerms should attempt to resolve Vanilla command target selectors for LP commands.
-# See here for more info: https://minecraft.gamepedia.com/Commands#Target_selectors
+# See here for more info: https://minecraft.wiki/Commands#Target_selectors
 resolve-command-selectors: false


### PR DESCRIPTION
The Minecraft Wiki maintainers have decided to move away from Fandom. More information can be found here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all the URLs to the new domain: minecraft.wiki