### PR TITLE
paper: fall back to VERSION env var when jar missing metadata

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ RUN easy-add --var os=${TARGETOS} --var arch=${TARGETARCH}${TARGETVARIANT} \
   --var version=${MC_SERVER_RUNNER_VERSION} --var app=mc-server-runner --file {{.app}} \
   --from ${GITHUB_BASEURL}/itzg/{{.app}}/releases/download/{{.version}}/{{.app}}_{{.version}}_{{.os}}_{{.arch}}.tar.gz
 
-ARG MC_HELPER_VERSION=1.38.12
+ARG MC_HELPER_VERSION=1.38.13
 ARG MC_HELPER_BASE_URL=${GITHUB_BASEURL}/itzg/mc-image-helper/releases/download/${MC_HELPER_VERSION}
 # used for cache busting local copy of mc-image-helper
 ARG MC_HELPER_REV=1

--- a/scripts/start-setupRbac
+++ b/scripts/start-setupRbac
@@ -42,12 +42,18 @@ if [[ -v OPS_FILE ]]; then
 fi
 if [[ -v OPS ]]; then
   args=()
-  if isTrue "${APPEND_OPS:-false}" || isFalse "${OVERRIDE_OPS:-true}"; then
-    args+=(--append-only)
-  fi
   existing="$EXISTING_OPS_FILE"
+  # Working with an OPS list, so normalize the value to a "non-file" mode
   if [[ "$EXISTING_OPS_FILE" = SYNC_FILE_MERGE_LIST ]]; then
     existing=MERGE
+  fi
+  # legacy option
+  if [[ -v APPEND_OPS ]] && isTrue "${APPEND_OPS}"; then
+    existing=MERGE
+  fi
+  # legacy option
+  if [[ -v OVERRIDE_OPS ]] && isFalse "${OVERRIDE_OPS}"; then
+    existing=SKIP
   fi
   # shellcheck disable=SC2086
   mc-image-helper manage-users \


### PR DESCRIPTION
Follow up to #2797  and pulls in https://github.com/itzg/mc-image-helper/pull/422