### PR TITLE
Enhance CurseForge server packs that use variables.txt

### DIFF
--- a/scripts/start-finalExec
+++ b/scripts/start-finalExec
@@ -285,6 +285,9 @@ EOF
   if isTrue "${EXEC_DIRECTLY:-false}"; then
     "${finalArgs[@]}"
   else
+    JVM_ARGS="${JVM_XX_OPTS} ${JVM_OPTS} $expandedDOpts"
+    JVM_ARGS=${JVM_ARGS//$'\n'/}
+    sed -i "s~JAVA_ARGS=.*~JAVA_ARGS=\"${JVM_ARGS}\"~" "${FTB_DIR}/variables.txt"
     exec mc-server-runner "${mcServerRunnerArgs[@]}" "${finalArgs[@]}"
   fi
 elif [[ $SERVER =~ run.sh ]]; then

--- a/scripts/start-finalExec
+++ b/scripts/start-finalExec
@@ -285,9 +285,11 @@ EOF
   if isTrue "${EXEC_DIRECTLY:-false}"; then
     "${finalArgs[@]}"
   else
-    JVM_ARGS="${JVM_XX_OPTS} ${JVM_OPTS} $expandedDOpts"
-    JVM_ARGS=${JVM_ARGS//$'\n'/}
-    sed -i "s~JAVA_ARGS=.*~JAVA_ARGS=\"${JVM_ARGS}\"~" "${FTB_DIR}/variables.txt"
+    if [ -f "${FTB_DIR}/variables.txt" ]; then
+        JVM_ARGS="${JVM_XX_OPTS} ${JVM_OPTS} $expandedDOpts"
+        JVM_ARGS=${JVM_ARGS//$'\n'/}
+        sed -i "s~JAVA_ARGS=.*~JAVA_ARGS=\"${JVM_ARGS}\"~" "${FTB_DIR}/variables.txt"
+    fi
     exec mc-server-runner "${mcServerRunnerArgs[@]}" "${finalArgs[@]}"
   fi
 elif [[ $SERVER =~ run.sh ]]; then


### PR DESCRIPTION
The Curseforge server type has not been using the specified memory options. The startup logs (screenshot below) and server memory usage indicate that only 4GB is allocated regardless of the values set in the environment variables. Min 8GB, Max 16GB, and Aikar's flags have been enabled but the java args remain at -Xms4G -Xmx4G.

![image](https://github.com/itzg/docker-minecraft-server/assets/18615678/9860e084-a41d-4ed8-a8ad-15ea26faf545)

The issue is that the launch script used by /data/FeedTheBeast/start.sh uses the variables set in /data/FeedTheBeast/variables.txt to determine java launch options. The docker scripts set the desired launch options to variables but never write them to this file.

The proposed change replaces the current JAVA_ARGS variable in variables.txt with the ones defined within the script. Logs from the revised build show the desired result below.

![image](https://github.com/itzg/docker-minecraft-server/assets/18615678/e3515b7c-e34b-4063-a5fd-e1c1eb138d47)
