### PR TITLE
Update link to example compose file for HTTP Proxy config

### DIFF
--- a/docs/configuration/misc-options.md
+++ b/docs/configuration/misc-options.md
@@ -166,7 +166,7 @@ such as:
 
 ## HTTP Proxy
 
-You may configure the use of an HTTP/HTTPS proxy by passing the proxy's "host:port" via the environment variable `PROXY`. In [the example compose file](https://github.com/itzg/docker-minecraft-server/blob/master/examples/docker-compose-proxied.yml) it references a Squid proxy. The host and port can be separately passed via the environment variables `PROXY_HOST` and `PROXY_PORT`. A `|` delimited list of hosts to exclude from proxying can be passed via `PROXY_NON_PROXY_HOSTS`.
+You may configure the use of an HTTP/HTTPS proxy by passing the proxy's "host:port" via the environment variable `PROXY`. In [the example compose file](https://github.com/itzg/docker-minecraft-server/blob/master/examples/proxied/compose.yml) it references a Squid proxy. The host and port can be separately passed via the environment variables `PROXY_HOST` and `PROXY_PORT`. A `|` delimited list of hosts to exclude from proxying can be passed via `PROXY_NON_PROXY_HOSTS`.
 
 ## Using "noconsole" option
 


### PR DESCRIPTION
Quick little doc fix. I assume the compose file was moved at some point and this link was understandably missed.