### PR TITLE
auto-cf: remove necronomicon from global exclusions

### DIFF
--- a/files/cf-exclude-include.json
+++ b/files/cf-exclude-include.json
@@ -66,7 +66,6 @@
     "more-overlays",
     "mouse-tweaks",
     "neat",
-    "necronomicon",
     "nekos-enchanted-books",
     "no-recipe-book",
     "no-nv-flash",


### PR DESCRIPTION
It is not a client mod -- it's a utility library for other mods

https://www.curseforge.com/minecraft/mc-mods/necronomicon

Was incorrectly added in https://github.com/itzg/docker-minecraft-server/pull/2964