### PR TITLE
auto-cf: support modpack zips using IMPLODE compression method

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ RUN easy-add --var os=${TARGETOS} --var arch=${TARGETARCH}${TARGETVARIANT} \
   --var version=${MC_SERVER_RUNNER_VERSION} --var app=mc-server-runner --file {{.app}} \
   --from ${GITHUB_BASEURL}/itzg/{{.app}}/releases/download/{{.version}}/{{.app}}_{{.version}}_{{.os}}_{{.arch}}.tar.gz
 
-ARG MC_HELPER_VERSION=1.37.11
+ARG MC_HELPER_VERSION=1.37.12
 ARG MC_HELPER_BASE_URL=${GITHUB_BASEURL}/itzg/mc-image-helper/releases/download/${MC_HELPER_VERSION}
 # used for cache busting local copy of mc-image-helper
 ARG MC_HELPER_REV=1

--- a/docs/configuration/server-properties.md
+++ b/docs/configuration/server-properties.md
@@ -128,6 +128,11 @@ To change the behavior when the whitelist file already exists, set the variable 
 
 To [enforce the whitelist changes immediately](https://minecraft.wiki/w/Server.properties#enforce-whitelist) when whitelist commands are used , set `ENFORCE_WHITELIST` to "true". If managing the whitelist file manually, `ENABLE_WHITELIST` can be set to "true" to set the `white-list` property.
 
+!!! tip "Changing user API provider"
+
+    The usernames provided for whitelist and ops processing are resolved using either [PlayerDB](https://playerdb.co/) or [Mojang's API](https://wiki.vg/Mojang_API#Username_to_UUID). The default uses PlayerDB, but can be changed by setting the environment variable `USER_API_PROVIDER` to "mojang". Sometimes one or the other service can become overloaded, which is why there is the ability to switch providers.
+
+
 ### Op/Administrator Players
 
 Similar to the whitelist, users can be provisioned as operators (aka administrators) to your Minecraft server by


### PR DESCRIPTION
Resolves https://github.com/itzg/docker-minecraft-server/issues/2645

Observed with https://www.curseforge.com/minecraft/modpacks/age-of-engineering/files/2503175

Also
- adds and uses by default the PlayerDB API for resolving whitelist and ops. Pulls in https://github.com/itzg/mc-image-helper/pull/393