### PR TITLE
Revert (for now) the feature to limit concurrent modpack file downloads

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ RUN easy-add --var os=${TARGETOS} --var arch=${TARGETARCH}${TARGETVARIANT} \
   --var version=${MC_SERVER_RUNNER_VERSION} --var app=mc-server-runner --file {{.app}} \
   --from ${GITHUB_BASEURL}/itzg/{{.app}}/releases/download/{{.version}}/{{.app}}_{{.version}}_{{.os}}_{{.arch}}.tar.gz
 
-ARG MC_HELPER_VERSION=1.41.8
+ARG MC_HELPER_VERSION=1.41.9
 ARG MC_HELPER_BASE_URL=${GITHUB_BASEURL}/itzg/mc-image-helper/releases/download/${MC_HELPER_VERSION}
 # used for cache busting local copy of mc-image-helper
 ARG MC_HELPER_REV=1

--- a/tests/setuponlytests/auto_curseforge/docker-compose.yml
+++ b/tests/setuponlytests/auto_curseforge/docker-compose.yml
@@ -7,9 +7,8 @@ services:
       MODPACK_PLATFORM: AUTO_CURSEFORGE
       CF_API_KEY: ${CF_API_KEY}
       CF_SLUG: the-pixelmon-modpack
-      CF_FILENAME_MATCHER: "9.1.2"
-      # Use the image bundled one to ensure latest is being tested
-      CF_EXCLUDE_INCLUDE_FILE: /image/cf-exclude-include.json
+      CF_FILENAME_MATCHER: "9.1.13"
+      DEBUG: true
     volumes:
       - ./data:/data
 

--- a/tests/setuponlytests/test.sh
+++ b/tests/setuponlytests/test.sh
@@ -47,6 +47,7 @@ setupOnlyMinecraftTest(){
   status=PASSED
   verify=
   if ! logs=$(docker compose run --rm -e SETUP_ONLY=true -e DEBUG="${DEBUG:-false}" mc 2>&1); then
+    status=FAILED
     outputContainerLog "$logs"
     result=1
   elif [ -f verify.sh ]; then


### PR DESCRIPTION
It was likely causing some newly observed networking issues. I'll need to research further a better way to limit the concurrent file downloads.

See https://github.com/itzg/mc-image-helper/releases/tag/1.41.9

https://github.com/itzg/mc-image-helper/pull/554