### PR TITLE
Fix logError call when using CF_API_KEY_FILE

### DIFF
--- a/scripts/start-setupModpack
+++ b/scripts/start-setupModpack
@@ -11,7 +11,10 @@ set -e -o pipefail
 : "${REMOVE_OLD_MODS_INCLUDE:=*.jar,*-version.json}"
 : "${CF_API_KEY_FILE:=}" # Path to file containing CurseForge API key
 : "${MODRINTH_LOADER:=}"
-sum_file=/data/.generic_pack.sum
+
+# shellcheck source=start-utils
+. "$(dirname "$0")/start-utils"
+isDebugging && set -x
 
 if [[ -n ${CF_API_KEY_FILE} ]]; then
   if [[ -r "${CF_API_KEY_FILE}" ]]; then
@@ -23,13 +26,7 @@ if [[ -n ${CF_API_KEY_FILE} ]]; then
   fi
 fi
 
-# shellcheck source=start-utils
-. "$(dirname "$0")/start-utils"
-isDebugging && set -x
-
-#  CURSE_URL_BASE used in manifest downloads below
-CURSE_URL_BASE=${CURSE_URL_BASE:-https://minecraft.curseforge.com/projects}
-
+sum_file=/data/.generic_pack.sum
 # Remove old mods/plugins
 if isTrue "${REMOVE_OLD_MODS}" && [ -z "${MODS_FILE}" ]; then
   removeOldMods "$MODS_OUT_DIR"


### PR DESCRIPTION
Resolves

```
/image/scripts/start-setupModpack: line 21: logError: command not found
```