### PR TITLE
Add optional Modrinth projects support (`?` suffix) documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ RUN easy-add --var os=${TARGETOS} --var arch=${TARGETARCH}${TARGETVARIANT} \
   --from ${GITHUB_BASEURL}/itzg/{{.app}}/releases/download/{{.version}}/{{.app}}_{{.version}}_{{.os}}_{{.arch}}.tar.gz
 
 # renovate: datasource=github-releases packageName=itzg/mc-image-helper versioning=loose
-ARG MC_HELPER_VERSION=1.55.4
+ARG MC_HELPER_VERSION=1.56.0
 ARG MC_HELPER_BASE_URL=${GITHUB_BASEURL}/itzg/mc-image-helper/releases/download/${MC_HELPER_VERSION}
 # used for cache busting local copy of mc-image-helper
 ARG MC_HELPER_REV=1

--- a/docs/mods-and-plugins/modrinth.md
+++ b/docs/mods-and-plugins/modrinth.md
@@ -86,6 +86,54 @@ Where:
 
     To temporarily disable processing of the `MODRINTH_PROJECTS` list, then comment out the `MODRINTH_PROJECTS` environment variable.
 
+## Optional projects
+
+Projects that are not critical for the server to function can be marked as **optional** by appending a `?` to the project slug or ID. When a compatible version cannot be found for an optional project, the server logs a warning and continues startup instead of failing.
+
+This is particularly useful for server-side mods that tend to lag behind on Minecraft updates, such as map renderers (Pl3xmap, BlueMap), performance mods (Lithium, C2ME), or admin tools (Spark, LuckPerms).
+
+```yaml
+      MODRINTH_PROJECTS: |
+        fabric-api
+        lithium
+        pl3xmap?
+        bluemap?:beta
+```
+
+The `?` marker can be combined with all existing format options:
+
+| Format                     | Example                   |
+|----------------------------|---------------------------|
+| Slug only                  | `pl3xmap?`                |
+| With version               | `pl3xmap?:Oa9ZDzZq`      |
+| With release type          | `pl3xmap?:beta`           |
+| With loader prefix         | `fabric:pl3xmap?`         |
+| Full combination           | `fabric:pl3xmap?:beta`    |
+| In listing files           | `pl3xmap?` *(one per line)* |
+
+When combined with [`VERSION_FROM_MODRINTH_PROJECTS`](#version-from-projects), optional projects are **excluded** from the version calculation. This means an optional mod that hasn't been updated yet will never block a Minecraft version upgrade.
+
+!!! example "Automatic upgrades without optional-mod breakage"
+
+    ```yaml
+        MODRINTH_PROJECTS: |
+          fabric-api
+          lithium
+          pl3xmap?
+        VERSION_FROM_MODRINTH_PROJECTS: true
+    ```
+    
+    If a new Minecraft version is released and `fabric-api` + `lithium` support it but `pl3xmap` does not:
+    
+    1. The resolved `VERSION` is set to the new version (pl3xmap is not considered)
+    2. `fabric-api` and `lithium` are installed normally
+    3. `pl3xmap` is skipped with a warning in the logs
+    4. On a future restart, once pl3xmap publishes a compatible build, it is picked up automatically
+
+!!! note
+
+    Optional projects marked with `?` in listing files (`@/path/to/file.txt`) are supported ; the `?` is parsed from each line the same way as inline entries.
+
 ## Version from Projects
 
 When the environment variable `VERSION_FROM_MODRINTH_PROJECTS` is set to "true" the Minecraft [`VERSION`](../versions/minecraft.md) will be automatically determined by looking at the most recent version of Minecraft that is supported by all the projects provided in `MODRINTH_PROJECTS`.
@@ -115,4 +163,3 @@ When the environment variable `VERSION_FROM_MODRINTH_PROJECTS` is set to "true" 
 
 `MODRINTH_LOADER`
 : When using a custom server, set this to specify which loader type will be requested during lookups
-


### PR DESCRIPTION
Closes #3997

## Summary

> @Vianpyro will still need the documentation part of https://github.com/itzg/docker-minecraft-server/pull/3998/changes#diff-25b277033deeeef5aa02116dbc7e3cc7aea7a77c88ce9c83b3791a357b835e21
>
> I'll cut a release to include this PR change though and get that included in the itzg/minecraft-server image.
>
_Originally posted by @itzg in https://github.com/itzg/mc-image-helper/issues/742#issuecomment-4208052613_

Adds documentation for the optional Modrinth projects feature (`?` suffix), whose implementation lives in [itzg/mc-image-helper#742](https://github.com/itzg/mc-image-helper/pull/742).

## Usage

```yaml
MODRINTH_PROJECTS: |
  fabric-api
  lithium
  pl3xmap?
  bluemap?:beta
```

The `?` works with all existing format variations: `slug?`, `prefix:slug?`, `slug?:version`, etc.

### Combined with `VERSION_FROM_MODRINTH_PROJECTS`

Optional projects are excluded from version resolution, so they never block a Minecraft upgrade:

```yaml
VERSION_FROM_MODRINTH_PROJECTS: true
MODRINTH_PROJECTS: |
  fabric-api
  lithium
  pl3xmap?
```

## Changes

| File | What changed |
|---|---|
| `docs/mods-and-plugins/modrinth.md` | New "Optional projects" section with syntax table and usage examples |

## Behavior

1. **All mods available** -> everything installs normally (no change in behavior)
2. **Optional mod unavailable** -> warning logged, startup continues without it
3. **Required mod unavailable** -> startup fails as before
4. **Version resolution** -> only required (non-`?`) projects determine the Minecraft version