### PR TITLE
add check for absolute directories to world copy script

### DIFF
--- a/scripts/start-setupWorld
+++ b/scripts/start-setupWorld
@@ -5,10 +5,15 @@
 set -e
 isDebugging && set -x
 
-if [ "$TYPE" = "CURSEFORGE" ]; then
-  worldDest=$FTB_DIR/${LEVEL:-world}
+# support absolute directories
+if [[ "${LEVEL:-world}" =~ ^\/.*$ ]]; then
+  worldDest=${LEVEL}
 else
-  worldDest=/data/${LEVEL:-world}
+  if [ "$TYPE" = "CURSEFORGE" ]; then
+    worldDest=$FTB_DIR/${LEVEL:-world}
+  else
+    worldDest=/data/${LEVEL:-world}
+  fi
 fi
 
 if [[ "$WORLD" ]] && ( isTrue "${FORCE_WORLD_COPY}" || [ ! -d "$worldDest" ] ); then


### PR DESCRIPTION
noticed that the "copy existing world" ability does not check if a level path is absolute, and appends it to /data/, added simple regex ( ^\/.*$ ) check to see if LEVEL is absolute