### PR TITLE
build: upgrading git-lfs from packagecloud

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN easy-add --var os=${TARGETOS} --var arch=${TARGETARCH}${TARGETVARIANT} \
   --var version=${RESTIFY_VERSION} --var app=restify --file {{.app}} \
   --from ${GITHUB_BASEURL}/itzg/{{.app}}/releases/download/{{.version}}/{{.app}}_{{.version}}_{{.os}}_{{.arch}}.tar.gz
 
-ARG RCON_CLI_VERSION=1.6.4
+ARG RCON_CLI_VERSION=1.6.6
 RUN easy-add --var os=${TARGETOS} --var arch=${TARGETARCH}${TARGETVARIANT} \
   --var version=${RCON_CLI_VERSION} --var app=rcon-cli --file {{.app}} \
   --from ${GITHUB_BASEURL}/itzg/{{.app}}/releases/download/{{.version}}/{{.app}}_{{.version}}_{{.os}}_{{.arch}}.tar.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ EXPOSE 25565
 ARG APPS_REV=1
 ARG GITHUB_BASEURL=https://github.com
 
-ARG EASY_ADD_VERSION=0.8.4
+ARG EASY_ADD_VERSION=0.8.5
 ADD ${GITHUB_BASEURL}/itzg/easy-add/releases/download/${EASY_ADD_VERSION}/easy-add_${TARGETOS}_${TARGETARCH}${TARGETVARIANT} /usr/bin/easy-add
 RUN chmod +x /usr/bin/easy-add
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,14 +9,12 @@ ARG TARGETOS
 ARG TARGETARCH
 ARG TARGETVARIANT
 
-# CI system should set this to a hash or git revision of the build directory and it's contents to
-# ensure consistent cache updates.
-ARG BUILD_FILES_REV=1
+ARG FORCE_INSTALL_PACKAGES=1
 RUN --mount=target=/build,source=build \
-    REV=${BUILD_FILES_REV} TARGET=${TARGETARCH}${TARGETVARIANT} /build/run.sh install-packages
+    TARGET=${TARGETARCH}${TARGETVARIANT} /build/run.sh install-packages
 
 RUN --mount=target=/build,source=build \
-    REV=${BUILD_FILES_REV} /build/run.sh setup-user
+    /build/run.sh setup-user
 
 COPY --chmod=644 files/sudoers* /etc/sudoers.d
 

--- a/build/alpine/install-packages.sh
+++ b/build/alpine/install-packages.sh
@@ -16,7 +16,6 @@ apk add --no-cache -U \
     bash \
     curl iputils \
     git \
-    git-lfs \
     jq \
     mysql-client \
     tzdata \

--- a/build/ol/install-packages.sh
+++ b/build/ol/install-packages.sh
@@ -25,7 +25,6 @@ dnf install -y ImageMagick \
   iputils \
   curl \
   git \
-  git-lfs \
   jq \
   dos2unix \
   mysql \

--- a/build/ubuntu/install-packages.sh
+++ b/build/ubuntu/install-packages.sh
@@ -16,7 +16,6 @@ apt-get install -y \
   iputils-ping \
   curl \
   git \
-  git-lfs \
   jq \
   dos2unix \
   mysql-client \


### PR DESCRIPTION
Removing git-lfs for now due to numerous CVEs including two critical:

