### PR TITLE
Use PAT for auto releaser runs

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -11,4 +11,5 @@ jobs:
         with:
           stable-duration: 3d
           force-duration: 14d
+          token: '${{ secrets.GH_TOKEN }}'
   


### PR DESCRIPTION
....otherwise the push-tag doesn't trigger the build and release workflow