### PR TITLE
Add smithing-template-viewer to cf-exclude-include.json

### DIFF
--- a/files/cf-exclude-include.json
+++ b/files/cf-exclude-include.json
@@ -109,6 +109,7 @@
     "shulkerboxviewer",
     "skin-layers-3d",
     "smart-hud",
+    "smithing-template-viewer",
     "smooth-font",
     "smoothwater",
     "sodium",


### PR DESCRIPTION
I updated my [All The Mods 10](https://www.curseforge.com/minecraft/modpacks/all-the-mods-10) pack to version [2.46](https://github.com/AllTheMods/ATM-10/blob/main/changelogs/CHANGELOG-ATM10-2.45-2.46.md), and had a crash happen because of [smithing-template-viewer](https://www.curseforge.com/minecraft/mc-mods/smithing-template-viewer).
Therefore I added this mod to the environmental variable to exclude it (after deleting the jar file), and now the server starts just fine.

Thought it best to just have it globally excluded.

EDIT: They just updated to 2.47 ([no github changelog as of this edit](https://github.com/AllTheMods/ATM-10/blob/main/CHANGELOG.md))
Hotfix:
- Updated Smithing Template Viewer to fix a crash when rejoining worlds
- Updated Minecolonies to fix a connection crash
- Updated Almost Unified to fix some recipes missing
- Updated AllTheLeaks to fix a crash when indirectly breaking blocks
- Reverted Cataclysm loottable

I tried to remove `smithing-template-viewer` from the exclusion just to make sure it needs to be excluded, and the server crashed on startup because of it again. So it's safe to say it needs to be excluded from ATM10 at least.

The reason I tried to omit the exclusion is because I have no idea which mods are client mods. Though, the server complaining about screens and GUIs is kind of a large hint 🤪