### PR TITLE
Exit early on failed GTNH packs retrieval

### DIFF
--- a/scripts/start-deployGTNH
+++ b/scripts/start-deployGTNH
@@ -8,10 +8,11 @@ function getGTNHdownloadPath(){
   gtnh_download_path=""
   current_java_version=$(mc-image-helper java-release)
     
-  if ! mapfile -t packs < <(curl -sfL 'http://downloads.gtnewhorizons.com/ServerPacks/?raw'); then
+  if ! packs_data="$(curl -sfL 'http://downloads.gtnewhorizons.com/ServerPacks/?raw')"; then
     logError "Failed to retrieve data from http://downloads.gtnewhorizons.com/ServerPacks/?raw"
     exit 1
   fi
+  mapfile -t packs <<< "$packs_data"
 
   log "Start locating server files..."
   for pack in "${packs[@]}"; do


### PR DESCRIPTION
I had to restore a GTNH server instance from a backup and thought I broke something since the server was not starting and instead outputting the below error message:

```text
[ERROR] Server files not found for GTNH_PACK_VERSION=2.8.4! Download not possible!
```

Turns out `gtnh_download_path` was not being set correctly because http://downloads.gtnewhorizons.com/ServerPacks/?raw is returning a 502 Bad Gateway error at the moment and `getGTNHdownloadPath` didn't exit early with the more descriptive message:

```text
[ERROR] Failed to retrieve data from http://downloads.gtnewhorizons.com/ServerPacks/?raw
```

The issue is caused by the `if ! mapfile -t packs < <(curl -sfL '...'); then` check succeeding even if the `curl` call fails since only the exit status of the `mapfile` is checked.

Changing the line to `if ! packs_data="$(curl -sfL '...')"; then` checks the exit code of `curl` instead of `mapfile`. With the change applied and the GTNH server still having issues I'm now getting the correct error message ("Failed  to retrieve data...").