### PR TITLE
fix: Remove EXTAR_ARGS quotes to allow multiple args (fixes #2715)

### DIFF
--- a/scripts/start-finalExec
+++ b/scripts/start-finalExec
@@ -297,7 +297,7 @@ elif [[ $SERVER =~ run.sh ]]; then
   if isTrue "${DEBUG_EXEC}"; then
     set -x
   fi
-  exec mc-server-runner "${mcServerRunnerArgs[@]}" --shell bash "${SERVER}" "${EXTRA_ARGS}"
+  exec mc-server-runner "${mcServerRunnerArgs[@]}" --shell bash "${SERVER}" $EXTRA_ARGS
 else
   # If we have a bootstrap.txt file... feed that in to the server stdin
   if [ -f /data/bootstrap.txt ]; then


### PR DESCRIPTION
Tested it works. The '' quotes are gone and args are standalone

```
[init] Using Forge supplied run.sh script...
+ exec mc-server-runner --stop-duration 60s --shell bash run.sh --universe /data/worlds
```