### PR TITLE
update mohist download script to use new API endpoint

### DIFF
--- a/scripts/start-deployMohist
+++ b/scripts/start-deployMohist
@@ -31,7 +31,6 @@ if [[ "${MOHIST_BUILD}" == "lastSuccessfulBuild" ]]; then
   MOHIST_BUILD="${buildNumber}"
 fi
 
-# Get the download URL for the specified build
 downloadUrl=$(
   get --json-path "$.builds[?(@.number==${MOHIST_BUILD})].url" "${mohistApiUrl}"
 )
@@ -42,7 +41,6 @@ if [[ -z "${downloadUrl}" ]]; then
   exit 1
 fi
 
-# Create server filename based on version and build number
 SERVER="/data/mohist-${VERSION}-${MOHIST_BUILD}-server.jar"
 
 if [ ! -f "${SERVER}" ]; then

--- a/scripts/start-deployMohist
+++ b/scripts/start-deployMohist
@@ -9,39 +9,48 @@ isDebugging && set -x
 resolveVersion
 : "${MOHIST_BUILD:=lastSuccessfulBuild}"
 
-mohistBaseUrl=https://ci.codemc.io/job/MohistMC/
-mohistJobs=${mohistBaseUrl}job/
-mohistJob=${mohistJobs}Mohist-${VERSION}/
+mohistBaseUrl="https://mohistmc.com/api/v2/projects/mohist/"
+mohistApiUrl="${mohistBaseUrl}${VERSION}/builds/"
 
 function logMohistAvailableVerisons(){
   logError "       check ${mohistBaseUrl} for available versions"
   logError "       and set VERSION accordingly"
 }
 
-if ! get --exists "${mohistJob}"; then
+if ! get --exists "${mohistApiUrl}"; then
   logError "Mohist builds do not exist for ${VERSION}"
   logMohistAvailableVerisons
   exit 1
 fi
 
-buildRelPath=$(
-  get --json-path '$.artifacts[0].relativePath' "${mohistJob}${MOHIST_BUILD}/api/json"
+if [[ "${MOHIST_BUILD}" == "lastSuccessfulBuild" ]]; then
+  # Get the latest build number from the API
+  buildNumber=$(
+    get --json-path '$.builds[-1].number' "${mohistApiUrl}"
+  )
+  MOHIST_BUILD="${buildNumber}"
+fi
+
+# Get the download URL for the specified build
+downloadUrl=$(
+  get --json-path "$.builds[?(@.number==${MOHIST_BUILD})].url" "${mohistApiUrl}"
 )
 
-baseName=$(basename "${buildRelPath}")
-if [[ ${baseName} != *-server.jar* ]]; then
-  logError "Mohist build for ${VERSION} is not a valid server jar, found ${baseName}"
+if [[ -z "${downloadUrl}" ]]; then
+  logError "Could not find build ${MOHIST_BUILD} for version ${VERSION}"
   logMohistAvailableVerisons
   exit 1
 fi
 
-export SERVER="/data/${baseName}"
+# Create server filename based on version and build number
+SERVER="/data/mohist-${VERSION}-${MOHIST_BUILD}-server.jar"
 
 if [ ! -f "${SERVER}" ]; then
-  log "Downloading ${baseName}"
-  get -o "${SERVER}" "${mohistJob}${MOHIST_BUILD}/artifact/${buildRelPath}"
+  log "Downloading Mohist build ${MOHIST_BUILD} for ${VERSION}"
+  get -o "${SERVER}" "${downloadUrl}"
 fi
 
 export FAMILY=HYBRID
+export SERVER
 
 exec "${SCRIPTS:-/}start-spiget" "$@"


### PR DESCRIPTION
Fixes #3246 
Tested on my end to work

```
% docker run -it -p 25565:25565 -e EULA=TRUE -e TYPE=MOHIST -e VERSION=1.20.1 -e MOHIST_BUILD=922 ana/minecraft-server
[init] Running as uid=1000 gid=1000 with /data as 'drwxr-x--- 2 1000 1000 4096 Jan 12 10:31 /data'
[init] Resolving type given MOHIST
[init] Resolved version given 1.20.1 into 1.20.1
[init] Downloading Mohist build 922 for 1.20.1
[init] Creating server properties in /data/server.properties
[init] Disabling whitelist functionality
[mc-image-helper] 10:33:54.686 INFO  : Created/updated 4 properties in /data/server.properties
[init] Setting initial memory to 1G and max to 1G
[init] Starting the Minecraft server...
File init exception!

 ███╗   ███╗  ██████╗  ██╗  ██╗ ██╗ ███████╗ ████████╗
 ████╗ ████║ ██╔═══██╗ ██║  ██║ ██║ ██╔════╝ ╚══██╔══╝
 ██╔████╔██║ ██║   ██║ ███████║ ██║ ███████╗    ██║
 ██║╚██╔╝██║ ██║   ██║ ██╔══██║ ██║ ╚════██║    ██║
 ██║ ╚═╝ ██║ ╚██████╔╝ ██║  ██║ ██║ ███████║    ██║
 ╚═╝     ╚═╝  ╚═════╝  ╚═╝  ╚═╝ ╚═╝ ╚══════╝    ╚═╝
 ```