### PR TITLE
Add 'ctm' to forceIncludes for ftb-stoneblock-4

### DIFF
--- a/files/cf-exclude-include.json
+++ b/files/cf-exclude-include.json
@@ -183,7 +183,10 @@
       "forceIncludes": ["just-enough-resources-jer"]
     },
     "ftb-stoneblock-4": {
-      "forceIncludes": ["particular-reforged"]
+      "forceIncludes": [
+        "particular-reforged",
+        "ctm"
+      ]
     },
     "mc-eternal-2": {
       "forceIncludes": [


### PR DESCRIPTION
[ConnectedTexturesMod](https://www.curseforge.com/minecraft/mc-mods/ctm) (ctm) must be included in the Stoneblock 4 modpack because of [Chisel](https://www.curseforge.com/minecraft/mc-mods/chisel)