### PR TITLE
Make sure download new version of FTB installer

### DIFF
--- a/scripts/start-deployFTBA
+++ b/scripts/start-deployFTBA
@@ -62,8 +62,11 @@ elif ! [[ ${FTB_MODPACK_VERSION_ID} =~ [0-9]+ ]]; then
   exit 1
 fi
 
-if isTrue "$FTB_FORCE_REINSTALL" || ! [ -f "${ftbManifest}" ] || ! [ -f "${ftbInstallMarker}" ] || [ "$(cat "${ftbInstallMarker}")" != "${FTB_MODPACK_ID}=${FTB_MODPACK_VERSION_ID}" ]; then
-  ftbInstaller=/data/ftb-installer
+if isTrue "$FTB_FORCE_REINSTALL" ||
+  ! [ -f "${ftbManifest}" ] ||
+  ! [ -f "${ftbInstallMarker}" ] ||
+  [ "$(cat "${ftbInstallMarker}")" != "${FTB_MODPACK_ID}=${FTB_MODPACK_VERSION_ID}" ]; then
+  ftbInstaller=/data/ftb-installer-v2
   arm=
   if ! [[ -f "${ftbInstaller}" ]]; then
     if [ "$(uname -m)" == "aarch64" ]; then


### PR DESCRIPTION
[Reported in Discord](https://discord.com/channels/660567679458869252/660567682751528981/1315710582175039546)

Follow up to #3177

```
mc  | [init] Installing modpack ID 100, version ID 6647
mc  | [init] This could take a while...
mc  | Server installer version 24.622.1046-linux-amd64 commit ea7895792cf8db92694f4feb3c54b6d9866b3d72
mc  | Running installer as user minecraft (1000)
mc  | 2024/12/09 15:57:17 Cannot locate modpack via filename. Error: unable to parse filename: ftb-installer
mc  | 2024/12/09 15:57:17                        _                  _              _
mc  | 2024/12/09 15:57:17                       | |                | |            | |
mc  | 2024/12/09 15:57:17    _ __ ___   ___   __| |_ __   __ _  ___| | _____   ___| |__
mc  | 2024/12/09 15:57:17   | '_ ` _ \ / _ \ / _` | '_ \ / _` |/ __| |/ / __| / __| '_ \
mc  | 2024/12/09 15:57:17   | | | | | | (_) | (_| | |_) | (_| | (__|   <\__ \| (__| | | |
mc  | 2024/12/09 15:57:17   |_| |_| |_|\___/ \__,_| .__/ \__,_|\___|_|\_\___(_)___|_| |_|
mc  | 2024/12/09 15:57:17                         | |
mc  | 2024/12/09 15:57:17                         |_|
mc  | 2024/12/09 15:57:17   modpacks.ch server downloader golang - build 24.622.1046-linux-amd64
mc  | 2024/12/09 15:57:17   based on commit ea7895792cf8db92694f4feb3c54b6d9866b3d72
mc  | 2024/12/09 15:57:17
mc  | 2024/12/09 15:57:17  Usage:
mc  | 2024/12/09 15:57:17    ftb-installer <modpackid> <versionid> - will install the modpack specified by <modpackid> with the version specified by <versionid>
mc  | 2024/12/09 15:57:17    ftb-installer <modpackid> - will install the modpack specified by <modpackid> with the latest version available
mc  | 2024/12/09 15:57:17
mc  | 2024/12/09 15:57:17  Arguments:
mc  | 2024/12/09 15:57:17    --auto-Ask no questions, use defaults.
mc  | 2024/12/09 15:57:17    --path-Directory to install in. Default: current directory
mc  | 2024/12/09 15:57:17    --noscript-Skip creating start script. Default: false
mc  | 2024/12/09 15:57:17    --nojava-Skip downloading a compatible Adoptium JRE. Default: false
mc  | 2024/12/09 15:57:17    --threads-Number of threads to use for downloading. Default: cpucores * 2
mc  | 2024/12/09 15:57:17    --integrityupdate-Whether changed files should be overwritten with fresh copies when updating. Most useful when used with Auto. Default: false
mc  |     Example: You changed config/test.cfg on your server from default. The modpack updates config/test.cfg - with this flag, it will assume you wish to overwrite with the latest version
mc  | 2024/12/09 15:57:17    --integrity-Do a full integrity check, even on files not changed by the update. integrityupdate assumed. Default: true
mc  | 2024/12/09 15:57:17    --verbose-Be a bit noisier on actions taken. Default: false
mc  | 2024/12/09 15:57:17    --latest-Install latest, ignoring any version in the file name or arguments. Default: false
mc  | 2024/12/09 15:57:17    --curseforge-Specifies that pack is a Curseforge modpack
mc  | 2024/12/09 15:57:17    --help-This help
mc  | jq: error: Could not open file .manifest.json: No such file or directory
```