### PR TITLE
File suffix support for CF_API_KEY

### DIFF
--- a/.github/workflows/verify-pr.yml
+++ b/.github/workflows/verify-pr.yml
@@ -81,11 +81,16 @@ jobs:
             BASE_IMAGE=${{ matrix.baseImage }}
           cache-from: type=gha,scope=${{ matrix.variant }}
 
+      - name: Generate CF API KEY secrets file
+        run: |
+          echo ${{ secrets.CF_API_KEY }} > tests/setuponlytests/auto_curseforge_file/cf_api_key.secret
+
       - name: Run tests
         env:
           MINECRAFT_VERSION: ${{ matrix.mcVersion }}
           VARIANT: ${{ matrix.variant }}
           CF_API_KEY: ${{ secrets.CF_API_KEY }}
+          CF_API_KEY_FILE_TEST: true
           DEBUG: ${{ runner.debug }}
         run: |
           tests/test.sh

--- a/docs/mods-and-plugins/curseforge-files.md
+++ b/docs/mods-and-plugins/curseforge-files.md
@@ -6,7 +6,7 @@ A specific file can be omitted from each reference to allow for auto-selecting t
 
 !!! warning "CurseForge API key usage"
 
-    A CurseForge API key must be allocated and set with `CF_API_KEY` [as described here](../types-and-platforms/mod-platforms/auto-curseforge.md#api-key).
+    A CurseForge API key must be allocated and set with `CF_API_KEY` (or `CF_API_KEY_FILE`) [as described here](../types-and-platforms/mod-platforms/auto-curseforge.md#api-key).
 
 ## Project-file references
 

--- a/docs/types-and-platforms/mod-platforms/auto-curseforge.md
+++ b/docs/types-and-platforms/mod-platforms/auto-curseforge.md
@@ -32,6 +32,20 @@ To manage a CurseForge modpack automatically with upgrade support, pinned or lat
     docker run --env-file=.env itzg/minecraft-server
     ```
 
+    Alternately you can use [docker secrets](https://docs.docker.com/compose/how-tos/use-secrets/) with a `CF_API_KEY_FILE` environment variable:
+    ```
+    service:
+      environment:
+        CF_API_KEY_FILE: /run/secrets/cf_api_key.secret
+      secrets:
+        - cf_api_key
+
+    secrets:
+      cf_api_key:
+        file: cf_api_key.secret
+    ```
+
+
 !!! note
     Be sure to use the appropriate [image tag for the Java version compatible with the modpack](../../versions/java.md).
     

--- a/docs/types-and-platforms/mod-platforms/auto-curseforge.md
+++ b/docs/types-and-platforms/mod-platforms/auto-curseforge.md
@@ -36,7 +36,7 @@ To manage a CurseForge modpack automatically with upgrade support, pinned or lat
     ```
     service:
       environment:
-        CF_API_KEY_FILE: /run/secrets/cf_api_key.secret
+        CF_API_KEY_FILE: /run/secrets/cf_api_key
       secrets:
         - cf_api_key
 

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -731,6 +731,12 @@ alternatively, you can mount: <code>/etc/localtime:/etc/localtime:ro
             <td>✅</td>
         </tr>
         <tr>
+            <td><code>CF_API_KEY_FILE</code></td>
+            <td>A path to a file inside of container that contains <strong>YOUR</strong> CurseForge (Eternal) API Key.</td>
+            <td><code></code></td>
+            <td>✅</td>
+        </tr>        
+        <tr>
             <td><code>CF_PAGE_URL</code></td>
             <td>Pass a page URL to the modpack or a specific file</td>
             <td><code></code></td>

--- a/scripts/start-deployAutoCF
+++ b/scripts/start-deployAutoCF
@@ -24,6 +24,11 @@ set -eu
 
 resultsFile=/data/.install-curseforge.env
 
+if [[ -n ${CF_API_KEY_FILE} ]]; then
+  CF_API_KEY="$(cat "${CF_API_KEY_FILE}")"
+  export CF_API_KEY
+fi
+
 isDebugging && set -x
 
 ensureRemoveAllModsOff "MODPACK_PLATFORM=AUTO_CURSEFORGE"

--- a/scripts/start-deployAutoCF
+++ b/scripts/start-deployAutoCF
@@ -21,6 +21,7 @@ set -eu
 : "${CF_DOWNLOADS_REPO=$([ -d /downloads ] && echo '/downloads' || echo '')}"
 : "${CF_MODPACK_MANIFEST:=}"
 : "${CF_API_CACHE_DEFAULT_TTL:=}" # as ISO-8601 duration, such as P2D or PT12H
+: "${CF_API_KEY_FILE:=}" # Path to file containing CurseForge API key
 
 resultsFile=/data/.install-curseforge.env
 

--- a/scripts/start-setupModpack
+++ b/scripts/start-setupModpack
@@ -11,6 +11,7 @@ set -e -o pipefail
 : "${PLUGINS_FILE:=}"
 : "${REMOVE_OLD_MODS_DEPTH:=1} "
 : "${REMOVE_OLD_MODS_INCLUDE:=*.jar,*-version.json}"
+: "${CF_API_KEY_FILE:=}" # Path to file containing CurseForge API key
 sum_file=/data/.generic_pack.sum
 
 if [[ -n ${CF_API_KEY_FILE} ]]; then

--- a/scripts/start-setupModpack
+++ b/scripts/start-setupModpack
@@ -13,6 +13,11 @@ set -e -o pipefail
 : "${REMOVE_OLD_MODS_INCLUDE:=*.jar,*-version.json}"
 sum_file=/data/.generic_pack.sum
 
+if [[ -n ${CF_API_KEY_FILE} ]]; then
+  CF_API_KEY="$(cat "${CF_API_KEY_FILE}")"
+  export CF_API_KEY
+fi
+
 # shellcheck source=start-utils
 . "${SCRIPTS:-/}start-utils"
 isDebugging && set -x

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,1 +1,2 @@
 data/
+cf_api_key.secret

--- a/tests/setuponlytests/auto_curseforge_file/docker-compose.yml
+++ b/tests/setuponlytests/auto_curseforge_file/docker-compose.yml
@@ -1,0 +1,18 @@
+services:
+  mc:
+    image: ${IMAGE_TO_TEST:-itzg/minecraft-server}
+    environment:
+      EULA: "true"
+      SETUP_ONLY: "TRUE"
+      MODPACK_PLATFORM: AUTO_CURSEFORGE
+      CF_API_KEY_FILE: /run/secrets/cf_api_key
+      CF_PAGE_URL: https://www.curseforge.com/minecraft/modpacks/the-pixelmon-modpack/files/5954570
+      DEBUG: true
+    volumes:
+      - ./data:/data
+    secrets:
+      - cf_api_key
+secrets:
+  cf_api_key:
+    file: cf_api_key.secret
+

--- a/tests/setuponlytests/auto_curseforge_file/require.sh
+++ b/tests/setuponlytests/auto_curseforge_file/require.sh
@@ -1,0 +1,1 @@
+[[ $CF_API_KEY_FILE_TEST ]] || exit 1

--- a/tests/setuponlytests/auto_curseforge_file/verify.sh
+++ b/tests/setuponlytests/auto_curseforge_file/verify.sh
@@ -1,0 +1,2 @@
+mc-image-helper assert fileExists "/data/mods/ExplorersCompass-1.16.5-1.1.2-forge.jar"
+mc-image-helper assert fileExists "/data/forge-1.16.5-36.2.34.jar"


### PR DESCRIPTION
### Summary

This PR enables setting the CF_API_KEY from Docker secrets using the standard _FILE suffix convention (e.g., CF_API_KEY_FILE). This aligns with common Docker patterns for secret management.

### Background

This implementation is largely based on the original PR #3388 by @MaxLevs, which was reverted due to a misunderstanding. Thanks to @MaxLevs for the foundational work.

### Changes

- Introduced support for CF_API_KEY_FILE to load the API key from a file.
- Updated relevant documentation to reflect the new configuration option.
- Added a test case: test_auto_curseforge_file.
- Integrated the test into the GitHub Actions workflow (verify_pr.yml).
- Added cf_api_key.secret to tests/.gitignore to allow for local secret-based testing.

### Testing

Local tests have passed successfully.

