### PR TITLE
Fixed issue of unbound REMOVE_OLD_MODS_EXCLUDE variable when using SPIGET_RESOURCES

### DIFF
--- a/examples/spiget/docker-compose.yml
+++ b/examples/spiget/docker-compose.yml
@@ -1,6 +1,5 @@
 # NOTE
-# This file is named spiget with an "e"
-# since it provides an example of the 
+# This file is purposely named spiget with an "e" since it provides an example of the
 # feature https://docker-minecraft-server.readthedocs.io/en/latest/mods-and-plugins/spiget/
 # which uses the Spiget API at https://spiget.org/
 
@@ -13,8 +12,6 @@ services:
       EULA: "TRUE"
       TYPE: PAPER
       SPIGET_RESOURCES: 34315,3836
+      REMOVE_OLD_MODS: true
     volumes:
-      - data:/data
-
-volumes:
-  data: {}
+      - ./data:/data

--- a/scripts/start-spiget
+++ b/scripts/start-spiget
@@ -8,7 +8,10 @@ handleDebugMode
 
 : "${SPIGET_RESOURCES:=}"
 : "${SPIGET_DOWNLOAD_TOLERANCE:=5}" # in minutes
+: "${REMOVE_OLD_MODS:=false}"
+: "${REMOVE_OLD_MODS_EXCLUDE:=}"
 : "${REMOVE_OLD_MODS_INCLUDE:=*.jar,*-version.json}"
+: "${REMOVE_OLD_MODS_DEPTH:=1} "
 
 acceptArgs=(--accept application/zip --accept application/java-archive --accept application/octet-stream)
 
@@ -127,7 +130,7 @@ downloadResourceFromSpiget() {
 }
 
 if [[ ${SPIGET_RESOURCES} ]]; then
-  if isTrue "${REMOVE_OLD_MODS:-false}"; then
+  if isTrue "${REMOVE_OLD_MODS}"; then
     removeOldMods /data/plugins
     REMOVE_OLD_MODS=false
   fi

--- a/scripts/start-utils
+++ b/scripts/start-utils
@@ -207,13 +207,13 @@ eula=${EULA,,}
 
 function removeOldMods {
   if [ -d "$1" ]; then
-    log "Removing old mods including:${REMOVE_OLD_MODS_INCLUDE} excluding:${REMOVE_OLD_MODS_EXCLUDE}"
+    log "Removing old mods including='${REMOVE_OLD_MODS_INCLUDE}' excluding='${REMOVE_OLD_MODS_EXCLUDE}' up to depth=${REMOVE_OLD_MODS_DEPTH}"
     args=(
       --delete
       --type file
-      --min-depth=1 --max-depth "${REMOVE_OLD_MODS_DEPTH:-16}"
-      --name "${REMOVE_OLD_MODS_INCLUDE:-*}"
-      --exclude-name "${REMOVE_OLD_MODS_EXCLUDE:-}"
+      --min-depth=1 --max-depth "${REMOVE_OLD_MODS_DEPTH}"
+      --name "${REMOVE_OLD_MODS_INCLUDE}"
+      --exclude-name "${REMOVE_OLD_MODS_EXCLUDE}"
     )
     if ! isDebugging; then
       args+=(--quiet)


### PR DESCRIPTION
[Reported in Discord](https://discord.com/channels/660567679458869252/660569755320844308/1250536212318523514)

> After I added the SPIGET_RESOURCES line to my docker_compose, I received an variable unboiund error that crashed the container from the variable: REMOVE_OLD_MODS_EXCLUDE:
I did not set this variable since I do not need it I think.