### PR TITLE
Exclude compass-coords globally from cf and mr, client side mod

### DIFF
--- a/files/cf-exclude-include.json
+++ b/files/cf-exclude-include.json
@@ -24,6 +24,7 @@
     "cherished-worlds",
     "chunk-animator",
     "clickable-advancements",
+    "compass-coords",
     "configured",
     "controlling",
     "craftpresence",

--- a/files/modrinth-exclude-include.json
+++ b/files/modrinth-exclude-include.json
@@ -22,6 +22,7 @@
     "cherishedworlds",
     "citresewn",
     "clickadv",
+    "compass-coords",
     "connectedness",
     "connector",
     "craftpresence",


### PR DESCRIPTION
Excludes this mod https://www.curseforge.com/minecraft/mc-mods/compass-coords (and https://modrinth.com/mod/compass-coords on MR)

Per the mod description "Needed on Client-side only, can't be installed on the server." and sure enough it crashed the server when installed. Came across this while trying to set up a the DawnCraft modpack