### PR TITLE
Fix incorrect warning about setting TYPE and MODPACK_PLATFORM

### DIFF
--- a/scripts/start-configuration
+++ b/scripts/start-configuration
@@ -160,7 +160,7 @@ fi
 
 : "${MODPACK_PLATFORM:=${MOD_PLATFORM:-}}"
 
-if [[ $MODPACK_PLATFORM && $TYPE ]]; then
+if [[ $MODPACK_PLATFORM && $TYPE && $TYPE != VANILLA ]]; then
   logWarning "Avoid setting TYPE and MODPACK_PLATFORM"
 fi
 


### PR DESCRIPTION
Was seeing these warnings even when only `MODPACK_PLATFORM` was set:

```
[init] [WARN] Avoid setting TYPE and MODPACK_PLATFORM 
```

Follow up to #3120. Forgot that TYPE defaults to "VANILLA"