### PR TITLE
Add a support for magma maintained

### DIFF
--- a/docs/types-and-platforms/server-types/hybrids.md
+++ b/docs/types-and-platforms/server-types/hybrids.md
@@ -8,14 +8,24 @@ A [Magma](https://magmafoundation.org/) server, which is a combination of Forge 
 
 !!! note
 
-The Magma project [has benn terminated](https://git.magmafoundation.org/magmafoundation/magma-1-20-x/-/commit/4e7abe37403c47d09b74b77bcfc26a19b18f5891). Please use Ketting for 1.20.2+.
+The Magma project [has been terminated](https://git.magmafoundation.org/magmafoundation/magma-1-20-x/-/commit/4e7abe37403c47d09b74b77bcfc26a19b18f5891). Please use Magma Maintained for 1.12.2, 1.18.2, 1.19.3, and 1.20.1, or Ketting for 1.20.2+.
 
 There are limited base versions supported, so you will also need to  set `VERSION`, such as "1.12.2", "1.16.5", etc.
 
+### Magma Maintained
+A [Magma Maintained](https://github.com/magmamaintained/) server, which is a alternative project of Magma, can be used with
+
+    -e TYPE=MAGMA_MAINTAINED
+
+!!! note
+
+There are limited base versions supported, so you will also need to set `VERSION`, such as "1.12.2", "1.18.2", "1.19.3", or "1.20.1".
+
+In addition, `FORGE_VERSION` and `MAGMA_MAINTAINED_TAG` must be specified. You can find the supported `FORGE_VERSION` and `MAGMA_MAINTAINED_TAG` in a releases page for each repositories.
 
 ### Ketting
 
-A [Ketting](https://github.com/kettingpowered/Ketting-1-20-x) server, which is a alternative project of Magma 1.20+, can be used with
+A [Ketting](https://github.com/kettingpowered/Ketting-1-20-x) server, which is a alternative project of Magma 1.20.2+, can be used with
 
     -e TYPE=KETTING
 

--- a/docs/types-and-platforms/server-types/hybrids.md
+++ b/docs/types-and-platforms/server-types/hybrids.md
@@ -8,9 +8,9 @@ A [Magma](https://magmafoundation.org/) server, which is a combination of Forge 
 
 !!! note
 
-The Magma project [has been terminated](https://git.magmafoundation.org/magmafoundation/magma-1-20-x/-/commit/4e7abe37403c47d09b74b77bcfc26a19b18f5891). Please use Magma Maintained for 1.12.2, 1.18.2, 1.19.3, and 1.20.1, or Ketting for 1.20.2+.
+    The Magma project [has been terminated](https://git.magmafoundation.org/magmafoundation/magma-1-20-x/-/commit/4e7abe37403c47d09b74b77bcfc26a19b18f5891). Please use Magma Maintained for 1.12.2, 1.18.2, 1.19.3, and 1.20.1, or Ketting for 1.20.2+.
 
-There are limited base versions supported, so you will also need to  set `VERSION`, such as "1.12.2", "1.16.5", etc.
+    There are limited base versions supported, so you will also need to  set `VERSION`, such as "1.12.2", "1.16.5", etc.
 
 ### Magma Maintained
 A [Magma Maintained](https://github.com/magmamaintained/) server, which is a alternative project of Magma, can be used with
@@ -19,9 +19,9 @@ A [Magma Maintained](https://github.com/magmamaintained/) server, which is a alt
 
 !!! note
 
-There are limited base versions supported, so you will also need to set `VERSION`, such as "1.12.2", "1.18.2", "1.19.3", or "1.20.1".
+    There are limited base versions supported, so you will also need to set `VERSION`, such as "1.12.2", "1.18.2", "1.19.3", or "1.20.1".
 
-In addition, `FORGE_VERSION` and `MAGMA_MAINTAINED_TAG` must be specified. You can find the supported `FORGE_VERSION` and `MAGMA_MAINTAINED_TAG` in a releases page for each repositories.
+    In addition, `FORGE_VERSION` and `MAGMA_MAINTAINED_TAG` must be specified. You can find the supported `FORGE_VERSION` and `MAGMA_MAINTAINED_TAG` in a releases page for each repositories.
 
 ### Ketting
 
@@ -35,7 +35,7 @@ In addition, `FORGE_VERSION` and `KETTING_VERSION` must be specified. You can fi
 
 !!! note
 
-The length of `KETTING_VERSION` is 8, not 7 since it is taken from an abbreviated git commit hash. The value can be found in a jar file link on an Assets section for each releases.
+    The length of `KETTING_VERSION` is 8, not 7 since it is taken from an abbreviated git commit hash. The value can be found in a jar file link on an Assets section for each releases.
 
 
 ### Mohist
@@ -46,7 +46,7 @@ A [Mohist](https://github.com/MohistMC/Mohist) server can be used with
 
 !!! note
 
-There are limited base versions supported, so you will also need to  set `VERSION`, such as "1.12.2"
+    There are limited base versions supported, so you will also need to  set `VERSION`, such as "1.12.2"
 
 By default the latest build will be used; however, a specific build number can be selected by setting `MOHIST_BUILD`, such as
 

--- a/scripts/start-configuration
+++ b/scripts/start-configuration
@@ -234,6 +234,11 @@ case "${TYPE^^}" in
     exec "${SCRIPTS:-/}start-deployMagma" "$@"
   ;;
 
+  MAGMA_MAINTAINED)
+    evaluateJavaCompatibilityForForge
+    exec "${SCRIPTS:-/}start-deployMagmaMaintained" "$@"
+  ;;
+
   KETTING)
     evaluateJavaCompatibilityForForge
     exec "${SCRIPTS:-/}start-deployKetting" "$@"

--- a/scripts/start-deployMagmaMaintained
+++ b/scripts/start-deployMagmaMaintained
@@ -4,20 +4,27 @@
 . "${SCRIPTS:-/}start-utils"
 isDebugging && set -x
 
-: "${FORGE_VERSION:=${FORGEVERSION:-RECOMMENDED}}"
+: "${FORGE_VERSION:=}"
 : "${MAGMA_MAINTAINED_TAG:=}"
 
 resolveVersion
 
-if ! downloadUrl="https://github.com/magmamaintained/Magma-${VERSION}/releases/download/${MAGMA_MAINTAINED_TAG}/magma-${VERSION}-${FORGE_VERSION}-${MAGMA_MAINTAINED_TAG}-server.jar"; then
-  log "ERROR failed to locate latest Magma Maintained download for ${VERSION}, ${FORGE_VERSION}, and ${MAGMA_MAINTAINED_TAG}. Is that version supported?"
+if [ -z $VERSION ]; then
+  log "ERROR the variable VERSION is not specified"
   exit 1
 fi
 
-if [[ $downloadUrl == null ]]; then
-  log "ERROR Magma Maintained does not seem to be available for $VERSION"
+if [ -z $FORGE_VERSION ]; then
+  log "ERROR the variable FORGE_VERSION is not specified"
   exit 1
 fi
+
+if [ -z $MAGMA_MAINTAINED_TAG ]; then
+  log "ERROR the variable MAGMA_MAINTAINED_TAG is not specified"
+  exit 1
+fi
+
+downloadUrl="https://github.com/magmamaintained/Magma-${VERSION}/releases/download/${MAGMA_MAINTAINED_TAG}/magma-${VERSION}-${FORGE_VERSION}-${MAGMA_MAINTAINED_TAG}-server.jar"
 
 if ! SERVER=$(get --output-filename --skip-up-to-date --output /data "$downloadUrl"); then
   log "ERROR: failed to download Magma Maintained server jar from $downloadUrl"

--- a/scripts/start-deployMagmaMaintained
+++ b/scripts/start-deployMagmaMaintained
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# shellcheck source=start-utils
+. "${SCRIPTS:-/}start-utils"
+isDebugging && set -x
+
+: "${FORGE_VERSION:=${FORGEVERSION:-RECOMMENDED}}"
+: "${MAGMA_MAINTAINED_TAG:=}"
+
+resolveVersion
+
+if ! downloadUrl="https://github.com/magmamaintained/Magma-${VERSION}/releases/download/${MAGMA_MAINTAINED_TAG}/magma-${VERSION}-${FORGE_VERSION}-${MAGMA_MAINTAINED_TAG}-server.jar"; then
+  log "ERROR failed to locate latest Magma Maintained download for ${VERSION}, ${FORGE_VERSION}, and ${MAGMA_MAINTAINED_TAG}. Is that version supported?"
+  exit 1
+fi
+
+if [[ $downloadUrl == null ]]; then
+  log "ERROR Magma Maintained does not seem to be available for $VERSION"
+  exit 1
+fi
+
+if ! SERVER=$(get --output-filename --skip-up-to-date --output /data "$downloadUrl"); then
+  log "ERROR: failed to download Magma Maintained server jar from $downloadUrl"
+  exit 1
+fi
+
+export SERVER
+export FAMILY=HYBRID
+
+exec "${SCRIPTS:-/}start-spiget" "$@"


### PR DESCRIPTION
I have implemented a support for [Magma maintained](https://github.com/magmamaintained/) which is an alternative project for terminated Magma project. It supports a bit old versions of Minecraft "1.12.2", "1.18.2", "1.19.3", and "1.20.1".