### PR TITLE
Handle I/O timout type errors from autopause mc-monitor call

### DIFF
--- a/files/auto/autopause-fcns.sh
+++ b/files/auto/autopause-fcns.sh
@@ -24,7 +24,9 @@ java_clients_connections() {
   local connections
   if java_running ; then
     if ! connections=$(mc-monitor status --host localhost --port "$SERVER_PORT" --show-player-count); then
-      connections=0
+      # consider it a non-zero player count if the ping fails
+      # otherwise a laggy server with players connected could get paused
+      connections=1
     fi
   else
     connections=0


### PR DESCRIPTION
From [discussion in Discord](https://discord.com/channels/660567679458869252/660569755320844308/1198425036734865442)