### PR TITLE
ADD : Tailscale docker-compose yml example

### DIFF
--- a/examples/docker-compose-tailscale.yml
+++ b/examples/docker-compose-tailscale.yml
@@ -9,7 +9,7 @@ services:
       TS_STATE_DIR: "/var/lib/tailscale"
       TS_USERSPACE: "FALSE" # If not using Auto-pause it can be set as true
     volumes:
-      - ${PWD}/ts-minecraft/state:/var/lib/tailscale
+      - ./ts-minecraft/state:/var/lib/tailscale
       - /dev/net/tun:/dev/net/tun
     cap_add:
       - net_admin

--- a/examples/docker-compose-tailscale.yml
+++ b/examples/docker-compose-tailscale.yml
@@ -1,0 +1,36 @@
+version: "3"
+services:
+  tailscale-client:
+    image: tailscale/tailscale:latest
+    container_name: tailscale
+    hostname: tailscale-minecraft # This name will be the one on the tailscale network
+    environment:
+      TS_AUTHKEY: "tskey-auth-PLACE-YOUR-KEY-HERE"
+      TS_STATE_DIR: "/var/lib/tailscale"
+      TS_USERSPACE: "FALSE" # If not using Auto-pause it can be set as true
+    volumes:
+      - ${PWD}/ts-minecraft/state:/var/lib/tailscale
+      - /dev/net/tun:/dev/net/tun
+    cap_add:
+      - net_admin
+      - sys_module
+    restart: unless-stopped
+    # ports: # Not needed, tailscale is directly linking to the container.
+      # - "25565:25565"
+  minecraft-server:
+    image: itzg/minecraft-server
+    network_mode: container:tailscale
+    stdin_open: true
+    tty: true
+    environment:
+      EULA: "TRUE"
+      # ENABLE_AUTOPAUSE: "TRUE"
+      # AUTOPAUSE_KNOCK_INTERFACE: "tailscale0"
+      # MAX_TICK_TIME: "-1"
+    volumes:
+      - minecraftserver:/data
+    restart: unless-stopped
+
+    
+volumes:
+  minecraftserver:


### PR DESCRIPTION
Added a docker-compose.yml example for creating a minecraft server using tailscale, as suggested in #2744 