### PR TITLE
Do not overwrite existing NanoLimbo settings.yml

### DIFF
--- a/files/nanolimbo-settings-patch.json
+++ b/files/nanolimbo-settings-patch.json
@@ -1,0 +1,12 @@
+{
+  "file": "/data/settings.yml",
+  "ops": [
+    {
+      "$set": {
+        "path": "$.bind.port",
+        "value": "${SERVER_PORT}",
+        "value-type": "int"
+      }
+    }
+  ]
+}

--- a/scripts/start-deployNanoLimbo
+++ b/scripts/start-deployNanoLimbo
@@ -160,22 +160,7 @@ traffic:
 EOF
 fi
 
-cat <<EOF > /tmp/settings-patch.json
-{
-  "file": "/data/settings.yml",
-  "ops": [
-    {
-      "\$set": {
-        "path": "$.bind.port",
-        "value": ${SERVER_PORT}
-      }
-    }
-  ]
-}
-EOF
-
-mc-image-helper patch /tmp/settings-patch.json && \
-rm /tmp/settings-patch.json
+mc-image-helper patch --patch-env-prefix "" /image/nanolimbo-settings-patch.json
 
 export SERVER
 export FAMILY=LIMBO


### PR DESCRIPTION
Ran into a likely edge case where any modified changes to the settings.yml is immediately overwritten by the `start-deployNanoLimbo` bash script every time the container starts. This change fixed it for me.