### PR TITLE
port configuration for local modrinth modpack setup

### DIFF
--- a/examples/modrinth/local-modpack/docker-compose.yml
+++ b/examples/modrinth/local-modpack/docker-compose.yml
@@ -7,6 +7,8 @@ services:
       # Download the mrpack file from https://modrinth.com/modpack/cobblemon-fabric/version/1.4.1 and place in
       # modpacks directory next to this compose file.
       MODRINTH_MODPACK: /modpacks/Cobblemon Modpack [Fabric] 1.4.1.mrpack
+    ports:
+      -  "25565:25565"
     volumes:
       - mc-data:/data
       - ./modpacks:/modpacks:ro


### PR DESCRIPTION
missing port configuration on docker compose for local modrinth modpack setup