### PR TITLE
Changed foamfix mod name

### DIFF
--- a/files/cf-exclude-include.json
+++ b/files/cf-exclude-include.json
@@ -44,7 +44,7 @@
     "falling-leaves-forge",
     "fancymenu",
     "faster-ladder-climbing",
-    "foamfix-for-minecraft",
+    "foamfix-optimization-mod",
     "free-cam",
     "ftb-backups-2",
     "fullscreen-windowed-borderless-for-minecraft",


### PR DESCRIPTION
A commit was done to exclusions causing an error 'unable to resolve slug into ID (no matches): foamfix-for-minecraft. However, this is no longer the mod name so caused an error https://www.curseforge.com/minecraft/mc-mods/foamfix-optimization-mod.