### PR TITLE
Added support for FOLIA_CHANNEL

### DIFF
--- a/docs/types-and-platforms/server-types/paper.md
+++ b/docs/types-and-platforms/server-types/paper.md
@@ -65,13 +65,19 @@ Extra variables:
 
 ### Folia
 
-Enable Folia server mode by adding a `-e TYPE=FOLIA` to your command-line.
+A [Folia server](https://papermc.io/software/folia) can be used by setting the environment variable `TYPE` to "FOLIA".
 
-By default, the container will run the latest build of [Folia server](https://papermc.io/downloads), but you can also choose to run a specific build with `-e FOLIABUILD=26`.
+By default, the container will run the latest experimental build of [Folia server](https://papermc.io/downloads), but you can also choose to run a specific build with `-e FOLIABUILD=26`. The release channel can be changed with the variable `FOLIA_CHANNEL`; however, only experimental builds are available at this time.
 
+!!! example
+
+    Using `docker run`
+    
+    ```
     docker run -d -v /path/on/host:/data \
         -e TYPE=FOLIA \
         -p 25565:25565 -e EULA=TRUE --name mc itzg/minecraft-server
+    ```
 
 If you are hosting your own copy of Folia you can override the download URL with `FOLIA_DOWNLOAD_URL=<url>`.
 

--- a/scripts/start-deployFolia
+++ b/scripts/start-deployFolia
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+: "${FOLIA_CHANNEL:=experimental}"
+
+# shellcheck source=start-utils
+. "${SCRIPTS:-/}start-utils"
+set -o pipefail
+handleDebugMode
+
 if [[ $FOLIA_DOWNLOAD_URL ]]; then
   export PAPER_DOWNLOAD_URL="$FOLIA_DOWNLOAD_URL"
 fi
@@ -8,4 +15,7 @@ if [[ $FOLIABUILD ]]; then
   export PAPERBUILD="$FOLIABUILD"
 fi
 
-PAPER_PROJECT="folia" PAPER_NAME="FoliaMC" exec "${SCRIPTS:-/}start-deployPaper" "$@"
+PAPER_PROJECT="folia" \
+PAPER_NAME="FoliaMC" \
+PAPER_CHANNEL="${FOLIA_CHANNEL}" \
+  exec "${SCRIPTS:-/}start-deployPaper" "$@"


### PR DESCRIPTION
[Reported in Discord](https://discord.com/channels/660567679458869252/660569641550217327/1269287470646824970)

```
mc-1  | [init] Running as uid=1000 gid=1000 with /data as 'drwxr-xr-x 2 1000 1000 4096 Aug  3 13:17 /data'
mc-1  | [init] Resolving type given FOLIA
mc-1  | [mc-image-helper] 13:18:56.782 ERROR : Invalid parameter provided for 'install-paper' command: No build found with channel 'default'. Perhaps try a different channel: experimental
mc-1  | [init] ERROR: failed to download folia
```