### PR TITLE
auto-cf: add option to ignore files missing from previous installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ RUN easy-add --var os=${TARGETOS} --var arch=${TARGETARCH}${TARGETVARIANT} \
   --var version=${MC_SERVER_RUNNER_VERSION} --var app=mc-server-runner --file {{.app}} \
   --from ${GITHUB_BASEURL}/itzg/{{.app}}/releases/download/{{.version}}/{{.app}}_{{.version}}_{{.os}}_{{.arch}}.tar.gz
 
-ARG MC_HELPER_VERSION=1.37.12
+ARG MC_HELPER_VERSION=1.37.13
 ARG MC_HELPER_BASE_URL=${GITHUB_BASEURL}/itzg/mc-image-helper/releases/download/${MC_HELPER_VERSION}
 # used for cache busting local copy of mc-image-helper
 ARG MC_HELPER_REV=1

--- a/docs/types-and-platforms/mod-platforms/auto-curseforge.md
+++ b/docs/types-and-platforms/mod-platforms/auto-curseforge.md
@@ -207,12 +207,36 @@ Ant-style paths can include the following globbing/wildcard symbols:
 ## World/Level Data
 
 Some modpacks come with world/save data via a worlds file and/or the overrides provided with the modpack. Either approach can be selected to set the `LEVEL` to the resulting saves directory by setting `CF_SET_LEVEL_FROM` to either:
+
 - `WORLD_FILE`
 - `OVERRIDES`
+
+## Ignore missing files
+
+Some mods use temporary files from the modpack and delete them when finished. Others will patch themselves and "disable" the original mod jar, such as gregtech. In order to avoid the installer from detecting the absent file(s) and re-installing, those files can be ignored by passing a comma or newline delimited list to `CF_IGNORE_MISSING_FILES`.
+
+!!! hint
+
+    A warning log will indicate what files were found to be missing from the previous installation run, such as
+
+    ```
+    Re-installing due to missing files from modpack: [mods/gregtech-2.6.2-beta.jar]
+    ```
+
+!!! example
+
+    In a Compose file
+    ```yaml
+      environment:
+        CF_IGNORE_MISSING_FILES: |
+          mods/gregtech-2.6.2-beta.jar
+    ```
+
 
 ## Extra options
 
 Other configuration available:
+
 - `CF_PARALLEL_DOWNLOADS` (default is 4): specify how many parallel mod downloads to perform
 - `CF_OVERRIDES_SKIP_EXISTING` (default is false): if set, files in the overrides that already exist in the data directory are skipped. **NOTE** world data is always skipped, if present.
 - `CF_FORCE_REINSTALL_MODLOADER` (default is false): this can be set to `true` to force the modpack's declared modloader, such as Forge, to be reinstalled. This is useful if some of the modloader's files become corrupted.

--- a/scripts/start-deployAutoCF
+++ b/scripts/start-deployAutoCF
@@ -11,6 +11,7 @@ set -eu
 : "${CF_PARALLEL_DOWNLOADS:=4}"
 : "${CF_FORCE_SYNCHRONIZE:=false}"
 : "${CF_FORCE_REINSTALL_MODLOADER:=false}"
+: "${CF_IGNORE_MISSING_FILES:=}"
 : "${CF_EXCLUDE_INCLUDE_FILE=https://raw.githubusercontent.com/itzg/docker-minecraft-server/master/files/cf-exclude-include.json}"
 : "${CF_EXCLUDE_MODS:=}"
 : "${CF_FORCE_INCLUDE_MODS:=}"
@@ -49,6 +50,9 @@ if [[ ${CF_SET_LEVEL_FROM} ]]; then
 fi
 if [[ ${CF_OVERRIDES_EXCLUSIONS} ]]; then
   args+=(--overrides-exclusions="$CF_OVERRIDES_EXCLUSIONS")
+fi
+if [[ ${CF_IGNORE_MISSING_FILES} ]]; then
+  args+=(--ignore-missing-files="$CF_IGNORE_MISSING_FILES")
 fi
 args+=(
   --force-synchronize="$CF_FORCE_SYNCHRONIZE"


### PR DESCRIPTION
[Discussed in Discord](https://discord.com/channels/660567679458869252/660569641550217327/1205669805684949022)

Modpack https://www.curseforge.com/minecraft/modpacks/nomi-ceu/files/4724273 was patching gregtech at startup

Pulls in https://github.com/itzg/mc-image-helper/pull/395