### PR TITLE
docs: refine deployment chapters and add section about Shulker

### DIFF
--- a/docs/misc/deployment/index.md
+++ b/docs/misc/deployment/index.md
@@ -1,11 +1,21 @@
 # More Deployment Info 
 
-## Using Helm
+## On Kubernetes
+
+### Using Helm
 
 - itzg Helm Chart:
     - [GitHub repo](https://github.com/itzg/minecraft-server-charts)
       - [Helm Chart repo](https://itzg.github.io/minecraft-server-charts/)
 - [mcsh/server-deployment](https://github.com/mcserverhosting-net/charts)
+
+### Using Shulker
+
+[Shulker](https://github.com/jeremylvln/Shulker) is a Kubernetes operator for managing complex and dynamic Minecraft infrastructures, including game servers and proxies. It uses the docker-minecraft-server and docker-bungeecord images under-the-hood.
+
+## On CloudFormation (AWS)
+
+If you're looking for a simple way to deploy this to the Amazon Web Services Cloud, check out the [Minecraft Server Deployment (CloudFormation) repository](https://github.com/vatertime/minecraft-spot-pricing). This repository contains a CloudFormation template that will get you up and running in AWS in a matter of minutes. Optionally it uses Spot Pricing so the server is very cheap, and you can easily turn it off when not in use.
 
 ## Supporting Articles
 
@@ -16,7 +26,3 @@ Below are supporting articles for server deployment.
     https://dev.to/rela-v/zero-to-minecraft-server-with-docker-desktop-and-compose-500a
 
     - This is a reference guide/tutorial on how to set up a vanilla Minecraft server using this project, including step-by-step instructions, and information on topics such as port-forwarding.
-
-## Deploying onto AWS
-
-If you're looking for a simple way to deploy this to the Amazon Web Services Cloud, check out the [Minecraft Server Deployment (CloudFormation) repository](https://github.com/vatertime/minecraft-spot-pricing). This repository contains a CloudFormation template that will get you up and running in AWS in a matter of minutes. Optionally it uses Spot Pricing so the server is very cheap, and you can easily turn it off when not in use.


### PR DESCRIPTION
I work since quite some time on a Kubernetes operator to manage flawlessly a dynamic Minecraft infrastructure (with proxies and servers working together). It uses the docker-minecraft-server and docker-bungeecord images under-the-hood and they are a huge time saver (thanks a lot!).

I found out that there was a new documentation website, so I took my chance to add a backlink to my work on the Deployment section.

I also refined a bit the chapters in this same section to group by deployment target (Kubernetes, AWS), so adding more in the future will be clearer.

Rendered documentation page (courtesy of ReadTheDocs): https://docker-minecraft-server--2454.org.readthedocs.build/en/2454/misc/deployment/#supporting-articles