### PR TITLE
build: pin mc-image-helper version for Java 8

### DIFF
--- a/.github/workflows/build-multiarch.yml
+++ b/.github/workflows/build-multiarch.yml
@@ -160,7 +160,7 @@ jobs:
           push: false
           build-args: |
             BASE_IMAGE=${{ matrix.baseImage }}
-            MC_HELPER_VERSION=${{ matrix.mcHelperVersion }}
+            ${{ matrix.mcHelperVersion && format('MC_HELPER_VERSION={0}', matrix.mcHelperVersion) }}
           cache-from: type=gha,scope=${{ matrix.variant }}
           # no cache-to to avoid cross-cache update from next build step
 
@@ -215,6 +215,6 @@ jobs:
             BUILDTIME=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
             VERSION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
             REVISION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.revision'] }}
-            MC_HELPER_VERSION=${{ matrix.mcHelperVersion }}
+            ${{ matrix.mcHelperVersion && format('MC_HELPER_VERSION={0}', matrix.mcHelperVersion) }}
           cache-from: type=gha,scope=${{ matrix.variant }}
           cache-to: type=gha,mode=max,scope=${{ matrix.variant }}

--- a/.github/workflows/build-multiarch.yml
+++ b/.github/workflows/build-multiarch.yml
@@ -79,18 +79,26 @@ jobs:
             baseImage: eclipse-temurin:8u312-b07-jre-focal
             platforms: linux/amd64,linux/arm/v7,linux/arm64
             mcVersion: 1.12.2
+            # Pin version for Java 8
+            mcHelperVersion: 1.42.1
           - variant: java8-graalvm-ce
             baseImage: ghcr.io/graalvm/graalvm-ce:java8
             platforms: linux/amd64
             mcVersion: 1.12.2
+            # Pin version for Java 8
+            mcHelperVersion: 1.42.1
           - variant: java8-jdk
             baseImage: eclipse-temurin:8u312-b07-jdk-focal
             platforms: linux/amd64,linux/arm64
             mcVersion: 1.12.2
+            # Pin version for Java 8
+            mcHelperVersion: 1.42.1
           - variant: java8-openj9
             baseImage: ibm-semeru-runtimes:open-8u312-b07-jre
             platforms: linux/amd64,linux/arm64
             mcVersion: 1.12.2
+            # Pin version for Java 8
+            mcHelperVersion: 1.42.1
     env:
       IMAGE_TO_TEST: "${{ github.repository_owner }}/minecraft-server:test-${{ matrix.variant }}-${{ github.run_id }}"
       HAS_IMAGE_REPO_ACCESS: ${{ secrets.DOCKER_USER != '' && secrets.DOCKER_PASSWORD != '' }}
@@ -152,6 +160,7 @@ jobs:
           push: false
           build-args: |
             BASE_IMAGE=${{ matrix.baseImage }}
+            MC_HELPER_VERSION=${{ matrix.mcHelperVersion }}
           cache-from: type=gha,scope=${{ matrix.variant }}
           # no cache-to to avoid cross-cache update from next build step
 
@@ -206,5 +215,6 @@ jobs:
             BUILDTIME=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
             VERSION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
             REVISION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.revision'] }}
+            MC_HELPER_VERSION=${{ matrix.mcHelperVersion }}
           cache-from: type=gha,scope=${{ matrix.variant }}
           cache-to: type=gha,mode=max,scope=${{ matrix.variant }}

--- a/.github/workflows/verify-pr.yml
+++ b/.github/workflows/verify-pr.yml
@@ -65,7 +65,7 @@ jobs:
           pull: true
           build-args: |
             BASE_IMAGE=${{ matrix.baseImage }}
-            MC_HELPER_VERSION=${{ matrix.mcHelperVersion }}
+            ${{ matrix.mcHelperVersion && format('MC_HELPER_VERSION={0}', matrix.mcHelperVersion) }}
           cache-from: type=gha,scope=${{ matrix.variant }}
 
       - name: Build for test
@@ -82,7 +82,7 @@ jobs:
           push: false
           build-args: |
             BASE_IMAGE=${{ matrix.baseImage }}
-            MC_HELPER_VERSION=${{ matrix.mcHelperVersion }}
+            ${{ matrix.mcHelperVersion && format('MC_HELPER_VERSION={0}', matrix.mcHelperVersion) }}
           cache-from: type=gha,scope=${{ matrix.variant }}
 
       - name: Run tests

--- a/.github/workflows/verify-pr.yml
+++ b/.github/workflows/verify-pr.yml
@@ -42,6 +42,8 @@ jobs:
             baseImage: eclipse-temurin:8u312-b07-jre-focal
             platforms: linux/amd64
             mcVersion: 1.12.2
+            # Pin version for Java 8
+            mcHelperVersion: 1.42.1
     env:
       IMAGE_TO_TEST: ${{ github.repository_owner }}/minecraft-server:test-${{ matrix.variant }}-${{ github.run_id }}
     runs-on: ubuntu-22.04
@@ -63,6 +65,7 @@ jobs:
           pull: true
           build-args: |
             BASE_IMAGE=${{ matrix.baseImage }}
+            MC_HELPER_VERSION=${{ matrix.mcHelperVersion }}
           cache-from: type=gha,scope=${{ matrix.variant }}
 
       - name: Build for test
@@ -79,6 +82,7 @@ jobs:
           push: false
           build-args: |
             BASE_IMAGE=${{ matrix.baseImage }}
+            MC_HELPER_VERSION=${{ matrix.mcHelperVersion }}
           cache-from: type=gha,scope=${{ matrix.variant }}
 
       - name: Run tests


### PR DESCRIPTION
Preparing for upgrading mc image helper to be built for Java 11 in order to gain language and JDK features. 