### PR TITLE
Add 'neoculus' to cf-exclude-include.json

### DIFF
--- a/files/cf-exclude-include.json
+++ b/files/cf-exclude-include.json
@@ -110,6 +110,7 @@
     "mouse-tweaks",
     "neat",
     "nekos-enchanted-books",
+    "neoculus",
     "no-nv-flash",
     "no-recipe-book",
     "not-enough-animations",


### PR DESCRIPTION
I started up a Minecolonies Dimensional Adventure server and it crashed trying to load [NeOculus](https://www.curseforge.com/minecraft/mc-mods/neoculus). I set `CF_EXCLUDE_MODS=neoculus` and the server started fine. I'm assuming this is a client mod.