### PR TITLE
feat: force include just-enough-resources-jer for create-arcane-engineering modpack

### DIFF
--- a/files/cf-exclude-include.json
+++ b/files/cf-exclude-include.json
@@ -51,14 +51,13 @@
   ],
   "modpacks": {
     "all-of-fabric-6": {
-      "forceIncludes": [
-        "revelationary"
-      ]
+      "forceIncludes": ["revelationary"]
     },
     "valhelsia-5": {
-      "excludes": [
-        "modernfix"
-      ]
+      "excludes": ["modernfix"]
+    },
+    "create-arcane-engineering": {
+      "forceIncludes": ["just-enough-resources-jer"]
     }
   }
 }


### PR DESCRIPTION
When creating a server for [create-arcane-engineering modpack](https://www.curseforge.com/minecraft/modpacks/create-arcane-engineering) I had to force include [just-enough-resources-jer](https://www.curseforge.com/minecraft/mc-mods/just-enough-resources-jer).
Here is a PR to add this to the defaults if you wish to, so that it's easier for people that might encounter the same issue :)