### PR TITLE
Add back java16 variant for Paper 1.16.5 Also - remove non-JRE java8 variants to offset extra builds

### DIFF
--- a/.github/workflows/build-multiarch.yml
+++ b/.github/workflows/build-multiarch.yml
@@ -29,6 +29,7 @@ jobs:
           - java17
           - java17-graalvm
           - java17-alpine
+          - java16
           - java11
           - java8
           - java8-graalvm-ce
@@ -75,10 +76,16 @@ jobs:
             baseImage: eclipse-temurin:17-jre-alpine
             platforms: linux/amd64
             mcVersion: 1.20.4
+        # JAVA 16
+          - variant: java16
+            baseImage: adoptopenjdk:16-jre-hotspot
+            platforms: linux/amd64,linux/arm/v7,linux/arm64
+            mcVersion: 1.16.5
+        # JAVA 11
           - variant: java11
             baseImage: adoptopenjdk:11-jre-hotspot
             platforms: linux/amd64,linux/arm/v7,linux/arm64
-            mcVersion: 1.16.5
+            mcVersion: 1.16.4
         # JAVA 8: NOTE: Unable to go past 8u312 because of Forge dependencies
           - variant: java8
             baseImage: eclipse-temurin:8u312-b07-jre-focal

--- a/docs/versions/java.md
+++ b/docs/versions/java.md
@@ -10,31 +10,29 @@ or explicitly include the tag, such as
 
 where `<tag>` refers to the first column of this table:
 
-| Tag              | Java version | Linux  | JVM Type           | Architecture        | Note |
-|------------------|--------------|--------|--------------------|---------------------|------|
-| latest           | 21           | Ubuntu | Hotspot            | amd64, arm64        |      |
-| stable           | 21           | Ubuntu | Hotspot            | amd64, arm64        |      |
-| java24           | 24           | Ubuntu | Hotspot            | amd64, arm64        | (2)  |
-| java24-graalvm   | 24           | Oracle | Oracle GraalVM (3) | amd64, arm64        | (2)  |   
-| java21           | 21           | Ubuntu | Hotspot            | amd64, arm64        |      |
-| java21-jdk       | 21           | Ubuntu | Hotspot+JDK        | amd64, arm64        |      |
-| java21-alpine    | 21           | Alpine | Hotspot            | amd64, arm64        |      |
-| java21-graalvm   | 21           | Oracle | Oracle GraalVM (3) | amd64, arm64        |      |   
-| java17           | 17           | Ubuntu | Hotspot            | amd64, arm64, armv7 |      |
-| java17-graalvm   | 17           | Oracle | Oracle GraalVM (3) | amd64, arm64        |      |   
-| java17-alpine    | 17           | Alpine | Hotspot            | amd64  (1)          |      |
-| java11           | 11           | Ubuntu | Hotspot            | amd64, arm64, armv7 | (4)  |
-| java8            | 8            | Ubuntu | Hotspot            | amd64, arm64, armv7 |      |
-| java8-jdk        | 8            | Ubuntu | Hotspot+JDK        | amd64               |      |
-| java8-openj9     | 8            | Debian | OpenJ9             | amd64               |      |
-| java8-graalvm-ce | 8            | Oracle | GraalVM CE         | amd64               |      |
+| Tag            | Java version | Linux  | JVM Type           | Architecture        | Note |
+|----------------|--------------|--------|--------------------|---------------------|------|
+| latest         | 21           | Ubuntu | Hotspot            | amd64, arm64        |      |
+| stable         | 21           | Ubuntu | Hotspot            | amd64, arm64        |      |
+| java24         | 24           | Ubuntu | Hotspot            | amd64, arm64        | (2)  |
+| java24-graalvm | 24           | Oracle | Oracle GraalVM (3) | amd64, arm64        | (2)  |   
+| java21         | 21           | Ubuntu | Hotspot            | amd64, arm64        |      |
+| java21-jdk     | 21           | Ubuntu | Hotspot+JDK        | amd64, arm64        |      |
+| java21-alpine  | 21           | Alpine | Hotspot            | amd64, arm64        |      |
+| java21-graalvm | 21           | Oracle | Oracle GraalVM (3) | amd64, arm64        |      |   
+| java17         | 17           | Ubuntu | Hotspot            | amd64, arm64, armv7 |      |
+| java17-graalvm | 17           | Oracle | Oracle GraalVM (3) | amd64, arm64        |      |   
+| java17-alpine  | 17           | Alpine | Hotspot            | amd64  (1)          |      |
+| java16         | 16           | Ubuntu | Hotspot            | amd64, arm64, armv7 | (4)  |
+| java11         | 11           | Ubuntu | Hotspot            | amd64, arm64, armv7 |      |
+| java8          | 8            | Ubuntu | Hotspot            | amd64, arm64, armv7 |      |
 
 Notes
 
 1. Why no arm64 for Java 17 Alpine? That is because the base images, such as [elipse-temurin](https://hub.docker.com/_/eclipse-temurin/tags?page=&page_size=&ordering=&name=17-jre-alpine) do not provide support for that. Use the Ubuntu based images instead.
 2. Short-term variant, subject to deprecation upon next version introduction
 3. Based on the [Oracle GraalMV images](https://blogs.oracle.com/java/post/new-oracle-graalvm-container-images), which as of JDK 17, are now under the [GraalVM Free License](https://blogs.oracle.com/java/post/graalvm-free-license) incorporating what used to be known as the GraalVM Enterprise.
-4. This version of Java works with PaperMC, etc version 1.16.5
+4. This version of Java is [recommended for PaperMC 1.16.5](https://docs.papermc.io/paper/getting-started/#requirements)
 
 !!! example "Example using java8"
 
@@ -133,11 +131,11 @@ The following image tags have been deprecated and are no longer receiving update
 - adopt15
 - openj9-nightly
 - multiarch-latest
-- java16/java16-openj9
+- java16-openj9
 - java17-graalvm-ce
 - java17-openj9
 - java19
 - java20-graalvm, java20, java20-alpine
 - java23-*
 - java8-multiarch is still built and pushed, but please move to java8 instead
-- java8-alpine
+- java8-alpine, java8-jdk, java8-openj9, java8-graalvm-ce


### PR DESCRIPTION
PaperMC calls out Java 16 specifically

https://docs.papermc.io/paper/getting-started/#requirements

Also deprecating java8-jdk, java8-openj9, java8-graalvm-ce since the total number of build variants can't grow unbounded.