### PR TITLE
build: disable java17-openj9 for now

### DIFF
--- a/.github/workflows/build-multiarch.yml
+++ b/.github/workflows/build-multiarch.yml
@@ -25,7 +25,6 @@ jobs:
           - java17
           - java17-graalvm
           - java17-jdk
-          - java17-openj9
           - java17-alpine
           - java8
           - java8-graalvm-ce

--- a/docs/versions/java.md
+++ b/docs/versions/java.md
@@ -19,7 +19,6 @@ where `<tag>` refers to the first column of this table:
 | java21-graalvm   | 21           | Oracle | Oracle GraalVM[^1] | amd64,arm64       |   
 | java17           | 17           | Ubuntu | Hotspot            | amd64,arm64,armv7 |
 | java17-jdk       | 17           | Ubuntu | Hotspot+JDK        | amd64,arm64,armv7 |
-| java17-openj9    | 17           | Debian | OpenJ9             | amd64             |
 | java17-graalvm   | 17           | Oracle | Oracle GraalVM[^1] | amd64,arm64       |   
 | java17-alpine    | 17           | Alpine | Hotspot            | amd64             |
 | java11           | 11           | Ubuntu | Hotspot            | amd64,arm64,armv7 |
@@ -117,6 +116,7 @@ The following image tags have been deprecated and are no longer receiving update
 - multiarch-latest
 - java16/java16-openj9
 - java17-graalvm-ce
+- java17-openj9
 - java20-graalvm, java20, java20-alpine
 - java8-multiarch is still built and pushed, but please move to java8 instead
 


### PR DESCRIPTION
Test keeps failing and needs to be investigated later.

```
Starting Tests on multi-part-motd
 Network multi-part-motd_default  Creating
 Network multi-part-motd_default  Created
 Container multi-part-motd-mc-1  Creating
 Container multi-part-motd-mc-1  Created
 Container multi-part-motd-mc-1  Starting
 Container multi-part-motd-mc-1  Started
multi-part-motd Result: failed=true
failed to ping mc:25565 : could not connect to Minecraft server: dial tcp: lookup mc on 127.0.0.11:53: server misbehaving Container multi-part-motd-monitor-run-6ba4dae01354  Stopping
```