### PR TITLE
Added hide-online-players server property

### DIFF
--- a/docs/configuration/server-properties.md
+++ b/docs/configuration/server-properties.md
@@ -495,4 +495,4 @@ When using `docker run` from a bash shell, the entries must be quoted with the `
 | SIMULATION_DISTANCE               | simulation-distance               |
 | SYNC_CHUNK_WRITES                 | sync-chunk-writes                 |
 | USE_NATIVE_TRANSPORT              | use-native-transport              |
-
+| HIDE_ONLINE_PLAYERS               | hide-online-players               

--- a/files/property-definitions.json
+++ b/files/property-definitions.json
@@ -54,5 +54,6 @@
   "previews-chat": {"env": "PREVIEWS_CHAT"},
   "enforce-secure-profile": {"env": "ENFORCE_SECURE_PROFILE"},
   "initial-enabled-packs": {"env": "INITIAL_ENABLED_PACKS"},
-  "initial-disabled-packs": {"env": "INITIAL_DISABLED_PACKS"}
+  "initial-disabled-packs": {"env": "INITIAL_DISABLED_PACKS"},
+  "hide-online-players": {"env": "HIDE_ONLINE_PLAYERS"}
 }


### PR DESCRIPTION
I think I've done what I need to add this server property.
`hide-online-players` was added in 1.18 21w44a and prevents sending of player list on status requests