### PR TITLE
Temporarily disable auto-pause with graalvm images

### DIFF
--- a/build/ol/install-packages.sh
+++ b/build/ol/install-packages.sh
@@ -64,12 +64,16 @@ fi
 # Clean up DNF when done
 dnf clean all
 
-# Download and install patched knockd
-curl -fsSL -o /tmp/knock.tar.gz https://github.com/Metalcape/knock/releases/download/0.8.1/knock-0.8.1-$TARGET.tar.gz
-tar -xf /tmp/knock.tar.gz -C /usr/local/ && rm /tmp/knock.tar.gz
-ln -s /usr/local/sbin/knockd /usr/sbin/knockd
-ls -l /usr/local/sbin/knockd
-setcap cap_net_raw=ep /usr/local/sbin/knockd
+cat <<EOF > /usr/local/sbin/knockd
+#!/bin/sh
+
+echo "Auto-pause (using knockd) is currently unavailable on graalvm image variants"
+echo "Consider using a different image variant https://docker-minecraft-server.readthedocs.io/en/latest/versions/java/"
+echo "or mc-router's auto scale up/down feature https://github.com/itzg/mc-router#docker-auto-scale-updown"
+exit 2
+EOF
+chmod 755 /usr/local/sbin/knockd
+# TODO restore retrieval from https://github.com/Metalcape/knock when tar's "Cannot open: Invalid argument" is solved
 
 # Set git credentials globally
 cat <<EOF >> /etc/gitconfig


### PR DESCRIPTION
Due to build-time issue with tar:

```
#36 202.9 tar: bin/knock: Cannot open: Invalid argument
#36 202.9 tar: etc/knockd.conf: Cannot open: Invalid argument
#36 202.9 tar: sbin/knockd: Cannot open: Invalid argument
#36 202.9 tar: sbin/knock_helper_ipt.sh: Cannot open: Invalid argument
#36 202.9 tar: share/man: Cannot mkdir: Invalid argument
#36 202.9 tar: share/man/man1: Cannot mkdir: Invalid argument
#36 202.9 tar: share/man/man1/knock.1: Cannot open: Invalid argument
#36 202.9 tar: share/man/man1/knockd.1: Cannot open: Invalid argument
#36 202.9 tar: share/doc: Cannot mkdir: Invalid argument
#36 202.9 tar: share/doc/knock: Cannot mkdir: Invalid argument
#36 202.9 tar: share/doc/knock/COPYING: Cannot open: Invalid argument
#36 202.9 tar: share/doc/knock/ChangeLog: Cannot open: Invalid argument
#36 202.9 tar: share/doc/knock/TODO: Cannot open: Invalid argument
#36 202.9 tar: share/doc/knock/README.md: Cannot open: Invalid argument
#36 202.9 tar: Exiting with failure status due to previous errors
```