### PR TITLE
Temporarily remove particle-effects-reforged from global excludes

### DIFF
--- a/files/cf-exclude-include.json
+++ b/files/cf-exclude-include.json
@@ -120,7 +120,6 @@
     "packmenu",
     "packmodemenu",
     "particle-effects",
-    "particle-effects-reforged",
     "particle-rain",
     "particular",
     "particular-reforged",


### PR DESCRIPTION
[Reported in Discord](https://discord.com/channels/660567679458869252/660569641550217327/1468224648578732184)

At start of install-curseForge command it tries to resolve the global excludes but encounters:

```shell
2026-02-03T13:17:37.702167461Z [mc-image-helper] 13:17:37.701 ERROR : 'install-curseforge' command failed. Version is 1.52.1
2026-02-03T13:17:37.702212961Z me.itzg.helpers.errors.GenericException: No mods found with slug=particle-effects-reforged
2026-02-03T13:17:37.702215336Z 	at me.itzg.helpers.curseforge.CurseForgeApiClient.lambda$searchMod$2(CurseForgeApiClient.java:151)
2026-02-03T13:17:37.702216461Z 	at reactor.core.publisher.MonoFlatMap$FlatMapMain.onNext(MonoFlatMap.java:133)
2026-02-03T13:17:37.702217502Z

2026-02-03T13:17:37.702231711Z 	Suppressed: java.lang.Exception: #block terminated with an error
2026-02-03T13:17:37.702232586Z 		at reactor.core.publisher.BlockingSingleSubscriber.blockingGet(BlockingSingleSubscriber.java:104)
2026-02-03T13:17:37.702233586Z 		at reactor.core.publisher.Mono.block(Mono.java:1773)
2026-02-03T13:17:37.702234461Z 		at me.itzg.helpers.curseforge.CurseForgeInstaller.resolveExcludeIncludes(CurseForgeInstaller.java:697)
2026-02-03T13:17:37.702257252Z 		at me.itzg.helpers.curseforge.CurseForgeInstaller.getModFiles(CurseForgeInstaller.java:558)
2026-02-03T13:17:37.702258711Z 		at me.itzg.helpers.curseforge.CurseForgeInstaller.processModpack(CurseForgeInstaller.java:617)
2026-02-03T13:17:37.702260211Z  
```