### PR TITLE
Feat: Disabling Mods in Generic Packs

### DIFF
--- a/docs/mods-and-plugins/index.md
+++ b/docs/mods-and-plugins/index.md
@@ -78,6 +78,20 @@ If applying large generic packs, the update can be time-consuming. To skip the u
 
 The most time-consuming portion of the generic pack update is generating and comparing the SHA1 checksum. To skip the checksum generation, set `SKIP_GENERIC_PACK_CHECKSUM` to "true".
 
+To disable specific mods, which can be useful for conflicts between multiple generic packs, you can use the `GENERIC_PACKS_DISABLE_MODS` variable to specify mods to disable.
+
+Disabling mods with docker run:
+```shell
+docker run -d -e GENERIC_PACKS_DISABLE_MODS=mod1.jar,mod2.jar ...
+```
+
+Disabling mods within docker compose files:
+```yaml
+      GENERIC_PACKS_DISABLE_MODS: |
+        mod1.jar
+        mod2.jar
+```
+
 ## Mods/plugins list
 
 You may also download or copy over individual mods/plugins using the `MODS` or `PLUGINS` environment variables. Both are a comma or newline delimited list of

--- a/docs/mods-and-plugins/index.md
+++ b/docs/mods-and-plugins/index.md
@@ -82,7 +82,7 @@ To disable specific mods, which can be useful for conflicts between multiple gen
 
 Disabling mods with docker run:
 ```shell
-docker run -d -e GENERIC_PACKS_DISABLE_MODS=mod1.jar,mod2.jar ...
+docker run -d -e GENERIC_PACKS_DISABLE_MODS="mod1.jar mod2.jar" ...
 ```
 
 Disabling mods within docker compose files:

--- a/scripts/start-setupModpack
+++ b/scripts/start-setupModpack
@@ -6,6 +6,7 @@ set -e -o pipefail
 : "${MODS:=}"
 : "${MODS_OUT_DIR:=/data/mods}"
 : "${MODS_FILE:=}"
+: "${DISABLED_MODS:=}"
 : "${PLUGINS:=}"
 : "${PLUGINS_OUT_DIR:=/data/plugins}"
 : "${PLUGINS_FILE:=}"
