### PR TITLE
For Auto CurseForge etc, increase default connection pool acquire timeout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN easy-add --var os=${TARGETOS} --var arch=${TARGETARCH}${TARGETVARIANT} \
   --var version=1.9.1 --var app=mc-server-runner --file {{.app}} \
   --from https://github.com/itzg/{{.app}}/releases/download/{{.version}}/{{.app}}_{{.version}}_{{.os}}_{{.arch}}.tar.gz
 
-ARG MC_HELPER_VERSION=1.36.11
+ARG MC_HELPER_VERSION=1.36.12
 ARG MC_HELPER_BASE_URL=https://github.com/itzg/mc-image-helper/releases/download/${MC_HELPER_VERSION}
 # used for cache busting local copy of mc-image-helper
 ARG MC_HELPER_REV=1


### PR DESCRIPTION
Pulls in https://github.com/itzg/mc-image-helper/pull/346

Helps to resolve the following. To increase the timeout, set the env var `FETCH_CONNECTION_POOL_PENDING_ACQUIRE_TIMEOUT` to a larger duration such as "PT240S"

```
reactor.core.Exceptions$ReactiveException: reactor.netty.internal.shaded.reactor.pool.PoolAcquireTimeoutException: Pool#acquire(Duration) has been pending for more than the configured timeout of 45000ms
	at reactor.core.Exceptions.propagate(Exceptions.java:408)
	at reactor.core.publisher.BlockingSingleSubscriber.blockingGet(BlockingSingleSubscriber.java:101)
	at reactor.core.publisher.Mono.block(Mono.java:1712)
	at me.itzg.helpers.curseforge.CurseForgeInstaller.processModpack(CurseForgeInstaller.java:551)
	at me.itzg.helpers.curseforge.CurseForgeInstaller.resolveModpackFileAndProcess(CurseForgeInstaller.java:366)
	at me.itzg.helpers.curseforge.CurseForgeInstaller.installByRetrievingModpackZip(CurseForgeInstaller.java:234)
	at me.itzg.helpers.curseforge.CurseForgeInstaller.lambda$install$3(CurseForgeInstaller.java:164)
	at me.itzg.helpers.curseforge.CurseForgeInstaller.install(CurseForgeInstaller.java:200)
	at me.itzg.helpers.curseforge.CurseForgeInstaller.install(CurseForgeInstaller.java:163)
	at me.itzg.helpers.curseforge.InstallCurseForgeCommand.call(InstallCurseForgeCommand.java:214)
	at me.itzg.helpers.curseforge.InstallCurseForgeCommand.call(InstallCurseForgeCommand.java:29)
	at picocli.CommandLine.executeUserObject(CommandLine.java:2041)
	at picocli.CommandLine.access$1500(CommandLine.java:148)
	at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2461)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2453)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2415)
	at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:2273)
	at picocli.CommandLine$RunLast.execute(CommandLine.java:2417)
	at picocli.CommandLine.execute(CommandLine.java:2170)
	at me.itzg.helpers.McImageHelper.main(McImageHelper.java:157)
	Suppressed: java.lang.Exception: #block terminated with an error
		at reactor.core.publisher.BlockingSingleSubscriber.blockingGet(BlockingSingleSubscriber.java:103)
		... 18 common frames omitted
Caused by: reactor.netty.internal.shaded.reactor.pool.PoolAcquireTimeoutException: Pool#acquire(Duration) has been pending for more than the configured timeout of 45000ms
	at reactor.netty.internal.shaded.reactor.pool.AbstractPool$Borrower.run(AbstractPool.java:413)
	Suppressed: reactor.core.publisher.FluxOnAssembly$OnAssemblyException: 
Error has been observed at the following site(s):
	*__checkpoint ⇢ Downloading file from modpack 250898:3260763
Original Stack Trace:
		at reactor.netty.internal.shaded.reactor.pool.AbstractPool$Borrower.run(AbstractPool.java:413)
		at reactor.core.scheduler.SchedulerTask.call(SchedulerTask.java:68)
		at reactor.core.scheduler.SchedulerTask.call(SchedulerTask.java:28)
		at java.util.concurrent.FutureTask.run(FutureTask.java:266)
		at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180)
		at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293)
		at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
		at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
		at java.lang.Thread.run(Thread.java:748)
[init] ERROR failed to auto-install CurseForge modpack
```