### PR TITLE
Leave docs sidebar nav collapsed by default

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,11 @@ on:
       - "examples/**"
       - "notes/**"
       - "kustomize/**"
+      - "docker-compose.yml"
       - "images.json"
+      - "compose-docs.yml"
+      - "zensical.toml"
+      - ".readthedocs.yaml"
 
 jobs:
   build:

--- a/.github/workflows/verify-pr.yml
+++ b/.github/workflows/verify-pr.yml
@@ -9,9 +9,11 @@ on:
       - "examples/**"
       - "notes/**"
       - "kustomize/**"
-      - "docker-compose*.yml"
-      - "mkdocs.yml"
+      - "docker-compose.yml"
       - "images.json"
+      - "compose-docs.yml"
+      - "zensical.toml"
+      - ".readthedocs.yaml"
 
 jobs:
   build:

--- a/zensical.toml
+++ b/zensical.toml
@@ -15,7 +15,6 @@ features = [
     "navigation.tabs",
     "navigation.tabs.sticky",
     "navigation.sections",
-    "navigation.expand",
     "navigation.top",
     "navigation.indexes"
 ]


### PR DESCRIPTION
On mobile devices it is overwhelming to scroll through all the expanded subpage listings.