### PR TITLE
Escape unicode in server.properties by default when less than 1.20

### DIFF
--- a/docs/configuration/server-properties.md
+++ b/docs/configuration/server-properties.md
@@ -26,7 +26,7 @@ renders
 
 !!! note "Escape unicode"
 
-    Some Minecraft versions and server types do not support unicode characters, such as §, in `server.properties`. In those cases, an extra "\u00C2" will appear in the file and the client will render those as Â characters. Unicode characters can be written as escaped codes by setting the environment variable `SERVER_PROPERTIES_ESCAPE_UNICODE` to "true".
+    For Minecraft versions less than 1.20, unicode characters in `server.properties` will be escaped as `\uXXXX`, by default. That behavior can be altered by setting `SERVER_PROPERTIES_ESCAPE_UNICODE` to "true" or "false".
 
 To produce a multi-line MOTD, embed a newline character as `\n` in the string, such as
 

--- a/scripts/start-setupServerProperties
+++ b/scripts/start-setupServerProperties
@@ -25,6 +25,7 @@ function customizeServerProps {
   # normalize MOTD
   if [[ ${TYPE^^} = LIMBO ]]; then
     if [[ $MOTD ]] && ! [[ $MOTD =~ ^{ ]]; then
+      # shellcheck disable=SC2089
       MOTD="{\"text\":\"${MOTD}\"}"
     fi
   fi
@@ -110,10 +111,16 @@ function customizeServerProps {
 
   setPropertiesArgs=(
     --definitions "/image/property-definitions.json"
-    --escape-unicode="${SERVER_PROPERTIES_ESCAPE_UNICODE:-false}"
   )
   if [[ -v CUSTOM_SERVER_PROPERTIES ]]; then
     setPropertiesArgs+=(--custom-properties "$CUSTOM_SERVER_PROPERTIES")
+  fi
+  if [[ -v SERVER_PROPERTIES_ESCAPE_UNICODE ]]; then
+    if isTrue "$SERVER_PROPERTIES_ESCAPE_UNICODE"; then
+      setPropertiesArgs+=(--escape-unicode)
+    fi
+  elif versionLessThan '1.20'; then
+    setPropertiesArgs+=(--escape-unicode)
   fi
 
   handleDebugMode


### PR DESCRIPTION
For #2478 