### PR TITLE
move USE_AIKAR_FLAGS=TRUE into else block

### DIFF
--- a/scripts/start-finalExec
+++ b/scripts/start-finalExec
@@ -159,8 +159,8 @@ if isTrue "${USE_MEOWICE_FLAGS}"; then
   else
     log "Your Java version is $java_major_version, MeowIce's flags are for Java 17+ falling back to Aikar's"
     USE_MEOWICE_FLAGS=FALSE
+    USE_AIKAR_FLAGS=TRUE
   fi
-  USE_AIKAR_FLAGS=TRUE
 fi
 
 if isTrue "${USE_AIKAR_FLAGS}"; then


### PR DESCRIPTION
fixes aikar flags always being enabled along-side meowice flags.. I think..
from [conversation in discord server](https://canary.discord.com/channels/660567679458869252/660567682751528981/1413234096989274203)