### PR TITLE
Fix pufferfish url script

### DIFF
--- a/scripts/start-deployPufferfish
+++ b/scripts/start-deployPufferfish
@@ -21,7 +21,9 @@ PUFFERFISH_BUILD_JSON=$(curl -X GET -s "https://ci.pufferfish.host/job/Pufferfis
 PUFFERFISH_BUILD_URL=$(jq -n "$PUFFERFISH_BUILD_JSON" | jq -jc '.url // empty' )
 # Example: "fileName": "pufferfish-paperclip-1.18.2-R0.1-SNAPSHOT-reobf.jar",
 PUFFERFISH_BUILD_FILENAME=$(jq -n "$PUFFERFISH_BUILD_JSON" | jq -jc '.artifacts[].fileName // empty' )
-PUFFERFISH_BUILD_DOWNLOAD_URL="${PUFFERFISH_BUILD_URL}artifact/build/libs/${PUFFERFISH_BUILD_FILENAME}"
+# Example: "relativePath": "pufferfish-server/build/libs/pufferfish-paperclip-1.21.7-R0.1-SNAPSHOT-mojmap.jar",
+PUFFERFISH_BUILD_PATH=$(jq -n "$PUFFERFISH_BUILD_JSON" | jq -jc '.artifacts[].relativePath // empty' )
+PUFFERFISH_BUILD_DOWNLOAD_URL="${PUFFERFISH_BUILD_URL}${PUFFERFISH_BUILD_PATH}"
 
 # Setting server to the Jar filename for export.
 export SERVER=$PUFFERFISH_BUILD_FILENAME


### PR DESCRIPTION
Fix a bad pufferfish url hardcode in script.

1.17:
https://ci.pufferfish.host/job/Pufferfish-1.17/lastSuccessfulBuild/api/json

<img width="631" height="404" alt="Captura de pantalla_2025-07-14_23-38-25" src="https://github.com/user-attachments/assets/a023df02-f297-456a-a308-3b69ab3c1e4e" />


1.21:
https://ci.pufferfish.host/job/Pufferfish-1.21/lastSuccessfulBuild/api/json

<img width="851" height="404" alt="Captura de pantalla_2025-07-14_23-35-56" src="https://github.com/user-attachments/assets/958b99a7-9dcb-4b09-b6e0-a6b3f4092d99" />
