### PR TITLE
Add optional Modrinth projects support (`?` suffix)

### DIFF
--- a/docs/mods-and-plugins/modrinth.md
+++ b/docs/mods-and-plugins/modrinth.md
@@ -4,7 +4,7 @@
 
 ## Usage
 
-To use this feature, set the environment variable `MODRINTH_PROJECTS` to a comma or newline separated list of projects.  
+To use this feature, set the environment variable `MODRINTH_PROJECTS` to a comma or newline separated list of projects.
 
 Each project entry can be any of the following combinations where a colon (`:`) is used to separate the different parts:
 
@@ -24,8 +24,8 @@ Where:
 - **Version** is the version ID (such as "Oa9ZDzZq") or number (such as "2.21.2"). When omitted, the latest release version will be selected. Using version ID will override Minecraft and loader compatibility checks.
 - **Release Type** is `release`, `beta`, or `alpha` indicating the latest version to select.
 - **Prefix** is `datapack`, `fabric`, `forge`, or `paper`
-    - The `datapack` prefix is optional when running a vanilla server
-    - The `fabric`, `forge`, and `paper` prefixes allow for installing mods/plugins that differ from server's `TYPE`. Using [Sinytra Connector](https://modrinth.com/mod/connector) is an example of this, where Fabric mods can be loaded into a NeoForge server.
+  - The `datapack` prefix is optional when running a vanilla server
+  - The `fabric`, `forge`, and `paper` prefixes allow for installing mods/plugins that differ from server's `TYPE`. Using [Sinytra Connector](https://modrinth.com/mod/connector) is an example of this, where Fabric mods can be loaded into a NeoForge server.
 - **Listing file** is a container path to a file containing a list of projects
 
 !!! tip "Project ID"
@@ -47,9 +47,9 @@ Where:
     ![Version ID](../img/modrinth-version-id.drawio.png)
 
 ### Examples
-            
+
 | Description                     | Example projects entry                                |
-|---------------------------------|-------------------------------------------------------|
+| ------------------------------- | ----------------------------------------------------- |
 | Select latest version           | `fabric-api`                                          |
 | Select specific version         | `fabric-api:bQZpGIz0`<br/>`fabric-api:0.119.2+1.21.4` |
 | Select latest beta version      | `fabric-api:beta`                                     |
@@ -64,15 +64,15 @@ Where:
 !!! info "More about listing files"
 
     Each line in the listing file is processed as one of the references above; however, blank lines and comments that start with `#` are ignored.
-    
+
     Make sure to place the listing file in a mounted directory/volume or declare an appropriate mount for it.
-    
+
     For example, `MODRINTH_PROJECTS` can be set to "@/extras/modrinth-mods.txt", assuming "/extras" has been added to `volumes` section, where the container file `/extras/modrinth-mods.txt` contains
-    
+
     ```text
     # This comment is ignored
     fabric-api
-    
+
     # This and previous blank line are ignore
     cloth-config
     datapack:terralith
@@ -93,7 +93,7 @@ When the environment variable `VERSION_FROM_MODRINTH_PROJECTS` is set to "true" 
 !!! example
 
     Given the environment variables
-    
+
     ```yaml
         MODRINTH_PROJECTS: |
           viaversion
