### PR TITLE
Add true-darkness to CF global excludes

### DIFF
--- a/files/cf-exclude-include.json
+++ b/files/cf-exclude-include.json
@@ -49,6 +49,7 @@
     "thaumic-jei",
     "tips",
     "torohealth-damage-indicators",
+    "true-darkness",
     "waila-harvestability",
     "zume"
   ],


### PR DESCRIPTION
added true-darkness because it is a client only mod. https://www.curseforge.com/minecraft/mc-mods/true-darkness