### PR TITLE
Download `paper.yml` and `bukkit.yml`

### DIFF
--- a/scripts/start-deployPaper
+++ b/scripts/start-deployPaper
@@ -42,10 +42,17 @@ else
   applyResultsFile ${resultsFile}
 fi
 
-# Download default configs to allow for consistent patching
-DOWNLOAD_DEFAULT_CONFIGS=$(buildDownloadList "$PAPER_CONFIG_DEFAULTS_REPO" "$VERSION" paper-global.yml paper-world-defaults.yml)
-export DOWNLOAD_DEFAULT_CONFIGS
-DOWNLOAD_DEFAULTS=$(buildDownloadList "$PAPER_CONFIG_DEFAULTS_REPO" "$VERSION" spigot.yml)
+defaultTopLevelConfigs="spigot.yml"
+if versionLessThan 1.19; then
+  defaultTopLevelConfigs+=" paper.yml"
+else
+  # Download default configs to allow for consistent patching
+  DOWNLOAD_DEFAULT_CONFIGS=$(buildDownloadList "$PAPER_CONFIG_DEFAULTS_REPO" "$VERSION" paper-global.yml paper-world-defaults.yml)
+  export DOWNLOAD_DEFAULT_CONFIGS
+fi
+
+# Download top-level configs to allow for consistent patching
+DOWNLOAD_DEFAULTS=$(buildDownloadList "$PAPER_CONFIG_DEFAULTS_REPO" "$VERSION" $defaultTopLevelConfigs)
 export DOWNLOAD_DEFAULTS
 
 # Normalize on Spigot for downstream operations

--- a/scripts/start-deployPaper
+++ b/scripts/start-deployPaper
@@ -42,7 +42,7 @@ else
   applyResultsFile ${resultsFile}
 fi
 
-defaultTopLevelConfigs="spigot.yml"
+defaultTopLevelConfigs="bukkit.yml spigot.yml"
 if versionLessThan 1.19; then
   defaultTopLevelConfigs+=" paper.yml"
 else


### PR DESCRIPTION
Thanks a lot for resolving #3211 🙂

I've made some further improvements:
- Only attempt download `paper-global.yml` and `paper-world-defaults.yml` if the version is 1.19 or newer, as [these configuration files were introduced in 1.19](https://forums.papermc.io/threads/paper-1-19.344/).
- Download `paper.yml` if the version is older than 1.19.
- Always download `bukkit.yml`, which is also present in https://github.com/dayyeeet/minecraft-default-configs.