### PR TITLE
add new server property in 24w33a

### DIFF
--- a/docs/configuration/server-properties.md
+++ b/docs/configuration/server-properties.md
@@ -502,3 +502,4 @@ When using `docker run` from a bash shell, the entries must be quoted with the `
 | LOG_IPS                           | log-ips                           |
 | REGION_FILE_COMPRESSION           | region-file-compression           |   
 | BUG_REPORT_LINK                   | bug-report-link                   |
+| PAUSE_WHEN_EMPTY_SECONDS          | pause-when-empty-seconds          |

--- a/files/property-definitions.json
+++ b/files/property-definitions.json
@@ -36,6 +36,7 @@
   "network-compression-threshold": {"env": "NETWORK_COMPRESSION_THRESHOLD"},
   "online-mode": {"env": "ONLINE_MODE"},
   "op-permission-level": {"env": "OP_PERMISSION_LEVEL"},
+  "pause-when-empty-seconds": {"env": "PAUSE_WHEN_EMPTY_SECONDS"},
   "player-idle-timeout": {"env": "PLAYER_IDLE_TIMEOUT"},
   "prevent-proxy-connections": {"env": "PREVENT_PROXY_CONNECTIONS"},
   "previews-chat": {"env": "PREVIEWS_CHAT"},


### PR DESCRIPTION
This new server property was added in [Java Edition 24w33a](https://minecraft.wiki/w/Java_Edition_24w33a). I was a bit unsure whether to open the PR now or wait till 1.21.2 is out, but since the image supports running snapshot versions I thought it would make sense to add it now.