### PR TITLE
Update the autopause server listener to be proxy aware

### DIFF
--- a/files/auto/autopause-fcns.sh
+++ b/files/auto/autopause-fcns.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# shellcheck source=../scripts/start-utils
+. "${SCRIPTS:-/}start-utils"
 current_uptime() {
   awk '{print $1}' /proc/uptime | cut -d . -f 1
 }
@@ -16,14 +18,20 @@ rcon_client_exists() {
   [[ -n "$(ps -ax -o comm | grep 'rcon-cli')" ]]
 }
 
+use_proxy() {
+  if isTrue "$USES_PROXY_PROTOCOL"; then
+    echo "--use-proxy"
+  fi
+}
+
 mc_server_listening() {
-  mc-monitor status --host "${SERVER_HOST:-localhost}" --port "$SERVER_PORT" --timeout 10s >& /dev/null
+  mc-monitor status $(use_proxy) --host "${SERVER_HOST:-localhost}" --port "$SERVER_PORT" --timeout 10s >&/dev/null
 }
 
 java_clients_connections() {
   local connections
-  if java_running ; then
-    if ! connections=$(mc-monitor status --host "${SERVER_HOST:-localhost}" --port "$SERVER_PORT" --show-player-count); then
+  if java_running; then
+    if ! connections=$(mc-monitor status $(use_proxy) --host "${SERVER_HOST:-localhost}" --port "$SERVER_PORT" --show-player-count); then
       # consider it a non-zero player count if the ping fails
       # otherwise a laggy server with players connected could get paused
       connections=1


### PR DESCRIPTION
I missed this in my previous PR, #2973. This makes it so the autostop monitor is proxy aware as well
