### PR TITLE
Fixed volume definition in docker-compose

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -35,7 +35,7 @@ where, in this case, the standard server port 25565 will be exposed on your host
         # ... image and environment section
         volumes:
           # attach the relative directory 'data' to the container's /data path
-          ./data:data
+          - ./data:data
     ```
 
 !!! note
@@ -84,3 +84,4 @@ Follow the logs of the container using `docker compose logs -f`, check on the st
 
 !!! note "Deployment Examples"
     The [deployments page](misc/deployment/index.md) provides more examples of deployment with and beyond Docker Compose.
+


### PR DESCRIPTION
I fixed the definition inside the documentation for the definition of the volumes. As far as I know, the volume section must be an enumeration and therefore requires the minus before each entry.