### PR TITLE
Fix mc-send-to-console running with uid=0(root)

### DIFF
--- a/bin/mc-send-to-console
+++ b/bin/mc-send-to-console
@@ -17,7 +17,7 @@ if [ ! -p "${CONSOLE_IN_NAMED_PIPE}" ]; then
   exit 1
 fi
 
-if [ "$(id -u)" != 0 ]; then
+if [ $UID != 0 ]; then
   if [[ $(getDistro) == alpine ]]; then
     exec su-exec minecraft bash -c "echo '$*' > '${CONSOLE_IN_NAMED_PIPE:-/tmp/minecraft-console-in}'"
   else

--- a/bin/mc-send-to-console
+++ b/bin/mc-send-to-console
@@ -17,7 +17,7 @@ if [ ! -p "${CONSOLE_IN_NAMED_PIPE}" ]; then
   exit 1
 fi
 
-if [ "$(id -u)" = 0 ]; then
+if [ "$(id -u)" != 0 ]; then
   if [[ $(getDistro) == alpine ]]; then
     exec su-exec minecraft bash -c "echo '$*' > '${CONSOLE_IN_NAMED_PIPE:-/tmp/minecraft-console-in}'"
   else

--- a/bin/mc-send-to-console
+++ b/bin/mc-send-to-console
@@ -17,7 +17,7 @@ if [ ! -p "${CONSOLE_IN_NAMED_PIPE}" ]; then
   exit 1
 fi
 
-if [ $UID != 0 ]; then
+if [ "$(id -u)" = 0 -a $UID != 0 ]; then
   if [[ $(getDistro) == alpine ]]; then
     exec su-exec minecraft bash -c "echo '$*' > '${CONSOLE_IN_NAMED_PIPE:-/tmp/minecraft-console-in}'"
   else


### PR DESCRIPTION
I found an error in the conditional statement` if [ "$(id -u)" != 0 ]; then`. 
This condition incorrectly allows the ‘minecraft’ user to access the pipe `/tmp/minecraft-console-in` when the UID is 0 (i.e., when running as the root user), resulting in permission errors. 
This pull request corrects the erroneous check.