### PR TITLE
Enable native access for quieter Java 25+ use of mc-image-helper

### DIFF
--- a/.github/workflows/build-multiarch.yml
+++ b/.github/workflows/build-multiarch.yml
@@ -92,19 +92,19 @@ jobs:
             platforms: linux/amd64,linux/arm/v7,linux/arm64
             mcVersion: 1.12.2
             # Pin version for Java 8
-#            mcHelperVersion: 1.46.0
+            mcHelperVersion: 1.51.1
           - variant: java8-graalvm-ce
             baseImage: ghcr.io/graalvm/graalvm-ce:java8
             platforms: linux/amd64
             mcVersion: 1.12.2
             # Pin version for Java 8
-#            mcHelperVersion: 1.46.0
+            mcHelperVersion: 1.51.1
           - variant: java8-jdk
             baseImage: eclipse-temurin:8u312-b07-jdk-focal
             platforms: linux/amd64,linux/arm64
             mcVersion: 1.12.2
             # Pin version for Java 8
-#            mcHelperVersion: 1.46.0
+            mcHelperVersion: 1.51.1
     env:
       IMAGE_TO_TEST: "${{ github.repository_owner }}/minecraft-server:test-${{ matrix.variant }}-${{ github.run_id }}"
       HAS_IMAGE_REPO_ACCESS: ${{ secrets.DOCKER_USER != '' && secrets.DOCKER_PASSWORD != '' }}

--- a/.github/workflows/verify-pr.yml
+++ b/.github/workflows/verify-pr.yml
@@ -1,8 +1,8 @@
 name: Verify PR
 on:
   pull_request:
-    branches: [ master ]
-    types: [assigned, opened, synchronize, labeled]
+    branches:
+      - master
     paths-ignore:
       - "*.md"
       - "docs/**"
@@ -44,7 +44,7 @@ jobs:
             platforms: linux/amd64
             mcVersion: 1.12.2
             # Pin version for Java 8
-#            mcHelperVersion: 1.42.1
+            mcHelperVersion: 1.51.1
     env:
       IMAGE_TO_TEST: ${{ github.repository_owner }}/minecraft-server:test-${{ matrix.variant }}-${{ github.run_id }}
     runs-on: ubuntu-22.04

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ RUN easy-add --var os=${TARGETOS} --var arch=${TARGETARCH}${TARGETVARIANT} \
   --var version=${MC_SERVER_RUNNER_VERSION} --var app=mc-server-runner --file {{.app}} \
   --from ${GITHUB_BASEURL}/itzg/{{.app}}/releases/download/{{.version}}/{{.app}}_{{.version}}_{{.os}}_{{.arch}}.tar.gz
 
-ARG MC_HELPER_VERSION=1.51.1
+ARG MC_HELPER_VERSION=1.52.0
 ARG MC_HELPER_BASE_URL=${GITHUB_BASEURL}/itzg/mc-image-helper/releases/download/${MC_HELPER_VERSION}
 # used for cache busting local copy of mc-image-helper
 ARG MC_HELPER_REV=1


### PR DESCRIPTION
**NOTE**

java8 builds are now pinned at 1.51.x versions of mc-image-helper.

Pulls in https://github.com/itzg/mc-image-helper/pull/680