### PR TITLE
Designate java21 as the latest/default image

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -11,9 +11,9 @@ body:
         
         Please double check some things first:
         1. Do you just have a question about something? If so, asking in the [Q&A Discussions](https://github.com/itzg/docker-minecraft-server/discussions/categories/q-a) or asking on [the Discord server](https://discord.gg/DXfKpjB) would be best.
-        2. Did you re-pull the newest image using `docker pull`? 
-        3. Is this bug happening after the `[init]` prefixed logs and after the log that says "Starting the Minecraft server"? If so, please report the bug with Mojang or the respective server provider.
-        4. Are you seeing a performance problem? If so, that is typically outside the scope of the image setup mechanims. Ask a question as above or contact the respective server provider.
+        2. Did you **re-pull the newest image** and confirmed the issue after that? Run `docker pull <image>` or if using a compose file, it's as easy as running `docker compose pull`. If using Kubernetes, add `imagePullPolicy: Always` to the container. 
+        4. Is this bug happening after the `[init]` prefixed logs and after the log that says "Starting the Minecraft server"? If so, please report the bug with Mojang or the respective server provider.
+        5. Are you seeing a performance problem? If so, that is typically outside the scope of this image. Ask a question as above or contact the respective server provider.
   - type: textarea
     id: problem
     attributes:

--- a/.github/workflows/build-multiarch.yml
+++ b/.github/workflows/build-multiarch.yml
@@ -107,8 +107,8 @@ jobs:
     env:
       IMAGE_TO_TEST: ${{ github.repository_owner }}/minecraft-server:test-${{ matrix.variant }}-${{ github.run_id }}
       HAS_IMAGE_REPO_ACCESS: ${{ secrets.DOCKER_USER != '' && secrets.DOCKER_PASSWORD != '' }}
-      MAIN_VARIANT: java17
-    runs-on: ubuntu-20.04
+      MAIN_VARIANT: java21
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.2

--- a/.github/workflows/stale-check.yml
+++ b/.github/workflows/stale-check.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   check:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     permissions:
       issues: write
       pull-requests: write

--- a/.github/workflows/verify-pr.yml
+++ b/.github/workflows/verify-pr.yml
@@ -42,7 +42,7 @@ jobs:
             mcVersion: 1.12.2
     env:
       IMAGE_TO_TEST: ${{ github.repository_owner }}/minecraft-server:test-${{ matrix.variant }}-${{ github.run_id }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.2


### PR DESCRIPTION
Resolves #2756

Also switches github actions runner to ubuntu-22.04