### PR TITLE
Add use-proxy support to health extra args

### DIFF
--- a/docs/misc/autopause-autostop/autostop.md
+++ b/docs/misc/autopause-autostop/autostop.md
@@ -2,7 +2,7 @@
 
 An option to stop the server after a specified time has been added for niche applications (e.g. billing saving on AWS Fargate). The function is incompatible with the Autopause functionality, as they basically cancel out each other.
 
-!!! note 
+!!! note
 
     the docker container variables have to be set accordingly (restart policy set to "no") and that the container has to be manually restarted.
 
@@ -25,3 +25,6 @@ The following environment variables define the behavior of auto-stopping:
   describes period of the daemonized state machine, that handles the stopping of the server
 
 > To troubleshoot, add `DEBUG_AUTOSTOP=true` to see additional output
+
+## Proxy Support
+If you make use of PROXY Protocol, i.e. through something like HAProxy or Fly.io, you will need to enable it in your variety of server's configuration, and then set the `USES_PROXY_PROTOCOL` envar to `true`. This lets Autostop monitor the server, where it otherwise wouldn't

--- a/scripts/start-finalExec
+++ b/scripts/start-finalExec
@@ -227,6 +227,12 @@ MC_HEALTH_EXTRA_ARGS=(
   --use-server-list-ping
 )
   " > /data/.mc-health.env
+elif isTrue "$USES_PROXY_PROTOCOL"; then
+  echo "
+MC_HEALTH_EXTRA_ARGS=(
+  --use-proxy
+)
+  " > /data/.mc-health.env
 else
   rm -f /data/.mc-health.env
 fi


### PR DESCRIPTION
This fixes #2828, and resolves the concerns in #2838.

Specifically, it adds an env of `USES_PROXY_PROTOCOL`, and when present, passes the `--use-proxy` argument to mc-health
