### PR TITLE
add more examples for new minecraft version schema

### DIFF
--- a/docs/versions/minecraft.md
+++ b/docs/versions/minecraft.md
@@ -2,7 +2,8 @@ To use a different Minecraft version, pass the `VERSION` environment variable (c
 
 - `LATEST` for latest release (the default)
 - `SNAPSHOT` for latest snapshot
-- a specific version, such as `1.7.9`, `25w35a`, `26.1`, `26.1-snapshot-1`, `26.1-pre-1`, or `26.1-rc-1`
+- a specific legacy version, such as `1.7.9`, `25w35a`, `1.15.2-pre2` or `1.21.11-rc1`
+- a specific [new version numbering system](https://www.minecraft.net/en-us/article/minecraft-new-version-numbering-system) version like `26.1`, `26.1-snapshot-1`, `26.1-pre-1`, or `26.1-rc-1`
 - or an alpha and beta version, such as "b1.7.3" (server download might not exist)
 
 For example, to use the latest snapshot:


### PR DESCRIPTION
I had to query the API just to be sure of how to specify pre-release and release candidates, so I thought I'd just add them as examples to the docs.

Could maybe make sense to change the layout of this page completely and use a table instead or something, but you let me know on that :)
