### PR TITLE
Add sound-reload to cf-exclude-include.json

### DIFF
--- a/files/cf-exclude-include.json
+++ b/files/cf-exclude-include.json
@@ -113,6 +113,7 @@
     "sodium-extra",
     "sodium-options-api",
     "sodium-rubidium-occlusion-culling-fix",
+    "sound-reloader",
     "sound-filters",
     "sound-physics-remastered",
     "stellar-sky",


### PR DESCRIPTION
While installing [Dungeons, Dragons and Space Shuttles](https://www.curseforge.com/minecraft/modpacks/dungeons-dragons-and-space-shuttles) (Minecraft 1.12.2, Forge) with server type `AUTO_CURSEFORGE` the server crashed on start because an old mod named [Sound Reloader](https://www.curseforge.com/minecraft/mc-mods/sound-reloader) is client-side only but was installed server-side.

Given this mod hasn't been updated for over 7 years now, I figure it's easier to exclude it here than to fix the mod itself.

[crash-2025-02-16_16.51.20-server.txt](https://github.com/user-attachments/files/18815488/crash-2025-02-16_16.51.20-server.txt)
