### PR TITLE
add sound to excluded mods as it crashes server on load.

### DIFF
--- a/files/cf-exclude-include.json
+++ b/files/cf-exclude-include.json
@@ -113,6 +113,7 @@
     "sodium-extra",
     "sodium-options-api",
     "sodium-rubidium-occlusion-culling-fix",
+    "sound",
     "sound-reloader",
     "sound-filters",
     "sound-physics-remastered",


### PR DESCRIPTION
This mod confusingly named [Sound​s](https://www.curseforge.com/minecraft/mc-mods/sound) with the slug `sound` is just incorrectly marked and crashes the server on load.