### PR TITLE
Cleanup discord release message

### DIFF
--- a/.github/workflows/discord.yml
+++ b/.github/workflows/discord.yml
@@ -22,13 +22,6 @@ jobs:
         uses: SethCohen/github-releases-to-discord@v1.13.1
         with:
           webhook_url: ${{ secrets.DISCORD_WEBHOOK }}
-      - name: on-publish
-        if: github.event_name == 'release' && github.event.action == 'published'
-        uses: kludge-cs/gitcord-release-changelogger@v3.0.0
-        with:
-          release-body: ${{ github.event.release.body }}
-          release-name: ${{ github.event.release.name }}
-          webhook-url: ${{ secrets.DISCORD_WEBHOOK }}
       - name: on-success
         if: github.event.workflow_run.conclusion == 'success'
         uses: Ilshidur/action-discord@master

--- a/.github/workflows/discord.yml
+++ b/.github/workflows/discord.yml
@@ -19,12 +19,16 @@ jobs:
     steps:
       - name: on-publish
         if: github.event_name == 'release' && github.event.action == 'published'
-        uses: Ilshidur/action-discord@master
+        uses: SethCohen/github-releases-to-discord@v1.13.1
         with:
-          args: |
-            Github repo: [${{ github.repository }}](<${{ github.event.repository.html_url}}>)
-            Release: [${{ github.event.release.name }}](<${{ github.event.release.html_url }}>)
-            ${{ github.event.release.body }}
+          webhook_url: ${{ secrets.DISCORD_WEBHOOK }}
+      - name: on-publish
+        if: github.event_name == 'release' && github.event.action == 'published'
+        uses: kludge-cs/gitcord-release-changelogger@v3.0.0
+        with:
+          release-body: ${{ github.event.release.body }}
+          release-name: ${{ github.event.release.name }}
+          webhook-url: ${{ secrets.DISCORD_WEBHOOK }}
       - name: on-success
         if: github.event.workflow_run.conclusion == 'success'
         uses: Ilshidur/action-discord@master


### PR DESCRIPTION
I played w/ a few actions and [github-releases-to-discord](https://github.com/marketplace/actions/github-releases-to-discord) looked the cleanest to me and has a couple other options if wanted. The only downside I saw was it doesn't cleanup HTML comments in the Release Body.  So when making a release it would be recommended to manually delete the HTML comment the "Generate release notes" button adds.  In the mean time, I'm going to submit an Issue/PR to that action to accommodate that scenario.