### PR TITLE
Fix alignment of annotations on shell command on commands docs page

### DIFF
--- a/docs/sending-commands/commands.md
+++ b/docs/sending-commands/commands.md
@@ -25,8 +25,8 @@ If rcon is disabled you can send commands by passing them as arguments to the pa
 
 ```shell
 docker exec --user 1000 mc mc-send-to-console op player
-            |                     |
-            +- container name     +- Minecraft commands start here
+                        |                     |
+                        +- container name     +- Minecraft commands start here
 ```
 
 ## Enabling interactive console


### PR DESCRIPTION
#3477 modified the example showing how to send a command when RCON is disabled, but forgot to update the annotation explaining parts of the command so they're misaligned now.