@@ -155,6 +156,7 @@ function handleGenericPacks() {
   : "${GENERIC_PACKS:=${GENERIC_PACK}}"
   : "${GENERIC_PACKS_PREFIX:=}"
   : "${GENERIC_PACKS_SUFFIX:=}"
+  : "${DISABLED_MODS:=${DISABLED_MODS}}"
 
   if [[ "${GENERIC_PACKS}" ]]; then
     IFS=',' read -ra packs <<< "${GENERIC_PACKS}"
@@ -190,6 +192,12 @@ function handleGenericPacks() {
       for pack in "${packFiles[@]}"; do
         isDebugging && ls -l "${pack}"
         extract "${pack}" "${base_dir}"
+      done
+
+      # Disable mods
+      for mod in ${DISABLED_MODS}; do
+	log Disabling $mod
+	find "${base_dir}" -name "$mod" -exec mv {} {}.DISABLED -v \;
       done
 
       # Remove any eula file since container manages it

--- a/scripts/start-setupModpack
+++ b/scripts/start-setupModpack
@@ -6,7 +6,7 @@ set -e -o pipefail
 : "${MODS:=}"
 : "${MODS_OUT_DIR:=/data/mods}"
 : "${MODS_FILE:=}"
-: "${DISABLE_MODS:=}"
+: "${GENERIC_PACKS_DISABLE_MODS:=}"
 : "${PLUGINS:=}"
 : "${PLUGINS_OUT_DIR:=/data/plugins}"
 : "${PLUGINS_FILE:=}"
@@ -156,7 +156,7 @@ function handleGenericPacks() {
   : "${GENERIC_PACKS:=${GENERIC_PACK}}"
   : "${GENERIC_PACKS_PREFIX:=}"
   : "${GENERIC_PACKS_SUFFIX:=}"
-  : "${DISABLE_MODS:=${DISABLE_MODS}}"
+  : "${GENERIC_PACKS_DISABLE_MODS:=}"
 
   if [[ "${GENERIC_PACKS}" ]]; then
     IFS=',' read -ra packs <<< "${GENERIC_PACKS}"
@@ -195,9 +195,9 @@ function handleGenericPacks() {
       done
 
       # Disable mods
-      for mod in ${DISABLE_MODS}; do
-	log Disabling $mod
-	find "${base_dir}" -name "$mod" -exec mv {} {}.DISABLED -v \;
+      for mod in ${GENERIC_PACKS_DISABLE_MODS}; do
+        log Disabling $mod
+        find "${base_dir}" -name "$mod" -exec mv {} {}.disabled -v \;
       done
 
       # Remove any eula file since container manages it

--- a/scripts/start-setupModpack
+++ b/scripts/start-setupModpack
@@ -6,7 +6,6 @@ set -e -o pipefail
 : "${MODS:=}"
 : "${MODS_OUT_DIR:=/data/mods}"
 : "${MODS_FILE:=}"
-: "${GENERIC_PACKS_DISABLE_MODS:=}"
 : "${PLUGINS:=}"
 : "${PLUGINS_OUT_DIR:=/data/plugins}"
 : "${PLUGINS_FILE:=}"
@@ -156,6 +155,7 @@ function handleGenericPacks() {
   : "${GENERIC_PACKS:=${GENERIC_PACK}}"
   : "${GENERIC_PACKS_PREFIX:=}"
   : "${GENERIC_PACKS_SUFFIX:=}"
+  : "${GENERIC_PACKS_DISABLE_MODS:=}"
 
   if [[ "${GENERIC_PACKS}" ]]; then
     IFS=',' read -ra packs <<< "${GENERIC_PACKS}"

--- a/scripts/start-setupModpack
+++ b/scripts/start-setupModpack
@@ -6,7 +6,7 @@ set -e -o pipefail
 : "${MODS:=}"
 : "${MODS_OUT_DIR:=/data/mods}"
 : "${MODS_FILE:=}"
-: "${DISABLED_MODS:=}"
+: "${DISABLE_MODS:=}"
 : "${PLUGINS:=}"
 : "${PLUGINS_OUT_DIR:=/data/plugins}"
 : "${PLUGINS_FILE:=}"
@@ -156,7 +156,7 @@ function handleGenericPacks() {
   : "${GENERIC_PACKS:=${GENERIC_PACK}}"
   : "${GENERIC_PACKS_PREFIX:=}"
   : "${GENERIC_PACKS_SUFFIX:=}"
-  : "${DISABLED_MODS:=${DISABLED_MODS}}"
+  : "${DISABLE_MODS:=${DISABLE_MODS}}"
 
   if [[ "${GENERIC_PACKS}" ]]; then
     IFS=',' read -ra packs <<< "${GENERIC_PACKS}"
@@ -195,7 +195,7 @@ function handleGenericPacks() {
       done
 
       # Disable mods
-      for mod in ${DISABLED_MODS}; do
+      for mod in ${DISABLE_MODS}; do
 	log Disabling $mod
 	find "${base_dir}" -name "$mod" -exec mv {} {}.DISABLED -v \;
       done

--- a/scripts/start-setupModpack
+++ b/scripts/start-setupModpack
@@ -156,7 +156,6 @@ function handleGenericPacks() {
   : "${GENERIC_PACKS:=${GENERIC_PACK}}"
   : "${GENERIC_PACKS_PREFIX:=}"
   : "${GENERIC_PACKS_SUFFIX:=}"
-  : "${GENERIC_PACKS_DISABLE_MODS:=}"
 
   if [[ "${GENERIC_PACKS}" ]]; then
     IFS=',' read -ra packs <<< "${GENERIC_PACKS}"


### PR DESCRIPTION
Adding the ability to disable mods for generic packs in `start-setupModpack` through a `DISABLE_MODS` environment variable.

Example of usage for something like running GTNH 2.7.2 with CrucibleMC, where `lwjgl3ify` and `archaicfix` need to be disabled for the pack to work:
```
  gtnh:
    image: itzg/minecraft-server
    container_name: gtnh
    tty: true
    stdin_open: true
    restart: unless-stopped
    environment:
      TYPE: CRUCIBLE
      VERSION: 1.7.10
      CRUCIBLE_RELEASE: staging-8ae5051
      GENERIC_PACKS: GT_New_Horizons_2.7.2_Server_Java_17-21
      GENERIC_PACKS_SUFFIX: .zip
      GENERIC_PACKS_PREFIX: https://downloads.gtnewhorizons.com/ServerPacks/
      DISABLE_MODS: |
        lwjgl3ify-2.1.5.jar
        archaicfix-0.7.4.jar
      ENABLE_QUERY: true
      EULA: TRUE
      MEMORY: 8G
      JVM_OPTS: -Dfml.readTimeout=180 @crucible-gtnh-java9args.txt
    ports:
      - '25565:25565'
    volumes:
      - ./gtnh/server:/data
      - ./gtnh/crucible-gtnh-java9args.txt:/data/crucible-gtnh-java9args.txt
      - ./gtnh/mods.txt:/data/mods.txt