### PR TITLE
Decommission EXEC_DIRECTLY

### DIFF
--- a/docs/misc/autopause-autostop/autopause.md
+++ b/docs/misc/autopause-autostop/autopause.md
@@ -22,8 +22,6 @@ A `.skip-pause` file can be created in the `/data` directory to make the server 
 
 A starting, example compose file has been provided in [the examples](https://github.com/itzg/docker-minecraft-server/blob/master/examples/autopause/compose.yml).
 
-Auto-pause is not compatible with `EXEC_DIRECTLY=true` and the two cannot be set together.
-
 !!! note 
 
     When configuring kubernetes readiness/liveness health checks with auto-pause enabled, be sure to reference the `mc-health` wrapper script rather than `mc-status` directly.

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -440,12 +440,6 @@ alternatively, you can mount: <code>/etc/localtime:/etc/localtime:ro
             <td>⬜️</td>
         </tr>
         <tr>
-            <td><code>EXEC_DIRECTLY</code></td>
-            <td>If you would like to docker attach to the Minecraft server console with color and interactive capabilities, then set to <code>true</code></td>
-            <td><code>false</code></td>
-            <td>⬜️</td>
-        </tr>
-        <tr>
             <td><code>STOP_SERVER_ANNOUNCE_DELAY</code></td>
             <td>To allow time for players to finish what they're doing during a graceful server shutdown, set <code>STOP_SERVER_ANNOUNCE_DELAY</code> to a number of seconds to delay after an announcement is posted by the server.</td>
             <td><code></code></td>
@@ -644,10 +638,6 @@ alternatively, you can mount: <code>/etc/localtime:/etc/localtime:ro
 </table>
 
 ### Auto-Pause
-
-!!! note
-
-    Autopause is not compatible with `EXEC_DIRECTLY=true` and the two cannot be set together.
 
 <table>
     <thead>

--- a/scripts/start-configuration
+++ b/scripts/start-configuration
@@ -95,11 +95,6 @@ fi
 ##########################################
 # Auto-pause/stop
 
-if isTrue "${ENABLE_AUTOPAUSE}" && isTrue "${EXEC_DIRECTLY:-false}"; then
-    logError "EXEC_DIRECTLY=true is incompatible with ENABLE_AUTOPAUSE=true"
-    exit 1
-fi
-
 if isTrue "${ENABLE_AUTOPAUSE}" && isTrue "${ENABLE_AUTOSTOP}"; then
     logError "ENABLE_AUTOPAUSE=true is incompatible with ENABLE_AUTOSTOP=true"
     exit 1

--- a/scripts/start-finalExec
+++ b/scripts/start-finalExec
@@ -541,16 +541,12 @@ fi
   if isTrue "${DEBUG_EXEC}"; then
     set -x
   fi
-  if isTrue "${EXEC_DIRECTLY:-false}"; then
-    "${finalArgs[@]}"
-  else
-    if [ -f "${FTB_DIR}/variables.txt" ]; then
-        JVM_ARGS="${JVM_XX_OPTS} ${JVM_OPTS} $expandedDOpts"
-        JVM_ARGS=${JVM_ARGS//$'\n'/}
-        sed -i "s~JAVA_ARGS=.*~JAVA_ARGS=\"${JVM_ARGS}\"~" "${FTB_DIR}/variables.txt"
-    fi
-    exec mc-server-runner "${mcServerRunnerArgs[@]}" "${finalArgs[@]}"
+  if [ -f "${FTB_DIR}/variables.txt" ]; then
+      JVM_ARGS="${JVM_XX_OPTS} ${JVM_OPTS} $expandedDOpts"
+      JVM_ARGS=${JVM_ARGS//$'\n'/}
+      sed -i "s~JAVA_ARGS=.*~JAVA_ARGS=\"${JVM_ARGS}\"~" "${FTB_DIR}/variables.txt"
   fi
+  exec mc-server-runner "${mcServerRunnerArgs[@]}" "${finalArgs[@]}"
 elif [[ $SERVER =~ run.sh ]]; then
   log "Using Forge supplied run.sh script..."
   echo $JVM_XX_OPTS $JVM_OPTS $expandedDOpts > user_jvm_args.txt
@@ -599,9 +595,5 @@ else
     set -x
   fi
 
-  if isTrue "${EXEC_DIRECTLY:-false}"; then
-    exec java "${finalArgs[@]}"
-  else
-    exec mc-server-runner ${bootstrapArgs} "${mcServerRunnerArgs[@]}" java "${finalArgs[@]}"
-  fi
+  exec mc-server-runner ${bootstrapArgs} "${mcServerRunnerArgs[@]}" java "${finalArgs[@]}"
 fi


### PR DESCRIPTION
This removes support for the `EXEC_DIRECTLY` option, which previously allowed users to attach directly to the Minecraft server console.