```
## Packages and Vulnerabilities

   2C    29H     0M     0L  stdlib 1.18.1
pkg:golang/stdlib@1.18.1

19: sha256:5c0fc48456768933513e10c645395539cfbe17f461f134498e8bfab06907dc4a
/usr/bin/git-lfs (evident by)

    x CRITICAL CVE-2023-24540
      https://scout.docker.com/v/CVE-2023-24540
      Affected range : <1.19.9
      Fixed version  : 1.19.9

    x CRITICAL CVE-2023-24538
      https://scout.docker.com/v/CVE-2023-24538
      Affected range : <1.19.8
      Fixed version  : 1.19.8

    x HIGH CVE-2023-29403
      https://scout.docker.com/v/CVE-2023-29403
      Affected range : <1.19.10
      Fixed version  : 1.19.10

    x HIGH CVE-2022-30580
      https://scout.docker.com/v/CVE-2022-30580
      Affected range : >=1.18.0-0
                     : <1.18.3
      Fixed version  : 1.18.3

    x HIGH CVE-2023-45287
      https://scout.docker.com/v/CVE-2023-45287
      Affected range : <1.20.0
      Fixed version  : 1.20.0

    x HIGH CVE-2023-45283
      https://scout.docker.com/v/CVE-2023-45283
      Affected range : <1.20.11
      Fixed version  : 1.20.11

    x HIGH CVE-2023-39325
      https://scout.docker.com/v/CVE-2023-39325
      Affected range : <1.20.10
      Fixed version  : 1.20.10

    x HIGH CVE-2023-24537
      https://scout.docker.com/v/CVE-2023-24537
      Affected range : <1.19.8
      Fixed version  : 1.19.8

    x HIGH CVE-2023-24536
      https://scout.docker.com/v/CVE-2023-24536
      Affected range : <1.19.8
      Fixed version  : 1.19.8

    x HIGH CVE-2023-24534
      https://scout.docker.com/v/CVE-2023-24534
      Affected range : <1.19.8
      Fixed version  : 1.19.8

    x HIGH CVE-2022-41725
      https://scout.docker.com/v/CVE-2022-41725
      Affected range : <1.19.6
      Fixed version  : 1.19.6

    x HIGH CVE-2022-41724
      https://scout.docker.com/v/CVE-2022-41724
      Affected range : <1.19.6
      Fixed version  : 1.19.6

    x HIGH CVE-2022-41723
      https://scout.docker.com/v/CVE-2022-41723
      Affected range : <1.19.6
      Fixed version  : 1.19.6

    x HIGH CVE-2022-41722
      https://scout.docker.com/v/CVE-2022-41722
      Affected range : <1.19.6
      Fixed version  : 1.19.6

    x HIGH CVE-2022-41720
      https://scout.docker.com/v/CVE-2022-41720
      Affected range : <1.18.9
      Fixed version  : 1.18.9

    x HIGH CVE-2022-41716
      https://scout.docker.com/v/CVE-2022-41716
      Affected range : <1.18.8
      Fixed version  : 1.18.8

    x HIGH CVE-2022-41715
      https://scout.docker.com/v/CVE-2022-41715
      Affected range : <1.18.7
      Fixed version  : 1.18.7

    x HIGH CVE-2022-32189
      https://scout.docker.com/v/CVE-2022-32189
      Affected range : >=1.18.0-0
                     : <1.18.5
      Fixed version  : 1.18.5

    x HIGH CVE-2022-30635
      https://scout.docker.com/v/CVE-2022-30635
      Affected range : >=1.18.0-0
                     : <1.18.4
      Fixed version  : 1.18.4

    x HIGH CVE-2022-30634
      https://scout.docker.com/v/CVE-2022-30634
      Affected range : >=1.18.0-0
                     : <1.18.3
      Fixed version  : 1.18.3

    x HIGH CVE-2022-30633
      https://scout.docker.com/v/CVE-2022-30633
      Affected range : >=1.18.0-0
                     : <1.18.4
      Fixed version  : 1.18.4

    x HIGH CVE-2022-30632
      https://scout.docker.com/v/CVE-2022-30632
      Affected range : >=1.18.0-0
                     : <1.18.4
      Fixed version  : 1.18.4

    x HIGH CVE-2022-30631
      https://scout.docker.com/v/CVE-2022-30631
      Affected range : >=1.18.0-0
                     : <1.18.4
      Fixed version  : 1.18.4

    x HIGH CVE-2022-30630
      https://scout.docker.com/v/CVE-2022-30630
      Affected range : >=1.18.0-0
                     : <1.18.4
      Fixed version  : 1.18.4

    x HIGH CVE-2022-29804
      https://scout.docker.com/v/CVE-2022-29804
      Affected range : >=1.18.0-0
                     : <1.18.3
      Fixed version  : 1.18.3

    x HIGH CVE-2022-2880
      https://scout.docker.com/v/CVE-2022-2880
      Affected range : <1.18.7
      Fixed version  : 1.18.7

    x HIGH CVE-2022-2879
      https://scout.docker.com/v/CVE-2022-2879
      Affected range : <1.18.7
      Fixed version  : 1.18.7

    x HIGH CVE-2022-28131
      https://scout.docker.com/v/CVE-2022-28131
      Affected range : >=1.18.0-0
                     : <1.18.4
      Fixed version  : 1.18.4

    x HIGH CVE-2022-27664
      https://scout.docker.com/v/CVE-2022-27664
      Affected range : <1.18.6
      Fixed version  : 1.18.6

    x HIGH CVE-2023-29400
      https://scout.docker.com/v/CVE-2023-29400
      Affected range : <1.19.9
      Fixed version  : 1.19.9

    x HIGH CVE-2023-24539
      https://scout.docker.com/v/CVE-2023-24539
      Affected range : <1.19.9
      Fixed version  : 1.19.9
```