### PR TITLE
Update start-deployGTNH to use hypeserv api since gtnh api is broken atm

### DIFF
--- a/scripts/start-deployGTNH
+++ b/scripts/start-deployGTNH
@@ -8,8 +8,8 @@ function getGTNHdownloadPath(){
   gtnh_download_path=""
   current_java_version=$(mc-image-helper java-release)
     
-  if ! packs_data="$(curl -sfL 'http://downloads.gtnewhorizons.com/ServerPacks/?raw')"; then
-    logError "Failed to retrieve data from http://downloads.gtnewhorizons.com/ServerPacks/?raw"
+  if ! packs_data="$(curl -sfL 'https://gtnh-versions.hypeserv.com/serverfiles')"; then
+    logError "Failed to retrieve data from https://gtnh-versions.hypeserv.com/serverfiles"
     exit 1
   fi
   mapfile -t packs <<< "$packs_data"


### PR DESCRIPTION
See https://github.com/itzg/docker-minecraft-server/issues/3932 for further information. Not tested, just doing this since no one else apparently did so.