@@ -102,7 +102,7 @@ When the environment variable `VERSION_FROM_MODRINTH_PROJECTS` is set to "true" 
           discordsrv
         VERSION_FROM_MODRINTH_PROJECTS: true
     ```
-    
+
     Let's say all are supported on Minecraft up to 1.21.8 except griefprevention, which is only supported up to 1.21.7. In that case, `VERSION` will be automatically set to 1.21.7.
 
 ## Extra options
@@ -116,3 +116,102 @@ When the environment variable `VERSION_FROM_MODRINTH_PROJECTS` is set to "true" 
 `MODRINTH_LOADER`
 : When using a custom server, set this to specify which loader type will be requested during lookups
 
+## Optional projects
+
+Projects that are not critical for the server to function can be marked as **optional** by appending a `?` to the project slug or ID. When a compatible version cannot be found for an optional project, the server logs a warning and continues startup instead of failing.
+
+This is useful for mods like map renderers, aesthetic plugins, or QoL mods that tend to lag behind on Minecraft updates.
+
+```yaml
+MODRINTH_PROJECTS: |
+  fabric-api
+  lithium
+  pl3xmap?
+  bluemap?:beta
+```
+
+The `?` marker can be combined with all existing format options:
+
+| Format             | Example                     |
+| ------------------ | --------------------------- |
+| Slug only          | `pl3xmap?`                  |
+| With version       | `pl3xmap?:Oa9ZDzZq`         |
+| With release type  | `pl3xmap?:beta`             |
+| With loader prefix | `fabric:pl3xmap?`           |
+| Full combination   | `fabric:pl3xmap?:beta`      |
+| In listing files   | `pl3xmap?` _(one per line)_ |
+
+When combined with [`VERSION_FROM_MODRINTH_PROJECTS`](#version-from-projects), optional projects are **excluded** from the version calculation. This means an optional mod that hasn't been updated yet will never block a Minecraft version upgrade.
+
+!!! example "Automatic upgrades without optional-mod breakage"
+
+```yaml
+MODRINTH_PROJECTS: |
+  fabric-api
+  lithium
+  pl3xmap?
+VERSION_FROM_MODRINTH_PROJECTS: true
+```
+
+If Minecraft 26.2 is released and `fabric-api` + `lithium` support it but `pl3xmap` does not:
+
+1. The resolved `VERSION` is set to 26.2 (pl3xmap is not considered)
+2. `fabric-api` and `lithium` are installed normally
+3. `pl3xmap` is skipped with a warning in the logs
+4. On a future restart, once pl3xmap publishes a 26.2 build, it is picked up automatically
+
+> [!NOTE]
+> Optional projects marked with `?` in listing files (`@/path/to/file.txt`) are supported, the `?` is parsed from each line the same way as inline entries.
+
+## 5. Test: `tests/setuponlytests/modrinth-optional/`
+
+### `docker-compose.yml`
+
+```yaml
+services:
+  mc:
+    image: ${IMAGE_TO_TEST:-itzg/minecraft-server}
+    environment:
+    EULA: "true"
+    SETUP_ONLY: "true"
+    TYPE: FABRIC
+    VERSION: 1.21.4
+    MODRINTH_PROJECTS: |
+      fabric-api
+      cloth-config
+      this-mod-does-not-exist-xyz123?
+    volumes:
+      - ./data:/data
+```
+
+### `verify.sh`
+
+```bash
+mc-image-helper assert fileExists "mods/cloth-config-*.jar" "mods/fabric-api-*.jar"
+```
+
+## How it works
+
+```
+MODRINTH_PROJECTS="fabric-api\nlithium\npl3xmap?"
+
+    ┌─ parseOptionalModrinthProjects() ──┐
+    │                                    │
+    │  required: fabric-api, lithium     │
+    │  optional: pl3xmap                 │
+    │  all-clean: fabric-api, lithium,   │
+    │             pl3xmap                │
+    └────────────────────────────────────┘
+
+VERSION_FROM_MODRINTH_PROJECTS?
+├─ yes -> resolve version from required only
+└─ no  -> use VERSION as-is
+
+Download phase:
+├─ Try all-clean -> success? -> done
+└─ Fail?
+    ├─ Install required only (with tracking)
+    └─ For each optional:
+        ├─ available -> install + log success
+        └─ not found -> log warning, continue
+```

--- a/scripts/start-configuration
+++ b/scripts/start-configuration
@@ -160,8 +160,21 @@ if isTrue "${VERSION_FROM_MODRINTH_PROJECTS:-}" && [[ ${MODRINTH_PROJECTS:-} ]];
   if [[ ${MODRINTH_PROJECTS_DEFAULT_VERSION_TYPE:-} ]]; then
     args+=(--allowed-version-type "${MODRINTH_PROJECTS_DEFAULT_VERSION_TYPE:-}")
   fi
-  if ! VERSION=$(mc-image-helper version-from-modrinth-projects "${args[@]}" --projects "${MODRINTH_PROJECTS}"); then
-    logError "failed to resolve version from MODRINTH_PROJECTS: ${MODRINTH_PROJECTS}"
+
+  # Only required (non-optional) projects constrain the Minecraft version.
+  # Optional projects (marked with ?) must not hold back an upgrade.
+  parseOptionalModrinthProjects "${MODRINTH_PROJECTS}"
+  local versionProjects="${_REQUIRED_MODRINTH_PROJECTS}"
+
+  if [[ -z "$versionProjects" ]]; then
+    # Every project is optional: fall back to using all of them
+    versionProjects="${_ALL_MODRINTH_PROJECTS_CLEAN}"
+  elif [[ -n "$_OPTIONAL_MODRINTH_PROJECTS" ]]; then
+    log "Resolving Minecraft version from required projects only (optional projects will not restrict the version)"
+  fi
+
+  if ! VERSION=$(mc-image-helper version-from-modrinth-projects "${args[@]}" --projects "${versionProjects}"); then
+    logError "failed to resolve version from MODRINTH_PROJECTS: ${versionProjects}"
     exit 1
   fi
   log "Resolved Minecraft version $VERSION from Modrinth projects"

--- a/scripts/start-setupModpack
+++ b/scripts/start-setupModpack
@@ -274,14 +274,52 @@ function handleModrinthProjects() {
       loader="${TYPE,,}"
     fi
 
-    mc-image-helper modrinth \
-      --output-directory=/data \
-      --world-directory="${LEVEL:-world}" \
-      --projects="${MODRINTH_PROJECTS}" \
-      --game-version="${VERSION}" \
-      --loader="$loader" \
-      --download-dependencies="$MODRINTH_DOWNLOAD_DEPENDENCIES" \
+    # Parse optional vs required projects
+    parseOptionalModrinthProjects "${MODRINTH_PROJECTS}"
+
+    local modrinthArgs=(
+      --output-directory=/data
+      --world-directory="${LEVEL:-world}"
+      --game-version="${VERSION}"
+      --loader="$loader"
+      --download-dependencies="$MODRINTH_DOWNLOAD_DEPENDENCIES"
       --allowed-version-type="$MODRINTH_PROJECTS_DEFAULT_VERSION_TYPE"
+    )
+
+    if [[ -z "$_OPTIONAL_MODRINTH_PROJECTS" ]]; then
+      # No optional projects: standard behaviour, fail on any error
+      mc-image-helper modrinth "${modrinthArgs[@]}" \
+        --projects="${MODRINTH_PROJECTS}"
+    else
+      # Try all projects first (? markers stripped)
+      if mc-image-helper modrinth "${modrinthArgs[@]}" \
+        --projects="${_ALL_MODRINTH_PROJECTS_CLEAN}"; then
+        # Everything resolved: nothing else to do
+        :
+      else
+        logWarning "Some mods could not be resolved for ${VERSION}/${loader}."
+        logWarning "Retrying with required mods only..."
+
+        # Install required mods with proper tracking / auto-cleanup
+        if [[ -n "$_REQUIRED_MODRINTH_PROJECTS" ]]; then
+          mc-image-helper modrinth "${modrinthArgs[@]}" \
+            --projects="${_REQUIRED_MODRINTH_PROJECTS}"
+        fi
+
+        # Attempt each optional mod individually: skip on failure
+        while IFS= read -r optProject; do
+          [[ -z "$optProject" ]] && continue
+          log "Attempting optional mod: ${optProject} ..."
+          if mc-image-helper modrinth "${modrinthArgs[@]}" \
+            --projects="${optProject}"; then
+            log "Optional mod '${optProject}' installed successfully"
+          else
+            logWarning "Optional mod '${optProject}' is not available for ${VERSION}/${loader}: skipping"
+          fi
+        done <<< "$_OPTIONAL_MODRINTH_PROJECTS"
+      fi
+    fi
+
   fi
 }
 

--- a/scripts/start-utils
+++ b/scripts/start-utils
@@ -577,3 +577,40 @@ function shiftArray {
     a=("${a[@]:1}")
   fi
 }
+
+function parseOptionalModrinthProjects() {
+  local projects="${1?}"
+  _REQUIRED_MODRINTH_PROJECTS=""
+  _OPTIONAL_MODRINTH_PROJECTS=""
+  _ALL_MODRINTH_PROJECTS_CLEAN=""
+
+  # Normalise comma-separated lists into newline-separated
+  local normalized
+  normalized=$(echo "$projects" | tr ',' '\n')
+
+  while IFS= read -r line; do
+    # Trim whitespace
+    line="${line#"${line%%[![:space:]]*}"}"
+    line="${line%"${line##*[![:space:]]}"}"
+
+    # Skip blanks and comments
+    [[ -z "$line" || "$line" == \#* ]] && continue
+
+    # Listing-file references (@path) cannot be pre-processed —
+    # treat them as required and pass through unchanged.
+    if [[ "$line" == @* ]]; then
+      _REQUIRED_MODRINTH_PROJECTS+="${_REQUIRED_MODRINTH_PROJECTS:+$'\n'}${line}"
+      _ALL_MODRINTH_PROJECTS_CLEAN+="${_ALL_MODRINTH_PROJECTS_CLEAN:+$'\n'}${line}"
+      continue
+    fi
+
+    if [[ "$line" == *"?"* ]]; then
+      local clean="${line//\?/}"
+      _OPTIONAL_MODRINTH_PROJECTS+="${_OPTIONAL_MODRINTH_PROJECTS:+$'\n'}${clean}"
+      _ALL_MODRINTH_PROJECTS_CLEAN+="${_ALL_MODRINTH_PROJECTS_CLEAN:+$'\n'}${clean}"
+    else
+      _REQUIRED_MODRINTH_PROJECTS+="${_REQUIRED_MODRINTH_PROJECTS:+$'\n'}${line}"
+      _ALL_MODRINTH_PROJECTS_CLEAN+="${_ALL_MODRINTH_PROJECTS_CLEAN:+$'\n'}${line}"
+    fi
+  done <<< "$normalized"
+}

--- a/tests/setuponlytests/modrinth/docker-compose.yml
+++ b/tests/setuponlytests/modrinth/docker-compose.yml
@@ -6,6 +6,9 @@ services:
       SETUP_ONLY: "true"
       TYPE: FABRIC
       VERSION: 1.21.4
-      MODRINTH_PROJECTS: fabric-api,cloth-config
+      MODRINTH_PROJECTS: |
+        fabric-api
+        cloth-config
+        this-mod-does-not-exist-xyz123?
     volumes:
       - ./data:/data


### PR DESCRIPTION
Closes #3997

## Summary

Adds the ability to mark `MODRINTH_PROJECTS` entries as **optional** using a `?` suffix. Optional mods that have no compatible version for the current Minecraft release are skipped with a warning instead of failing the entire startup.

## Motivation

When running a server with `VERSION=LATEST` or `VERSION_FROM_MODRINTH_PROJECTS=true`, a single mod that hasn't been updated yet blocks the entire upgrade. Mods like map renderers (Pl3xmap, BlueMap) or QoL plugins are often "nice to have" but shouldn't prevent the server from starting.

## Usage

```yaml
MODRINTH_PROJECTS: |
  fabric-api
  lithium
  pl3xmap?
  bluemap?:beta
