### PR TITLE
Add mc_health_extra_args to autopause-fcns.sh functions

### DIFF
--- a/files/auto/autopause-fcns.sh
+++ b/files/auto/autopause-fcns.sh
@@ -17,13 +17,13 @@ rcon_client_exists() {
 }
 
 mc_server_listening() {
-  mc-monitor status --host localhost --port "$SERVER_PORT" --timeout 10s >& /dev/null
+  mc-monitor status "${MC_HEALTH_EXTRA_ARGS[@]}" --host localhost --port "$SERVER_PORT" --timeout 10s >& /dev/null
 }
 
 java_clients_connections() {
   local connections
   if java_running ; then
-    if ! connections=$(mc-monitor status --host localhost --port "$SERVER_PORT" --show-player-count); then
+    if ! connections=$(mc-monitor status "${MC_HEALTH_EXTRA_ARGS[@]}" --host localhost --port "$SERVER_PORT" --show-player-count); then
       # consider it a non-zero player count if the ping fails
       # otherwise a laggy server with players connected could get paused
       connections=1


### PR DESCRIPTION
This adds ability that was non-working in issue #2828, allowing for use of undocumented environment variable MC_HEALTH_EXTRA_ARGS setting.

This functionality was originally in bin/mc-health but not in autopause-fcns.sh which is used to autostop and autopause, and which was non-working when for example proxy protocol acceptance was enabled in Paper.