### PR TITLE
Add zume to cf-exclude-include.json

### DIFF
--- a/files/cf-exclude-include.json
+++ b/files/cf-exclude-include.json
@@ -1,5 +1,6 @@
 {
   "globalExcludes": [
+    "zume",
     "ambientsounds",
     "armor-toughness-bar",
     "biomeinfo",

--- a/files/cf-exclude-include.json
+++ b/files/cf-exclude-include.json
@@ -1,6 +1,6 @@
 {
   "globalExcludes": [
-    "zume",
+    
     "ambientsounds",
     "armor-toughness-bar",
     "biomeinfo",
@@ -49,7 +49,8 @@
     "thaumic-jei",
     "tips",
     "torohealth-damage-indicators",
-    "waila-harvestability"
+    "waila-harvestability",
+    "zume"
   ],
   "modpacks": {
     "all-of-fabric-6": {


### PR DESCRIPTION
i added zume, it was producing a crash on industrial-village modpack, the creator said that it was client only.