### PR TITLE
fix: update autopause-fcns.sh path

### DIFF
--- a/files/shims/rcon-cmds-daemon.sh
+++ b/files/shims/rcon-cmds-daemon.sh
@@ -9,7 +9,7 @@
 
 # needed for the clients connected function residing in autopause
 # shellcheck source=../auto/autopause-fcns.sh
-. /auto/autopause-fcns.sh
+. /image/scripts/auto/autopause-fcns.sh
 
 # shellcheck source=start-utils
 . /image/scripts/start-utils

--- a/scripts/auto/autostop-daemon.sh
+++ b/scripts/auto/autostop-daemon.sh
@@ -49,7 +49,7 @@ do
     else
       if [[ $(current_uptime) -ge $TIME_THRESH ]] ; then
         logAutostop "No client connected since startup - stopping server"
-        /auto/stop.sh
+        "$(dirname "$0")"/stop.sh
         exit 0
       fi
     fi
@@ -74,7 +74,7 @@ do
     else
       if [[ $(current_uptime) -ge $TIME_THRESH ]] ; then
         logAutostop "No client reconnected - stopping"
-        /auto/stop.sh
+        "$(dirname "$0")"/stop.sh
         exit 0
       fi
     fi


### PR DESCRIPTION
Closes https://github.com/itzg/docker-minecraft-server/issues/3665

Found 2 other spots that I assume need to be updated.

There also may be a better way to update this path, not sure what you have in mind.