### PR TITLE
Remove JEI from exclusion list to fix ATM9 launch issue

### DIFF
--- a/files/cf-exclude-include.json
+++ b/files/cf-exclude-include.json
@@ -55,7 +55,6 @@
     "iris-flywheel-compat",
     "item-obliterator",
     "itemzoom",
-    "jei",
     "just-enough-harvestcraft",
     "just-enough-resources-jer",
     "legendary-tooltips",


### PR DESCRIPTION
https://github.com/itzg/docker-minecraft-server/issues/2968#issuecomment-2212320299
I confirmed that ATM9 launches normally locally after removing JEI from the exclusion list.


