### PR TITLE
Remove deprecated flag from mc-image-helper command in start-setupRbac

### DIFF
--- a/scripts/start-setupRbac
+++ b/scripts/start-setupRbac
@@ -77,12 +77,17 @@ if [[ -v WHITELIST_FILE ]]; then
 fi
 if [[ -v WHITELIST ]]; then
   args=()
-  if isTrue "${APPEND_WHITELIST:-false}" || isFalse "${OVERRIDE_WHITELIST:-true}"; then
-    args+=(--append-only)
-  fi
   existing="$EXISTING_WHITELIST_FILE"
   if [[ "$EXISTING_WHITELIST_FILE" = SYNC_FILE_MERGE_LIST ]]; then
     existing=MERGE
+  fi
+  # legacy option
+  if [[ -v APPEND_WHITELIST ]] && isTrue "${APPEND_WHITELIST}"; then
+    existing=MERGE
+  fi
+  # legacy option
+  if [[ -v OVERRIDE_WHITELIST ]] && isFalse "${OVERRIDE_WHITELIST}"; then
+    existing=SKIP
   fi
   # shellcheck disable=SC2086
   mc-image-helper manage-users \


### PR DESCRIPTION
The `--append-only` flag was removed from `mc-image-helper manage-users` in commit [5fbfd0e](https://github.com/itzg/mc-image-helper/commit/5fbfd0e31b50f8eab9b115f9681e7a5bd5807b09#diff-ebfa578788a4287084a9d0b5b0c25783b3dea399fd06bbaa9d1f9af88119019cL62). If `APPEND_WHITELIST` or `OVERRIDE_WHITELIST` are set to false the container fails to start. As far as I can tell it is safe to simply remove the section since if neither variable is set to true the script defaults to `--existing=MERGE` which is the desired behavior. 