### PR TITLE
patch: conditionally add knockd to sudoers file

### DIFF
--- a/files/auto/autopause-daemon.sh
+++ b/files/auto/autopause-daemon.sh
@@ -45,11 +45,7 @@ if isTrue "${DEBUG_AUTOPAUSE}"; then
   knockdArgs+=(-D)
 fi
 
-if isTrue "${SKIP_SUDO}"; then
-  /usr/local/sbin/knockd "${knockdArgs[@]}"
-else
-  sudo /usr/local/sbin/knockd "${knockdArgs[@]}"
-fi
+/usr/local/sbin/knockd "${knockdArgs[@]}"
 
 if [ $? -ne 0 ] ; then
   logAutopause "Failed to start knockd daemon."

--- a/files/sudoers-mc
+++ b/files/sudoers-mc
@@ -1,2 +1,1 @@
 minecraft ALL=(ALL) NOPASSWD:/usr/bin/pkill
-minecraft ALL=(ALL) NOPASSWD:/usr/local/sbin/knockd

--- a/scripts/start
+++ b/scripts/start
@@ -48,11 +48,6 @@ if ! isTrue "${SKIP_SUDO:-false}" && [ "$(id -u)" = 0 ]; then
     echo 'hosts: files dns' > /etc/nsswitch.conf
   fi
 
-  if [[ ${ENABLE_AUTOPAUSE^^} == TRUE ]]; then
-    log "Autopause is enabled, setting up permissions"
-    echo "minecraft ALL=(ALL) NOPASSWD:/usr/local/sbin/knockd" >> /etc/sudoers.d/sudoers-mc
-  fi
-
   exec $(getSudoFromDistro) ${runAsUser}:${runAsGroup} "${SCRIPTS:-/}start-configuration" "$@"
 else
   exec "${SCRIPTS:-/}start-configuration" "$@"

--- a/scripts/start
+++ b/scripts/start
@@ -48,6 +48,11 @@ if ! isTrue "${SKIP_SUDO:-false}" && [ "$(id -u)" = 0 ]; then
     echo 'hosts: files dns' > /etc/nsswitch.conf
   fi
 
+  if [[ ${ENABLE_AUTOPAUSE^^} == TRUE ]]; then
+    log "Autopause is enabled, setting up permissions"
+    echo "minecraft ALL=(ALL) NOPASSWD:/usr/local/sbin/knockd" >> /etc/sudoers.d/sudoers-mc
+  fi
+
   exec $(getSudoFromDistro) ${runAsUser}:${runAsGroup} "${SCRIPTS:-/}start-configuration" "$@"
 else
   exec "${SCRIPTS:-/}start-configuration" "$@"


### PR DESCRIPTION
If you are hosting this image for unknown users, sudo access to knockd can be used for privilege escalation _within_ the container.

There needs to be a lot of surrounding functionality for this to be a security risk, and for self-hosted minecraft servers this isn't a concern. I'm not 100% certain this is the correct approach, but I'm happy to make changes as necessary.

If you think this _is_ the correct approach I'm happy to update (with the help of [Peri123214](https://github.com/Peri123214)) the docs outlining the risk once this has been patched.

Big thanks to [Peri123214](https://github.com/Peri123214) for finding this.