### PR TITLE
Add just-zoom (jar: justzoom) to global exclude

### DIFF
--- a/files/cf-exclude-include.json
+++ b/files/cf-exclude-include.json
@@ -62,6 +62,7 @@
     "itemzoom",
     "just-enough-harvestcraft",
     "just-enough-resources-jer",
+    "just-zoom",
     "konkrete",
     "legendary-tooltips",
     "loot-capacitor-tooltips",

--- a/files/modrinth-exclude-include.json
+++ b/files/modrinth-exclude-include.json
@@ -45,7 +45,7 @@
     "iris-flywheel",
     "ItemBorders",
     "ItemLocks",
-    "just-zoom",
+    "justzoom",
     "language-reload",
     "lazy-language-loader",
     "LegendaryTooltips",

--- a/files/modrinth-exclude-include.json
+++ b/files/modrinth-exclude-include.json
@@ -45,6 +45,7 @@
     "iris-flywheel",
     "ItemBorders",
     "ItemLocks",
+    "just-zoom",
     "language-reload",
     "lazy-language-loader",
     "LegendaryTooltips",


### PR DESCRIPTION
Here are the URLs just to double check the IDs

https://www.curseforge.com/minecraft/mc-mods/just-zoom
https://modrinth.com/mod/just-zoom

This mod prevents the server from starting since it's dependency Konkrete was added to the global exclude. It seems to be a wrongly declared client side mod.