```

The `?` works with all existing format variations: `slug?`, `prefix:slug?`, `slug?:version`, etc.

### Combined with `VERSION_FROM_MODRINTH_PROJECTS`

Optional projects are excluded from version resolution, so they never block a Minecraft upgrade:

```yaml
VERSION_FROM_MODRINTH_PROJECTS: true
MODRINTH_PROJECTS: |
  fabric-api
  lithium
  pl3xmap?
```

## Changes

| File | What changed |
|---|---|
| `scripts/start-utils` | Added `parseOptionalModrinthProjects()` helper |
| `scripts/start-setupModpack` | Modified `handleModrinthProjects()` — try all, fallback to required-only + individual optional attempts |
| `scripts/start-configuration` | Modified `VERSION_FROM_MODRINTH_PROJECTS` block — exclude optional projects from version calculation |
| `docs/mods-and-plugins/modrinth.md` | New "Optional projects" section with examples |
| `tests/setuponlytests/modrinth-optional/` | New test: required mods install despite a bogus optional entry |

## Behavior

1. **All mods available** -> single `mc-image-helper modrinth` call installs everything (no change in behavior)
2. **Optional mod unavailable** -> retry with required-only, then attempt each optional individually, skipping failures with a warning
3. **Required mod unavailable** -> startup fails as before
4. **Version resolution** -> only required projects determine the Minecraft version

## Limitations

- When the fallback path runs (optional mod unavailable), `mc-image-helper` is called multiple times. This may cause optional mod jars to be cleaned up and re-downloaded on each startup cycle. This is acceptable for a first implementation.
- Listing files (`@/path/to/file.txt`) support `?` on individual lines. The file itself cannot be marked as optional.