### PR TITLE
[DRAFT] Update start-finalExec

### DIFF
--- a/scripts/start-finalExec
+++ b/scripts/start-finalExec
@@ -253,14 +253,8 @@ if isTrue "${USE_MEOWICE_FLAGS}"; then
   -XX:+RewriteBytecodes
   -XX:+RewriteFrequentPairs
   -XX:+UseFPUForSpilling
-  -XX:+UseFastStosb
-  -XX:+UseNewLongLShift
   -XX:+UseVectorCmov
   -XX:+UseXMMForArrayCopy
-  -XX:+UseXmmI2D
-  -XX:+UseXmmI2F
-  -XX:+UseXmmLoadAndClearUpper
-  -XX:+UseXmmRegToRegMoveAll
   -XX:+EliminateLocks
   -XX:+DoEscapeAnalysis
   -XX:+AlignVector
@@ -269,8 +263,6 @@ if isTrue "${USE_MEOWICE_FLAGS}"; then
   -XX:+UseCharacterCompareIntrinsics
   -XX:+UseCopySignIntrinsic
   -XX:+UseVectorStubs
-  -XX:UseAVX=2
-  -XX:UseSSE=4
   "
 fi
 


### PR DESCRIPTION
Fixes #3495

I ran `java -XX:+PrintFlagsFinal -version` and removed those that are not available on the graavlm

It might be wise to have someone more experienced with JVM optimization and the differences between Virtual Machines to take a closer look at whether there are replacements for these flags in java21+ [and whether these flags are available in other JVMs, Meowice seems to say on his post that their recommendations require Graavlm]