### PR TITLE
docs: updated with example on how to setup lazymc with minecraft container

### DIFF
--- a/docs/misc/examples.md
+++ b/docs/misc/examples.md
@@ -26,6 +26,54 @@ services:
 
 [Source](https://github.com/itzg/docker-minecraft-server/blob/master/examples/geyser/docker-compose.yml)
 
+## Lazymc - Put your Minecraft server to rest when idle
+
+With [lazymc-docker-proxy](https://github.com/joesturge/lazymc-docker-proxy/settings) you are able to use [lazymc](https://github.com/timvisee/lazymc) with the minecraft container.
+
+```yaml
+services:
+    lazymc:
+        container_name: lazymc
+        image: ghcr.io/joesturge/lazymc-docker-proxy:latest
+        environment:
+            # Point to the service name of the Minecraft server
+            - SERVER_ADDRESS=mc:25565
+            # Required to find the container to manage it
+            - LAZYMC_GROUP=mc
+        restart: unless-stopped
+        volumes:
+            # you should mount the minecraft server dir under /server, using read only.
+            - data:/server:ro
+            # you need to supply the docker socket, so that the container can run docker command
+            - /var/run/docker.sock:/var/run/docker.sock:ro
+        ports:
+            # lazymc-docker-proxy acts as a proxy, so there is
+            # no need to expose the server port on the Minecraft container
+            - "25565:25565"
+
+    # Standard Docker Minecraft server, also works with other server types
+    mc:
+        image: itzg/minecraft-server:java21
+        container_name: minecraft-server
+        # We need to add a label here so that lazymc-docker-proxy knows which
+        # container to manage
+        labels:
+            - lazymc.group=mc
+        tty: true
+        stdin_open: true
+        # This container should be managed solely by the lazymc container
+        # so set restart to no, or else the container will start again...
+        restart: no
+        environment:
+            EULA: "TRUE"
+        volumes:
+            - data:/data
+
+volumes:
+    data:
+```
+[Source](https://github.com/joesturge/lazymc-docker-proxy/blob/master/docker-compose.yaml)
+
 ## Lazytainer - Stop Minecraft container based on traffic
 Monitors network traffic to the Minecraft containers. If there is traffic, the container runs, otherwise the container is stopped/paused.
 

--- a/docs/misc/examples.md
+++ b/docs/misc/examples.md
@@ -28,49 +28,49 @@ services:
 
 ## Lazymc - Put your Minecraft server to rest when idle
 
-With [lazymc-docker-proxy](https://github.com/joesturge/lazymc-docker-proxy/settings) you are able to use [lazymc](https://github.com/timvisee/lazymc) with the minecraft container.
+With [lazymc-docker-proxy](https://github.com/joesturge/lazymc-docker-proxy) you are able to use [lazymc](https://github.com/timvisee/lazymc) with the minecraft container.
 
 ```yaml
 services:
-    lazymc:
-        container_name: lazymc
-        image: ghcr.io/joesturge/lazymc-docker-proxy:latest
-        environment:
-            # Point to the service name of the Minecraft server
-            - SERVER_ADDRESS=mc:25565
-            # Required to find the container to manage it
-            - LAZYMC_GROUP=mc
-        restart: unless-stopped
-        volumes:
-            # you should mount the minecraft server dir under /server, using read only.
-            - data:/server:ro
-            # you need to supply the docker socket, so that the container can run docker command
-            - /var/run/docker.sock:/var/run/docker.sock:ro
-        ports:
-            # lazymc-docker-proxy acts as a proxy, so there is
-            # no need to expose the server port on the Minecraft container
-            - "25565:25565"
+  lazymc:
+    container_name: lazymc
+    image: ghcr.io/joesturge/lazymc-docker-proxy:latest
+    environment:
+      # Point to the service name of the Minecraft server
+      SERVER_ADDRESS: mc:25565
+      # Required to find the container to manage it
+      LAZYMC_GROUP: mc
+    restart: unless-stopped
+    volumes:
+      # you should mount the minecraft server dir under /server, using read only.
+      - data:/server:ro
+      # you need to supply the docker socket, so that the container can run docker command
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    ports:
+      # lazymc-docker-proxy acts as a proxy, so there is
+      # no need to expose the server port on the Minecraft container
+      - "25565:25565"
 
-    # Standard Docker Minecraft server, also works with other server types
-    mc:
-        image: itzg/minecraft-server:java21
-        container_name: minecraft-server
-        # We need to add a label here so that lazymc-docker-proxy knows which
-        # container to manage
-        labels:
-            - lazymc.group=mc
-        tty: true
-        stdin_open: true
-        # This container should be managed solely by the lazymc container
-        # so set restart to no, or else the container will start again...
-        restart: no
-        environment:
-            EULA: "TRUE"
-        volumes:
-            - data:/data
+  # Standard Docker Minecraft server, also works with other server types
+  mc:
+    image: itzg/minecraft-server:java21
+    container_name: minecraft-server
+    # We need to add a label here so that lazymc-docker-proxy knows which
+    # container to manage
+    labels:
+      - lazymc.group=mc
+    tty: true
+    stdin_open: true
+    # This container should be managed solely by the lazymc container
+    # so set restart to no, or else the container will start again...
+    restart: no
+    environment:
+      EULA: "TRUE"
+    volumes:
+      - data:/data
 
 volumes:
-    data:
+  data:
 ```
 [Source](https://github.com/joesturge/lazymc-docker-proxy/blob/master/docker-compose.yaml)
 

--- a/examples/lazymc/docker_compose.yml
+++ b/examples/lazymc/docker_compose.yml
@@ -4,9 +4,9 @@ services:
     image: ghcr.io/joesturge/lazymc-docker-proxy:latest
     environment:
       # Point to the service name of the Minecraft server
-      - SERVER_ADDRESS=mc:25565
+      SERVER_ADDRESS: mc:25565
       # Required to find the container to manage it
-      - LAZYMC_GROUP=mc
+      LAZYMC_GROUP: mc
     restart: unless-stopped
     volumes:
       # you should mount the minecraft server dir under /server, using read only.

--- a/examples/lazymc/docker_compose.yml
+++ b/examples/lazymc/docker_compose.yml
@@ -1,0 +1,40 @@
+services:
+  lazymc:
+    container_name: lazymc
+    image: ghcr.io/joesturge/lazymc-docker-proxy:latest
+    environment:
+      # Point to the service name of the Minecraft server
+      - SERVER_ADDRESS=mc:25565
+      # Required to find the container to manage it
+      - LAZYMC_GROUP=mc
+    restart: unless-stopped
+    volumes:
+      # you should mount the minecraft server dir under /server, using read only.
+      - data:/server:ro
+      # you need to supply the docker socket, so that the container can run docker command
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    ports:
+      # lazymc-docker-proxy acts as a proxy, so there is
+      # no need to expose the server port on the Minecraft container
+      - "25565:25565"
+
+  # Standard Docker Minecraft server, also works with other server types
+  mc:
+    image: itzg/minecraft-server:java21
+    container_name: minecraft-server
+    # We need to add a label here so that lazymc-docker-proxy knows which
+    # container to manage
+    labels:
+      - lazymc.group=mc
+    tty: true
+    stdin_open: true
+    # This container should be managed solely by the lazymc container
+    # so set restart to no, or else the container will start again...
+    restart: no
+    environment:
+      EULA: "TRUE"
+    volumes:
+      - data:/data
+
+volumes:
+  data:


### PR DESCRIPTION
I have created a docker container which wraps LazyMc add adds the functionality to control a minecraft container

I have updated the docs to add this as an example. Feel free to check out the project here: https://github.com/joesturge/lazymc-docker-proxy

![image](https://github.com/user-attachments/assets/5763ac0c-c0df-4e98-af7f-424d00ea7902)
