### PR TITLE
add resources key to docker compose jvm options

### DIFF
--- a/docs/configuration/jvm-options.md
+++ b/docs/configuration/jvm-options.md
@@ -46,8 +46,9 @@ To let the JVM calculate the heap size from the container declared memory limit,
           MEMORY: ""
           JVM_XX_OPTS: "-XX:MaxRAMPercentage=75"
         deploy:
-          limits:
-            memory: 4G  
+          resources:
+            limits:
+              memory: 4G  
     ```
 
 !!! important


### PR DESCRIPTION
resources key was missing in example:

https://docs.docker.com/reference/compose-file/deploy/#resources

```yaml
deploy:
      resources:
        limits:
          cpus: '0.50'
          memory: 50M
          pids: 1
        reservations:
          cpus: '0.25'
          memory: 20M`
```