### PR TITLE
Apply cap_net_raw to knockd to allow rootless execution

### DIFF
--- a/build/alpine/install-packages.sh
+++ b/build/alpine/install-packages.sh
@@ -26,9 +26,11 @@ apk add --no-cache -U \
     zstd \
     nfs-utils \
     libpcap \
-    libwebp
+    libwebp \
+    libcap-utils
 
 # Patched knockd
 curl -fsSL -o /tmp/knock.tar.gz https://github.com/Metalcape/knock/releases/download/0.8.1/knock-0.8.1-alpine-amd64.tar.gz
 tar -xf /tmp/knock.tar.gz -C /usr/local/ && rm /tmp/knock.tar.gz
 ln -s /usr/local/sbin/knockd /usr/sbin/knockd
+setcap cap_net_raw=ep /usr/local/sbin/knockd

--- a/build/ol/install-packages.sh
+++ b/build/ol/install-packages.sh
@@ -46,3 +46,4 @@ bash /build/ol/install-gosu.sh
 curl -fsSL -o /tmp/knock.tar.gz https://github.com/Metalcape/knock/releases/download/0.8.1/knock-0.8.1-$TARGET.tar.gz
 tar -xf /tmp/knock.tar.gz -C /usr/local/ && rm /tmp/knock.tar.gz
 ln -s /usr/local/sbin/knockd /usr/sbin/knockd
+setcap cap_net_raw=ep /usr/local/sbin/knockd

--- a/build/ubuntu/install-packages.sh
+++ b/build/ubuntu/install-packages.sh
@@ -35,4 +35,5 @@ apt-get clean
 curl -fsSL -o /tmp/knock.tar.gz https://github.com/Metalcape/knock/releases/download/0.8.1/knock-0.8.1-$TARGET.tar.gz
 tar -xf /tmp/knock.tar.gz -C /usr/local/ && rm /tmp/knock.tar.gz
 ln -s /usr/local/sbin/knockd /usr/sbin/knockd
+setcap cap_net_raw=ep /usr/local/sbin/knockd
 find /usr/lib -name 'libpcap.so.0.8' -execdir cp '{}' libpcap.so.1 \;


### PR DESCRIPTION
Resolves #2421