### PR TITLE
Added xaeroplus and yungs-menu-tweaks to the exclude list

### DIFF
--- a/files/cf-exclude-include.json
+++ b/files/cf-exclude-include.json
@@ -125,6 +125,8 @@
     "vanillafix",
     "visuality",
     "waila-harvestability",
+    "xaeroplus",
+    "yungs-menu-tweaks",
     "zume"
   ],
   "modpacks": {


### PR DESCRIPTION
https://www.curseforge.com/minecraft/mc-mods/yungs-menu-tweaks  https://www.curseforge.com/minecraft/mc-mods/xaeroplus

I tested both with BetterMC4 and i got crashes due to being client-only