### PR TITLE
fixed logic to not compare the VERSION number when VERSION is set to …

### DIFF
--- a/files/auto/autopause-fcns.sh
+++ b/files/auto/autopause-fcns.sh
@@ -25,10 +25,16 @@ use_proxy() {
 }
 
 use_server_list_ping() {
+  if [[ "${VERSION^^}" == "LATEST" ]]; then
+    # Don't use server-list ping for unknown version
+    return 1
+  fi
+
   if versionLessThan 1.7; then
     echo "--use-server-list-ping"
   fi
 }
+
 
 mc_server_listening() {
   mc-monitor status $(use_proxy) --host "${SERVER_HOST:-localhost}" --port "$SERVER_PORT" $(use_server_list_ping) --timeout 10s >&/dev/null

--- a/files/auto/autopause-fcns.sh
+++ b/files/auto/autopause-fcns.sh
@@ -25,7 +25,7 @@ use_proxy() {
 }
 
 use_server_list_ping() {
-  if [[ "${VERSION^^}" == "LATEST" ]]; then
+  if [[ "${VERSION^^}" == "LATEST" || "${VERSION^^}" == "SNAPSHOT" ]]; then
     # Don't use server-list ping for unknown version
     return 1
   fi


### PR DESCRIPTION
…LATEST (default) and skip legacy flag in autopause