### PR TITLE
Added force include JER to Wold's Vaults in cf-exclude-include.json

### DIFF
--- a/files/cf-exclude-include.json
+++ b/files/cf-exclude-include.json
@@ -211,6 +211,9 @@
     },
     "valhelsia-5": {
       "excludes": ["modernfix"]
+    },
+    "wolds-vaults": {
+      "forceIncludes": ["just-enough-resources-jer"]
     }
   }
 }


### PR DESCRIPTION
Wold's Vaults uses [JER Loot Table Sync](https://www.curseforge.com/minecraft/mc-mods/jer-loot-table-sync) which needs [Just Enough Resources (JER)](https://www.curseforge.com/minecraft/mc-mods/just-enough-resources-jer) to load.