### PR TITLE
Temporarily remove flerovium from global excludes

### DIFF
--- a/files/cf-exclude-include.json
+++ b/files/cf-exclude-include.json
@@ -71,7 +71,6 @@
     "faster-ladder-climbing",
     "fastquit",
     "fastquit-forge",
-    "flerovium",
     "foamfix-optimization-mod",
     "forgeskyboxes",
     "fps-reducer",


### PR DESCRIPTION
Same as https://github.com/itzg/docker-minecraft-server/pull/3902

[Reported in Discord](https://discord.com/channels/660567679458869252/660569641550217327/1468250641209233408)