### PR TITLE
update docs copyright notice year

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,7 +16,6 @@ theme:
     - navigation.indexes
   locale: en
   palette:
-
     # Palette toggle for automatic mode
     - media: "(prefers-color-scheme)"
       toggle:
@@ -71,7 +70,7 @@ markdown_extensions:
       user: camalot
       repo: mkdocs-test
   - mkdocs-click
-copyright: Copyright &copy; itzg 2024.
+copyright: Copyright &copy; itzg 2025.
 plugins:
   - search
   - autorefs


### PR DESCRIPTION
noticed the copyright notice at the bottom of the docs page was out of date