### PR TITLE
Docs: fix env var for enabling query

### DIFF
--- a/docs/configuration/server-properties.md
+++ b/docs/configuration/server-properties.md
@@ -256,7 +256,7 @@ By default, the server listens for RCON on port 25575 within the container. It c
 
 ### Query
 
-Set the environment variable `QUERY_PORT` to "true" to enable the gamespy query protocol. Map to the server property [enable-query](https://minecraft.wiki/w/Server.properties#enable-query). By default, the query port will be `25565` (UDP) but can be changed with the `QUERY_PORT` environment variable.
+Set the environment variable `ENABLE_QUERY` to "true" to enable the gamespy query protocol. Maps to the server property [enable-query](https://minecraft.wiki/w/Server.properties#enable-query). By default, the query port will be `25565` (UDP) but can be changed with the `QUERY_PORT` environment variable.
 
 ### Level Seed
 


### PR DESCRIPTION
The docs referred to `QUERY_PORT` as the right env var for enabling query in the server properties, but as noted later in the docs that's for configuring the port for query (maps to the `query.port` server property), not for enabling/disabling query.

The correct env var to reference here is `ENABLE_QUERY`, I think. Ref https://github.com/itzg/docker-minecraft-server/blob/master/files/property-definitions.json#L12