### PR TITLE
Support ketting hybrid server

### DIFF
--- a/docs/types-and-platforms/server-types/hybrids.md
+++ b/docs/types-and-platforms/server-types/hybrids.md
@@ -11,6 +11,19 @@ A [Magma](https://magmafoundation.org/) server, which is a combination of Forge 
 There are limited base versions supported, so you will also need to  set `VERSION`, such as "1.12.2", "1.16.5", etc.
 
 
+### Ketting
+
+A [Ketting](https://github.com/kettingpowered/Ketting-1-20-x) server, which is a alternative project of Magma 1.20+, can be used with
+
+    -e TYPE=KETTING
+
+There are limited base versions supported, so you will also need to  set `VERSION`, such as "1.20.2" or later.
+
+In addition, `FORGE_VERSION` and `KETTING_VERSION` must be specified. You can find the supported `FORGE_VERSION` in the [project page](https://github.com/kettingpowered/Ketting-1-20-x), and `KETTING_VERSION` in the [release page](https://github.com/kettingpowered/Ketting-1-20-x/releases).
+
+NOTE: The length of `KETTING_VERSION` is 8, not 7 since it is taken from an abbreviated git commit hash. The value can be found in a jar file link on an Assets section for each releases.
+
+
 ### Mohist
 
 A [Mohist](https://github.com/MohistMC/Mohist) server can be used with

--- a/docs/types-and-platforms/server-types/hybrids.md
+++ b/docs/types-and-platforms/server-types/hybrids.md
@@ -8,6 +8,8 @@ A [Magma](https://magmafoundation.org/) server, which is a combination of Forge 
 
 !!! note
 
+The Magma project [has benn terminated](https://git.magmafoundation.org/magmafoundation/magma-1-20-x/-/commit/4e7abe37403c47d09b74b77bcfc26a19b18f5891). Please use Ketting for 1.20.2+.
+
 There are limited base versions supported, so you will also need to  set `VERSION`, such as "1.12.2", "1.16.5", etc.
 
 
@@ -21,7 +23,9 @@ There are limited base versions supported, so you will also need to  set `VERSIO
 
 In addition, `FORGE_VERSION` and `KETTING_VERSION` must be specified. You can find the supported `FORGE_VERSION` in the [project page](https://github.com/kettingpowered/Ketting-1-20-x), and `KETTING_VERSION` in the [release page](https://github.com/kettingpowered/Ketting-1-20-x/releases).
 
-NOTE: The length of `KETTING_VERSION` is 8, not 7 since it is taken from an abbreviated git commit hash. The value can be found in a jar file link on an Assets section for each releases.
+!!! note
+
+The length of `KETTING_VERSION` is 8, not 7 since it is taken from an abbreviated git commit hash. The value can be found in a jar file link on an Assets section for each releases.
 
 
 ### Mohist

--- a/scripts/start-configuration
+++ b/scripts/start-configuration
@@ -234,6 +234,11 @@ case "${TYPE^^}" in
     exec "${SCRIPTS:-/}start-deployMagma" "$@"
   ;;
 
+  KETTING)
+    evaluateJavaCompatibilityForForge
+    exec "${SCRIPTS:-/}start-deployKetting" "$@"
+  ;;
+
   MOHIST)
     evaluateJavaCompatibilityForForge
     exec "${SCRIPTS:-/}start-deployMohist" "$@"

--- a/scripts/start-deployKetting
+++ b/scripts/start-deployKetting
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# shellcheck source=start-utils
+. "${SCRIPTS:-/}start-utils"
+isDebugging && set -x
+
+: "${FORGE_VERSION:=${FORGEVERSION:-RECOMMENDED}}"
+: "${KETTING_VERSION:=}"
+: "${KETTING_TAG:=${KETTING_VERSION:0:7}}"
+
+resolveVersion
+
+if ! downloadUrl="https://github.com/kettingpowered/Ketting-1-20-x/releases/download/${KETTING_TAG}/ketting-${VERSION}-${FORGE_VERSION}-${KETTING_VERSION}-server.jar"; then
+  log "ERROR failed to locate latest Ketting download for ${VERSION}. Is that version supported?"
+  exit 1
+fi
+
+if [[ $downloadUrl == null ]]; then
+  log "ERROR Ketting does not seem to be available for $VERSION"
+  exit 1
+fi
+
+if ! SERVER=$(get --output-filename --skip-up-to-date --output /data "$downloadUrl"); then
+  log "ERROR: failed to download Ketting server jar from $downloadUrl"
+  exit 1
+fi
+
+export SERVER
+export FAMILY=HYBRID
+
+exec "${SCRIPTS:-/}start-spiget" "$@"


### PR DESCRIPTION
Since maintaining of magma project [has been stopped](https://git.magmafoundation.org/magmafoundation/magma-1-20-x/-/commit/4e7abe37403c47d09b74b77bcfc26a19b18f5891), I will add a support Ketting server for MC 1.20.2+ hybrid server.