### PR TITLE
fix(tests): ensure Nginx is fully spun up before starting MC container

### DIFF
--- a/tests/setuponlytests/generic-packs/docker-compose.yml
+++ b/tests/setuponlytests/generic-packs/docker-compose.yml
@@ -3,9 +3,15 @@ services:
     image: nginx
     volumes:
       - ./web:/usr/share/nginx/html
+    healthcheck:
+      test: ["CMD", "curl", "--fail", "http://localhost/configs.zip"]
+      interval: 3s
+      timeout: 5s
+      retries: 3
   mc:
     depends_on:
-      - web
+      web:
+        condition: service_healthy
     image: ${IMAGE_TO_TEST:-itzg/minecraft-server}
     environment:
       EULA: "true"

--- a/tests/setuponlytests/icon-gif-multiframe/docker-compose.yml
+++ b/tests/setuponlytests/icon-gif-multiframe/docker-compose.yml
@@ -3,9 +3,16 @@ services:
     image: nginx
     volumes:
       - ./web:/usr/share/nginx/html
+    healthcheck:
+      test:
+        ["CMD", "curl", "--fail", "http://localhost/motion-tween-example.gif"]
+      interval: 3s
+      timeout: 5s
+      retries: 3
   mc:
     depends_on:
-      - web
+      web:
+        condition: service_healthy
     image: ${IMAGE_TO_TEST:-itzg/minecraft-server}
     environment:
       EULA: "true"

--- a/tests/setuponlytests/icon-png-atscale/docker-compose.yml
+++ b/tests/setuponlytests/icon-png-atscale/docker-compose.yml
@@ -3,9 +3,21 @@ services:
     image: nginx
     volumes:
       - ./web:/usr/share/nginx/html
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "curl",
+          "--fail",
+          "http://localhost/4737386_minecraft_squircle_icon.png",
+        ]
+      interval: 3s
+      timeout: 5s
+      retries: 3
   mc:
     depends_on:
-      - web
+      web:
+        condition: service_healthy
     image: ${IMAGE_TO_TEST:-itzg/minecraft-server}
     environment:
       EULA: "true"

--- a/tests/setuponlytests/icon-png-scale/docker-compose.yml
+++ b/tests/setuponlytests/icon-png-scale/docker-compose.yml
@@ -3,9 +3,21 @@ services:
     image: nginx
     volumes:
       - ./web:/usr/share/nginx/html
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "curl",
+          "--fail",
+          "http://localhost/4737386_minecraft_squircle_icon.png",
+        ]
+      interval: 3s
+      timeout: 5s
+      retries: 3
   mc:
     depends_on:
-      - web
+      web:
+        condition: service_healthy
     image: ${IMAGE_TO_TEST:-itzg/minecraft-server}
     environment:
       EULA: "true"

--- a/tests/setuponlytests/packwiz/docker-compose.yml
+++ b/tests/setuponlytests/packwiz/docker-compose.yml
@@ -3,9 +3,15 @@ services:
     image: nginx
     volumes:
       - ./web:/usr/share/nginx/html
+    healthcheck:
+      test: ["CMD", "curl", "--fail", "http://localhost/pack.toml"]
+      interval: 3s
+      timeout: 5s
+      retries: 3
   mc:
     depends_on:
-      - web
+      web:
+        condition: service_healthy
     image: ${IMAGE_TO_TEST:-itzg/minecraft-server}
     environment:
       EULA: "true"


### PR DESCRIPTION
This change implements the behavior described in https://github.com/itzg/docker-minecraft-server/pull/3762#issuecomment-3536417072, which should help making test execution less racy.