### PR TITLE
build: deprecating java8-alpine (for now)

### DIFF
--- a/.github/workflows/build-multiarch.yml
+++ b/.github/workflows/build-multiarch.yml
@@ -31,7 +31,6 @@ jobs:
           - java8-graalvm-ce
           - java8-openj9
           - java8-jdk
-          - java8-alpine
           - java11
         include:
         # JAVA 21:
@@ -74,10 +73,6 @@ jobs:
           - variant: java8
             baseImage: eclipse-temurin:8u312-b07-jre-focal
             platforms: linux/amd64,linux/arm/v7,linux/arm64
-            mcVersion: 1.12.2
-          - variant: java8-alpine
-            baseImage: openjdk:8-jre-alpine3.9
-            platforms: linux/amd64
             mcVersion: 1.12.2
           - variant: java8-graalvm-ce
             baseImage: ghcr.io/graalvm/graalvm-ce:java8

--- a/docs/versions/java.md
+++ b/docs/versions/java.md
@@ -23,7 +23,6 @@ where `<tag>` refers to the first column of this table:
 | java17-alpine    | 17           | Alpine | Hotspot            | amd64  (1)          |
 | java11           | 11           | Ubuntu | Hotspot            | amd64, arm64, armv7 |
 | java8            | 8            | Ubuntu | Hotspot            | amd64, arm64, armv7 |
-| java8-alpine     | 8            | Alpine | Hotspot            | amd64  (1)          |
 | java8-jdk        | 8            | Ubuntu | Hotspot+JDK        | amd64               |
 | java8-openj9     | 8            | Debian | OpenJ9             | amd64               |
 | java8-graalvm-ce | 8            | Oracle | GraalVM CE         | amd64               |
@@ -133,5 +132,6 @@ The following image tags have been deprecated and are no longer receiving update
 - java17-openj9
 - java20-graalvm, java20, java20-alpine
 - java8-multiarch is still built and pushed, but please move to java8 instead
+- java8-alpine
 
 [^1]: Based on the [Oracle GraalMV images](https://blogs.oracle.com/java/post/new-oracle-graalvm-container-images), which as of JDK 17, are now under the [GraalVM Free License](https://blogs.oracle.com/java/post/graalvm-free-license) incorporating what used to be known as the GraalVM Enterprise. 


### PR DESCRIPTION
The Java 8 version used for Alpine is stuck on a really old version and is not compatible with Java operation shown in stack trace:

```
[mc-image-helper] 18:57:31.001 ERROR : 'get' command failed. Version is 1.39.12
java.lang.UnsupportedOperationException: The method shutdownOutput() is not supported in SSLSocket
        at sun.security.ssl.BaseSSLSocketImpl.shutdownOutput(BaseSSLSocketImpl.java:228)
        at org.apache.hc.core5.http.impl.io.BHttpConnectionBase.close(BHttpConnectionBase.java:252)
        at org.apache.hc.core5.http.impl.io.DefaultBHttpClientConnection.close(DefaultBHttpClientConnection.java:71)
        at org.apache.hc.client5.http.impl.io.DefaultManagedHttpClientConnection.close(DefaultManagedHttpClientConnection.java:176)
        at org.apache.hc.core5.pool.PoolEntry.discardConnection(PoolEntry.java:180)
        at org.apache.hc.core5.pool.StrictConnPool$PerRoutePool.shutdown(StrictConnPool.java:839)
        at org.apache.hc.core5.pool.StrictConnPool.close(StrictConnPool.java:142)
        at org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager.close(PoolingHttpClientConnectionManager.java:277)
        at org.apache.hc.client5.http.impl.classic.InternalHttpClient.close(InternalHttpClient.java:198)
        at org.apache.hc.client5.http.impl.classic.InternalHttpClient.close(InternalHttpClient.java:188)
        at me.itzg.helpers.get.GetCommand.call(GetCommand.java:227)
        at me.itzg.helpers.get.GetCommand.call(GetCommand.java:55)
        at picocli.CommandLine.executeUserObject(CommandLine.java:2045)
        at picocli.CommandLine.access$1500(CommandLine.java:148)
        at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2465)
        at picocli.CommandLine$RunLast.handle(CommandLine.java:2457)
        at picocli.CommandLine$RunLast.handle(CommandLine.java:2419)
        at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:2277)
        at picocli.CommandLine$RunLast.execute(CommandLine.java:2421)
        at picocli.CommandLine.execute(CommandLine.java:2174)
        at me.itzg.helpers.McImageHelper.main(McImageHelper.java:159)
[init] ERROR: failed to obtain version manifest URL (1)
```