### PR TITLE
Temporarily remove GraalVM variants from build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,17 +27,13 @@ jobs:
         variant:
           - java25
           - java25-jdk
-          - java25-graalvm
           - java21
           - java21-alpine
-          - java21-graalvm
           - java21-jdk
           - java17
-          - java17-graalvm
           - java16
           - java11
           - java8
-          - java8-graalvm-ce
           - java8-jdk
         include:
         # JAVA 25
@@ -49,15 +45,7 @@ jobs:
             baseImage: eclipse-temurin:25
             platforms: linux/amd64,linux/arm64
             mcVersion: latest
-          - variant: java25-graalvm
-            baseImage: container-registry.oracle.com/graalvm/jdk:25-ol10
-            platforms: linux/amd64,linux/arm64
-            mcVersion: latest
         # JAVA 21:
-          - variant: java21-graalvm
-            baseImage: container-registry.oracle.com/graalvm/jdk:21-ol10
-            platforms: linux/amd64,linux/arm64
-            mcVersion: latest
           - variant: java21
             baseImage: eclipse-temurin:21-jre
             platforms: linux/amd64,linux/arm64
@@ -76,10 +64,6 @@ jobs:
             baseImage: eclipse-temurin:17-jre-focal
             platforms: linux/amd64,linux/arm/v7,linux/arm64
             mcVersion: 1.20.4
-          - variant: java17-graalvm
-            baseImage: container-registry.oracle.com/graalvm/jdk:17-ol10
-            platforms: linux/amd64,linux/arm64
-            mcVersion: 1.20.4
         # JAVA 16
           - variant: java16
             baseImage: adoptopenjdk:16-jre-hotspot
@@ -94,12 +78,6 @@ jobs:
           - variant: java8
             baseImage: eclipse-temurin:8u312-b07-jre-focal
             platforms: linux/amd64,linux/arm/v7,linux/arm64
-            mcVersion: 1.12.2
-            # Pin version for Java 8
-            mcHelperVersion: 1.51.1
-          - variant: java8-graalvm-ce
-            baseImage: ghcr.io/graalvm/graalvm-ce:java8
-            platforms: linux/amd64
             mcVersion: 1.12.2
             # Pin version for Java 8
             mcHelperVersion: 1.51.1


### PR DESCRIPTION
Removed GraalVM variants for Java 25, 21, 17, and 8 from the build workflow.

The `tar` command bundled with Oracle Linux is not working when running in github actions. Weird 🤷

Failures look like

https://github.com/itzg/docker-minecraft-server/actions/runs/21500128278/job/61944413125#step:10:1493

```
#45 0.861 tar: mc-image-helper-1.52.1/lib: Cannot mkdir: Invalid argument
#45 0.883 tar: mc-image-helper-1.52.1/lib/mc-image-helper-1.52.1.jar: Cannot open: Invalid argument
#45 0.887 tar: mc-image-helper-1.52.1/lib/mbknor-jackson-jsonschema_2.13-1.0.39.jar: Cannot open: Invalid argument
#45 0.891 tar: mc-image-helper-1.52.1/lib/jackson-dataformat-toml-2.20.1.jar: Cannot open: Invalid argument
#45 0.894 tar: mc-image-helper-1.52.1/lib/jackson-dataformat-xml-2.20.1.jar: Cannot open: Invalid argument
#45 0.895 tar: mc-image-helper-1.52.1/lib/jackson-dataformat-yaml-2.20.1.jar: Cannot open: Invalid argument
#45 0.902 tar: mc-image-helper-1.52.1/lib/jackson-datatype-jsr310-2.20.1.jar: Cannot open: Invalid argument
#45 0.956 tar: mc-image-helper-1.52.1/lib/jackson-databind-2.20.1.jar: Cannot open: Invalid argument
#45 0.975 tar: mc-image-helper-1.52.1/lib/jackson-core-2.20.1.jar: Cannot open: Invalid argument
#45 0.984 tar: mc-image-helper-1.52.1/lib/logback-classic-1.3.16.jar: Cannot open: Invalid argument
#45 1.003 tar: mc-image-helper-1.52.1/lib/logback-core-1.3.16.jar: Cannot open: Invalid argument
#45 1.016 tar: mc-image-helper-1.52.1/lib/picocli-4.7.7.jar: Cannot open: Invalid argument
```