### PR TITLE
fabric: skip web API access when all versions match installed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ RUN easy-add --var os=${TARGETOS} --var arch=${TARGETARCH}${TARGETVARIANT} \
   --var version=${MC_SERVER_RUNNER_VERSION} --var app=mc-server-runner --file {{.app}} \
   --from ${GITHUB_BASEURL}/itzg/{{.app}}/releases/download/{{.version}}/{{.app}}_{{.version}}_{{.os}}_{{.arch}}.tar.gz
 
-ARG MC_HELPER_VERSION=1.40.13
+ARG MC_HELPER_VERSION=1.41.1
 ARG MC_HELPER_BASE_URL=${GITHUB_BASEURL}/itzg/mc-image-helper/releases/download/${MC_HELPER_VERSION}
 # used for cache busting local copy of mc-image-helper
 ARG MC_HELPER_REV=1

--- a/examples/fabric/compose.yml
+++ b/examples/fabric/compose.yml
@@ -4,6 +4,9 @@ services:
     environment:
       EULA: "true"
       TYPE: FABRIC
+#      VERSION: 1.21.4
+#      FABRIC_INSTALLER_VERSION: 1.0.1
+#      FABRIC_LOADER_VERSION: 0.16.10
     ports:
       - "25565:25565"
     volumes:


### PR DESCRIPTION
Resolves #3331

NOTE: only applicable when VERSION, FABRIC_INSTALLER_VERSION, and FABRIC_LOADER_VERSION are set to specific versions