### PR TITLE
feat: bump mc-server-runner & add note about bypassing `STOP_SERVER_ANNOUNCE_DELAY`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN easy-add --var os=${TARGETOS} --var arch=${TARGETARCH}${TARGETVARIANT} \
   --var version=${MC_MONITOR_VERSION} --var app=mc-monitor --file {{.app}} \
   --from ${GITHUB_BASEURL}/itzg/{{.app}}/releases/download/{{.version}}/{{.app}}_{{.version}}_{{.os}}_{{.arch}}.tar.gz
 
-ARG MC_SERVER_RUNNER_VERSION=1.12.3
+ARG MC_SERVER_RUNNER_VERSION=1.12.4
 RUN easy-add --var os=${TARGETOS} --var arch=${TARGETARCH}${TARGETVARIANT} \
   --var version=${MC_SERVER_RUNNER_VERSION} --var app=mc-server-runner --file {{.app}} \
   --from ${GITHUB_BASEURL}/itzg/{{.app}}/releases/download/{{.version}}/{{.app}}_{{.version}}_{{.os}}_{{.arch}}.tar.gz

--- a/docs/configuration/misc-options.md
+++ b/docs/configuration/misc-options.md
@@ -55,6 +55,8 @@ To allow time for players to finish what they're doing during a graceful server 
     
     The grace period can be increased using [the -t option on docker-compose down](https://docs.docker.com/compose/reference/down/) or set the [stop_grace_period](https://docs.docker.com/compose/compose-file/05-services/#stop_grace_period) in the compose file.
 
+The `STOP_SERVER_ANNOUNCE_DELAY` can be bypassed by sending a `SIGUSR1` signal to the `mc-server-runner` process.
+
 ## Configuration Options for Minecraft Server Health Monitoring
 
 The image tags include specific variables to simplify configuration for monitoring the health of a Minecraft server:

--- a/docs/configuration/misc-options.md
+++ b/docs/configuration/misc-options.md
@@ -57,6 +57,14 @@ To allow time for players to finish what they're doing during a graceful server 
 
 The `STOP_SERVER_ANNOUNCE_DELAY` can be bypassed by sending a `SIGUSR1` signal to the `mc-server-runner` process.
 
+`docker`:
+
+        docker stop --signal SIGUSR1 mc
+
+`docker compose`:
+
+        docker compose kill --signal SIGUSR1
+
 ## Configuration Options for Minecraft Server Health Monitoring
 
 The image tags include specific variables to simplify configuration for monitoring the health of a Minecraft server:


### PR DESCRIPTION
Feature introduced by https://github.com/itzg/mc-server-runner/pull/95

Should probably only be merged once a new version of `mc-server-runner` has been released and bumped.

Released in https://github.com/itzg/mc-server-runner/releases/tag/1.12.4