### PR TITLE
Allow Remote Console to be Enabled

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN easy-add --var os=${TARGETOS} --var arch=${TARGETARCH}${TARGETVARIANT} \
   --var version=${MC_MONITOR_VERSION} --var app=mc-monitor --file {{.app}} \
   --from ${GITHUB_BASEURL}/itzg/{{.app}}/releases/download/{{.version}}/{{.app}}_{{.version}}_{{.os}}_{{.arch}}.tar.gz
 
-ARG MC_SERVER_RUNNER_VERSION=1.9.1
+ARG MC_SERVER_RUNNER_VERSION=1.10.0
 RUN easy-add --var os=${TARGETOS} --var arch=${TARGETARCH}${TARGETVARIANT} \
   --var version=${MC_SERVER_RUNNER_VERSION} --var app=mc-server-runner --file {{.app}} \
   --from ${GITHUB_BASEURL}/itzg/{{.app}}/releases/download/{{.version}}/{{.app}}_{{.version}}_{{.os}}_{{.arch}}.tar.gz

--- a/scripts/start-finalExec
+++ b/scripts/start-finalExec
@@ -236,6 +236,9 @@ mcServerRunnerArgs=(
 if [[ ${STOP_SERVER_ANNOUNCE_DELAY} ]]; then
   mcServerRunnerArgs+=(--stop-server-announce-delay "${STOP_SERVER_ANNOUNCE_DELAY}s")
 fi
+if isTrue "${ENABLE_SSH}"; then
+  mcServerRunnerArgs+=(--remote-console)
+fi
 
 if [[ ${TYPE} == "CURSEFORGE" && "${SERVER}" ]]; then
   copyFilesForCurseForge


### PR DESCRIPTION
## Purpose 

This enables the work that was started in the mc-server-runner pull request to add a remote SSH console. 
https://github.com/itzg/mc-server-runner/pull/56

- Updates mc-server-runner to 1.10.0
- Adds `ENABLE_SSH` setting 

## Validation Performed

Built the docker container locally on an ARM64 system (M1 Mac mini with an Ubuntu VM running docker). Started a (Fabric) server with ENABLE_SSH set and the 2222 port exposed. Was able to login from a standard ssh client and issue commands to it. Docker logs were checked and confirmed that the output was sent to both locations and I could audit SSH connections. 

Discovered that the default password of 'minecraft' is never usable with the container due to the configuration scripts generating a scrambled password when RCON_PASSWORD is not defined.

Checked to ensure that the server still works when ENABLE_SSH is not defined, and logs behave as expected.