### PR TITLE
Update log4j2.xml to use full timestamp format in PatternLayout

### DIFF
--- a/files/log4j2.xml
+++ b/files/log4j2.xml
@@ -2,13 +2,13 @@
 <Configuration status="WARN">
     <Appenders>
         <Console name="SysOut" target="SYSTEM_OUT">
-            <PatternLayout pattern="[%d{HH:mm:ss}] [%t/%level]: %msg%n" />
+            <PatternLayout pattern="[%d{yyyy-MM-dd HH:mm:ss}] [%t/%level]: %msg%n" />
         </Console>
         <Queue name="TerminalConsole">
-            <PatternLayout pattern="[%d{HH:mm:ss} %level]: %msg%n" />
+            <PatternLayout pattern="[%d{yyyy-MM-dd HH:mm:ss} %level]: %msg%n" />
         </Queue>
         <RollingRandomAccessFile name="File" fileName="logs/latest.log" filePattern="logs/%d{yyyy-MM-dd}-%i.log.gz">
-            <PatternLayout pattern="[%d{HH:mm:ss}] [%t/%level]: %msg%n" />
+            <PatternLayout pattern="[%d{yyyy-MM-dd HH:mm:ss}] [%t/%level]: %msg%n" />
             <Policies>
                 <!-- Based on filePattern resolution, so daily -->
                 <TimeBasedTriggeringPolicy />


### PR DESCRIPTION
Include year, month and day in log4j output.