### PR TITLE
Fix typo in uname command in start-configuration

### DIFF
--- a/scripts/start-configuration
+++ b/scripts/start-configuration
@@ -50,7 +50,7 @@ fi
 
 if isTrue "${DEBUG_MEMORY:-false}"; then
   log "Memory usage and availability (in MB)"
-  uname -parts
+  uname -pars
   free -m
 fi
 


### PR DESCRIPTION
#3601 modified a call to the uname command. Now when `$DEBUG_MEMORY=true` it throws an error
```
[init] 2025-08-27 15:05:48+02:00 Memory usage and availability (in MB)
+ uname -parts
uname: invalid option -- 't'
Try 'uname --help' for more information.
```
I assume the `-t` switch is a typo since it's not available in any `uname` implementation I'm aware of. I removed it.