### PR TITLE
Globally exclude crash-assistant mod

### DIFF
--- a/files/cf-exclude-include.json
+++ b/files/cf-exclude-include.json
@@ -35,6 +35,7 @@
     "controllable",
     "controlling",
     "craftpresence",
+    "crash-assistant",
     "cull-less-leaves",
     "ctm",
     "custom-main-menu",

--- a/files/modrinth-exclude-include.json
+++ b/files/modrinth-exclude-include.json
@@ -32,6 +32,7 @@
     "continuity",
     "controlling",
     "craftpresence",
+    "CrashAssistant",
     "Cull Less Leaves",
     "cwb",
     "DisableCustomWorldsAdvice",


### PR DESCRIPTION
crash-assistant is client side only and is known to cause issues in at least some cases, so it should be excluded by default.
Fixes #3838 