### PR TITLE
Add Discord Release Notification

### DIFF
--- a/.github/workflows/discord.yml
+++ b/.github/workflows/discord.yml
@@ -10,7 +10,7 @@ on:
       - completed
 
 env:
- DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+  DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
 
 jobs:
   discord:
@@ -21,10 +21,10 @@ jobs:
         if: github.event_name == 'release' && github.event.action == 'published'
         uses: Ilshidur/action-discord@master
         with:
-         args: |
-           Github repo: [${{ github.repository }}](<${{ github.event.repository.html_url}}>)
-           Release: [${{ github.event.release.name }}](<${{ github.event.release.html_url }}>)
-           ${{ github.event.release.body }}
+          args: |
+            Github repo: [${{ github.repository }}](<${{ github.event.repository.html_url}}>)
+            Release: [${{ github.event.release.name }}](<${{ github.event.release.html_url }}>)
+            ${{ github.event.release.body }}
       - name: on-success
         if: github.event.workflow_run.conclusion == 'success'
         uses: Ilshidur/action-discord@master

--- a/.github/workflows/discord.yml
+++ b/.github/workflows/discord.yml
@@ -1,26 +1,45 @@
 name: Discord notifications
 
 on:
+  release:
+    types:
+      - published
   workflow_run:
-    workflows: ["ContinuousIntegration", "Build and Publish", "Build and publish multiarch" ]
+    workflows: ["Build and Publish"]
     types:
       - completed
 
 env:
-  DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+ DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
 
 jobs:
   discord:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: on-publish
+        if: github.event_name == 'release' && github.event.action == 'published'
+        uses: Ilshidur/action-discord@master
+        with:
+         args: |
+           Github repo: [${{ github.repository }}](<${{ github.event.repository.html_url}}>)
+           Release: [${{ github.event.release.name }}](<${{ github.event.release.html_url }}>)
+           ${{ github.event.release.body }}
       - name: on-success
-        if: ${{ github.event.workflow_run.conclusion == 'success' }}
+        if: github.event.workflow_run.conclusion == 'success'
         uses: Ilshidur/action-discord@master
         with:
-          args: "Github repo: ${{ github.repository }}\n- Branch: ${{ github.event.workflow_run.head_branch }}\n- [Link: to Actions](<${{ github.event.workflow_run.html_url }}>)\n- Status: 🎉  ${{ github.event.workflow_run.conclusion }}  🍏"
+          args: |
+            Github repo: ${{ github.repository }}
+            - Branch: ${{ github.event.workflow_run.head_branch }}
+            - [Link: to Actions](<${{ github.event.workflow_run.html_url }}>)
+            - Status: 🎉  ${{ github.event.workflow_run.conclusion }}  🍏
       - name: on-failure
-        if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+        if: github.event.workflow_run.conclusion == 'failure'
         uses: Ilshidur/action-discord@master
         with:
-          args: "Github repo: ${{ github.repository }}\n- Branch: ${{ github.event.workflow_run.head_branch }}\n- [Link: to Actions](<${{ github.event.workflow_run.html_url }}>)\n- Status: 🤔  ${{ github.event.workflow_run.conclusion }}  💣💥"
+          args: |
+            Github repo: ${{ github.repository }}
+            - Branch: ${{ github.event.workflow_run.head_branch }}
+            - [Link: to Actions](<${{ github.event.workflow_run.html_url }}>)
+            - Status: 🤔  ${{ github.event.workflow_run.conclusion }}  💣💥


### PR DESCRIPTION
Add an on-publish step to send a Discord notification when a release is published.

Additionally:
- removed old workflow names
- format the args a little nicer
- remove the redundant expression syntax on `if:`

I assume this will go to the `#ci` channel in Discord. Felt like `#releases` would make more sense, but I'm assuming that's just official Minecraft releases and integrated via Discord.