### PR TITLE
cf: remove failed mod downloads

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN easy-add --var os=${TARGETOS} --var arch=${TARGETARCH}${TARGETVARIANT} \
   --var version=${MC_SERVER_RUNNER_VERSION} --var app=mc-server-runner --file {{.app}} \
   --from ${GITHUB_BASEURL}/itzg/{{.app}}/releases/download/{{.version}}/{{.app}}_{{.version}}_{{.os}}_{{.arch}}.tar.gz
 
-ARG MC_HELPER_VERSION=1.48.10
+ARG MC_HELPER_VERSION=1.48.11
 ARG MC_HELPER_BASE_URL=${GITHUB_BASEURL}/itzg/mc-image-helper/releases/download/${MC_HELPER_VERSION}
 # used for cache busting local copy of mc-image-helper
 ARG MC_HELPER_REV=1

--- a/examples/auto-curseforge/craftoria/docker-compose.yml
+++ b/examples/auto-curseforge/craftoria/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       EULA: true
       ALLOW_FLIGHT: true
       MOD_PLATFORM: AUTO_CURSEFORGE
+      CF_API_KEY: ${CF_API_KEY}
       CF_SLUG: craftoria
       MOTD: |
         A %TYPE% server on %VERSION%


### PR DESCRIPTION
Pulls in https://github.com/itzg/mc-image-helper/pull/626

Also
- set default to http 1.1 (from http/2)