### PR TITLE
Add 'status-effect-bars-reforged' to global excludes

### DIFF
--- a/files/cf-exclude-include.json
+++ b/files/cf-exclude-include.json
@@ -148,6 +148,7 @@
     "sound-filters",
     "sound-physics-remastered",
     "sound-reloader",
+    "status-effect-bars-reforged",
     "stellar-sky",
     "swingthroughgrass",
     "textrues-embeddium-options",


### PR DESCRIPTION
I was trying to start up FTB Stoneblock 4 and this mod `Status Effect Bars Reforged` crashed my server.

I am also having some datapack issues, but that is a separate problem, I'll look into that after making this PR.

EDIT: Here is the link for the mod in question, in case you want to check it out https://www.curseforge.com/minecraft/mc-mods/status-effect-bars-reforged