### PR TITLE
auto-cf: exclude embeddium by default

### DIFF
--- a/files/cf-exclude-include.json
+++ b/files/cf-exclude-include.json
@@ -11,6 +11,7 @@
     "defensive-measures",
     "ding",
     "dynamiclights-reforged",
+    "embeddium",
     "enchantment-descriptions",
     "entity-texture-features-fabric",
     "entityculling",


### PR DESCRIPTION
For #2471

From the description it sounds like a client-side only mod:

> Embeddium is an unofficial fork of Sodium based off Rubidium, with additional changes and bugfixes to integrate it with the Forge modding ecosystem. 