### PR TITLE
Fixed compose error due to missing key in GTNH example

### DIFF
--- a/examples/gtnh/docker-compose.yaml
+++ b/examples/gtnh/docker-compose.yaml
@@ -13,7 +13,7 @@ services:
       GENERIC_PACKS_SUFFIX: .zip
       GENERIC_PACKS_PREFIX: https://downloads.gtnewhorizons.com/ServerPacks/
       # if this isn't true, then the container tries to download the modpack every run
-      : "true"
+      SKIP_GENERIC_PACK_UPDATE_CHECK: "true"
       # Make sure that this matches what is in your pack's startserver bash file
       CUSTOM_JAR_EXEC: "-Xms6G -Xmx6G -Dfml.readTimeout=180 @java9args.txt -jar lwjgl3ify-forgePatches.jar nogui"
     volumes:


### PR DESCRIPTION
Docker compose errored out due to a missing key, fixed it by adding the key that should go there based on the comment above.