### PR TITLE
feat: pass loader and version type to Modrinth version resolution

### DIFF
--- a/scripts/start-configuration
+++ b/scripts/start-configuration
@@ -162,7 +162,7 @@ export DECLARED_VERSION="$VERSION"
 
 if isTrue "${VERSION_FROM_MODRINTH_PROJECTS:-}" && [[ ${MODRINTH_PROJECTS:-} ]]; then
   if ! VERSION=$(mc-image-helper version-from-modrinth-projects \
-    --loader "${TYPE^^}" \
+    --loader "${TYPE}" \
     --allowed-version-type "${MODRINTH_PROJECTS_DEFAULT_VERSION_TYPE:-release}" \
     --projects "${MODRINTH_PROJECTS}"); then
     logError "failed to resolve version from MODRINTH_PROJECTS: ${MODRINTH_PROJECTS}"


### PR DESCRIPTION
Updates 'start-configuration' to pass server 'TYPE' and 'MODRINTH_PROJECTS_DEFAULT_VERSION_TYPE' to the version resolution command. Related to itzg/docker-minecraft-server#3681