### PR TITLE
Fix for Eternal 2 Modpack

### DIFF
--- a/files/cf-exclude-include.json
+++ b/files/cf-exclude-include.json
@@ -170,7 +170,7 @@
       "forceIncludes": ["revelationary"]
     },
     "beyond-depth": {
-      "forceIncludes": ["particular-reforged"]		
+      "forceIncludes": ["particular-reforged"]
     },
     "create-arcane-engineering": {
       "forceIncludes": ["just-enough-resources-jer"]
@@ -186,9 +186,7 @@
       "excludes": ["modernfix"]
     },
     "mc-eternal-2": {
-      "forceIncludes": [
-        "mob-player-animator"
-      ] 
+      "forceIncludes": ["mob-player-animator"]
     }
   }
 }

--- a/files/cf-exclude-include.json
+++ b/files/cf-exclude-include.json
@@ -186,7 +186,10 @@
       "excludes": ["modernfix"]
     },
     "mc-eternal-2": {
-      "forceIncludes": ["mob-player-animator"]
+      "forceIncludes": [
+        "particular-reforged",
+        "mob-player-animator"
+      ]
     }
   }
 }

--- a/files/cf-exclude-include.json
+++ b/files/cf-exclude-include.json
@@ -184,6 +184,11 @@
     },
     "valhelsia-5": {
       "excludes": ["modernfix"]
+    },
+    "mc-eternal-2": {
+      "forceIncludes": [
+        "mob-player-animator"
+      ] 
     }
   }
 }


### PR DESCRIPTION
Fixes issue https://github.com/adam9899/MC-Eternal-2/issues/288 that prevented [Eternal 2](https://www.curseforge.com/minecraft/modpacks/mc-eternal-2) from completing world-gen by including [mob-player-animator](https://www.curseforge.com/minecraft/mc-mods/mob-player-animator) in the "forceIncludes" section of cf-exclude-include.json. Also includes [particular-reforged](https://www.curseforge.com/minecraft/mc-mods/particular-reforged) as the eternal-2 client expects this to be on the server.