### PR TITLE
modrinth: exclude welcomescreen

### DIFF
--- a/files/modrinth-exclude-include.json
+++ b/files/modrinth-exclude-include.json
@@ -86,7 +86,8 @@
     "YeetusExperimentus",
     "yungsmenutweaks",
     "Zoomify",
-    "zume"
+    "zume",
+    "welcomescreen"
   ],
   "globalForceIncludes": [],
   "modpacks": {}


### PR DESCRIPTION
[Welcome Screen](https://modrinth.com/mod/welcome-screen) is a client-side mod.