### PR TITLE
Added image variant for GraalVM Java 21

### DIFF
--- a/.github/workflows/build-multiarch.yml
+++ b/.github/workflows/build-multiarch.yml
@@ -35,6 +35,11 @@ jobs:
           - java11-openj9
           - java11-jdk
         include:
+        # JAVA 21:
+          - variant: java21-graalvm
+            baseImage: container-registry.oracle.com/graalvm/jdk:21-ol8
+            platforms: linux/amd64,linux/arm64
+            mcVersion: 1.20.2
         # JAVA 20:
           - variant: java20
             baseImage: eclipse-temurin:20-jre
@@ -43,10 +48,6 @@ jobs:
           - variant: java20-alpine
             baseImage: eclipse-temurin:20-jre-alpine
             platforms: linux/amd64
-            mcVersion: 1.19.3
-          - variant: java20-graalvm
-            baseImage: container-registry.oracle.com/graalvm/jdk:20-ol8
-            platforms: linux/amd64,linux/arm64
             mcVersion: 1.19.3
         # JAVA 17:
           - variant: java17

--- a/docs/versions/java.md
+++ b/docs/versions/java.md
@@ -32,7 +32,7 @@ When using the image `itzg/minecraft-server` without a tag, the `latest` image t
 | java17-alpine    | 17           | Alpine | Hotspot        | amd64             |
 | java20-alpine    | 20           | Alpine | Hotspot        | amd64             |
 | java20           | 20           | Ubuntu | Hotspot        | amd64,arm64       |
-| java20-graalvm   | 20           | Oracle | Oracle GraalVM | amd64,arm64       |   
+| java21-graalvm   | 21           | Oracle | Oracle GraalVM | amd64,arm64       |   
 
 For example, to use Java version 8 on any supported architecture:
 
@@ -55,3 +55,4 @@ The following image tags have been deprecated and are no longer receiving update
 - multiarch-latest
 - java16/java16-openj9
 - java17-graalvm-ce
+- java20-graalvm


### PR DESCRIPTION
Deprecates java20-graalvm since Java 20 is not LTS.