### PR TITLE
fix(graalvm): update to Oracle Linux 10 to fix file command mimetype issues

### DIFF
--- a/.github/workflows/build-multiarch.yml
+++ b/.github/workflows/build-multiarch.yml
@@ -43,12 +43,12 @@ jobs:
             platforms: linux/amd64,linux/arm64
             mcVersion: latest
           - variant: java25-graalvm
-            baseImage: container-registry.oracle.com/graalvm/jdk:25-ol9
+            baseImage: container-registry.oracle.com/graalvm/jdk:25-ol10
             platforms: linux/amd64,linux/arm64
             mcVersion: latest
         # JAVA 21:
           - variant: java21-graalvm
-            baseImage: container-registry.oracle.com/graalvm/jdk:21-ol9
+            baseImage: container-registry.oracle.com/graalvm/jdk:21-ol10
             platforms: linux/amd64,linux/arm64
             mcVersion: latest
           - variant: java21
@@ -70,7 +70,7 @@ jobs:
             platforms: linux/amd64,linux/arm/v7,linux/arm64
             mcVersion: 1.20.4
           - variant: java17-graalvm
-            baseImage: container-registry.oracle.com/graalvm/jdk:17-ol9
+            baseImage: container-registry.oracle.com/graalvm/jdk:17-ol10
             platforms: linux/amd64,linux/arm64
             mcVersion: 1.20.4
           - variant: java17-alpine


### PR DESCRIPTION
While PR #3763 ensured that the Minecraft container no longer starts too early relative to the Nginx container during test execution, it didn't actually resolve the execution errors that appeared after upgrading the GraalVM images to Oracle Linux 9.

Luckily, after clearing my local Docker build cache, I was finally able to reproduce the issue locally using the commands outlined at <https://github.com/itzg/docker-minecraft-server/pull/3762#issuecomment-3536417072>. This allowed me to investigate the problem more deeply.

Using `docker exec`, I traced the root cause to a broken `file` command in Oracle Linux 9, which inconsistently reports MIME types for ZIP files. Some ZIP files I tested with were correctly identified as `application/zip`, but the problematic file, `tests/setuponlytests/generic-packs/web/configs.zip`, was an exception, as shown in https://github.com/itzg/docker-minecraft-server/actions/runs/19390730903/job/55483795809. Interestingly, the `file` command correctly identifies it as a ZIP file when the `--mime-type` flag is omitted: the issue lies solely in the MIME-type output.

Consequently, I decided to upgrade the base image to Oracle Linux 10, released in June 2025, ensuring the OS environment is as up-to-date as it gets. (For context, Oracle Linux 8, used before the bump to OL9, was originally released in 2019.) This update resolved the ZIP MIME-type inconsistencies, requiring only minor adjustments to the `install-packages.sh` script to account for naming changes in the latest OS release.

I've verified these changes to successfully restore passing CI results for GraalVM by achieving successful GraalVM workflow runs, which can be seen [here](https://github.com/AlexTMjugador/docker-minecraft-server/actions/runs/19392251445). (Only Alpine images are failing, but that's unrelated to any of the PRs I submitted lately.)

Thanks again to @itzg for the helpful pointers at https://github.com/itzg/docker-minecraft-server/pull/3763#issuecomment-3536622334 and the prompt reviews!