### PR TITLE
Add SpawnBox sponsor entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,6 @@ This image only supports Java edition natively; however, if looking for a server
 
 ## ![Sponsors](docs/img/banner-sponsors.png)
 
+[![SpawnBox](https://spawnbox.app/favicon-48x48.png)](https://spawnbox.app)
+
+[**SpawnBox**](https://spawnbox.app) - Powered by `itzg/minecraft-server`, it's a Windows desktop app for parents, teens, and friend groups who want a Minecraft server on their own PC without learning Docker, WSL2, or networking.


### PR DESCRIPTION
First sponsor entry for the new `## Sponsors` section. Adds SpawnBox with a single-line description and a 48x48 logo referenced from spawnbox.app so no image files are added to the repo.

Format is intentionally pure markdown (no HTML tables or divs) to match the existing README conventions and to sidestep the GFM sanitizer issue you ran into on the previous commit. Future sponsors can stack in the same pattern. Happy to iterate on wording, logo size, or placement in review.

Thanks for the opportunity and for running such a widely-used Minecraft server image.