### PR TITLE
build: adjust RTD config to explicitly use docs/requirements.txt

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,19 +1,15 @@
 version: 2
 
-python:
-  install:
-    - requirements: docs/requirements.txt
-
 build:
   os: ubuntu-24.04
   tools:
-    python: latest
+    python: "3.14"
   jobs:
     # We recommend using a requirements file for reproducible builds.
     # This is just a quick example to get started.
     # https://docs.readthedocs.io/page/guides/reproducible-builds.html
     install:
-      - pip install zensical
+      - pip install -r docs/requirements.txt
     build:
       html:
         - zensical build

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -22,4 +22,4 @@ PyYAML==6.0.3
 pyyaml_env_tag==1.1
 six==1.17.0
 watchdog==6.0.0
-# zensical @ file:///
+zensical==0.0.24


### PR DESCRIPTION
Trying to fix an issue where only when serving from RTD site, typing 'd' in the search box does nothing.