### PR TITLE
docs: simplify sponsor layout - drop table, use floated logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,26 +24,15 @@ This image only supports Java edition natively; however, if looking for a server
 
 <a name="sponsors"></a>
 
-<table>
+<a href="https://spawnbox.app"><img src="https://spawnbox.app/favicon-48x48.png" alt="SpawnBox logo" width="48" align="left" /></a>
 
-<tr>
-    <td width="140" align="center" valign="middle">
-        <a href="https://spawnbox.app">
-        <img src="https://spawnbox.app/favicon-48x48.png" alt="SpawnBox logo" width="48" />
-        </a>
-    </td>
-    <td valign="middle">
-        <a href="https://spawnbox.app"><b>SpawnBox</b></a> - Powered by
-        <code>itzg/minecraft-server</code>, it's a Windows desktop app for parents, teens, and friend groups
-        who want a Minecraft server on their own PC without learning Docker, WSL2, or networking.
-    </td>
-</tr>
+<a href="https://spawnbox.app"><b>SpawnBox</b></a> - Powered by <code>itzg/minecraft-server</code>, it's a Windows desktop app for parents, teens, and friend groups who want a Minecraft server on their own PC without learning Docker, WSL2, or networking.
 
-<!-- additional sponsors repeat a table row (tr) like above -->
+<br clear="left" />
+
+<!-- additional sponsors repeat the pattern above: floated logo + blurb + clear-left break -->
 <!-- logo image preferrably hosted on an external, stable site at a size of 48x48px -->
 <!-- link to sponsor site -->
 <!-- one or two line summary ideally with a mention of image integration -->
-
-</table>
 
 [and more...](https://github.com/sponsors/itzg)


### PR DESCRIPTION
Follow-up to #4008.

The table-based layout had two issues:

1. **Visible cell borders.** GitHub's `markdown-body` CSS applies `border: 1px solid` to every `table td`, which is why the earlier `border="0"` attempt had no effect - CSS wins over the HTML attribute. The only way to truly kill the border is to not use `<table>`.
2. **Dead space between logo and blurb.** The fixed `width="140"` icon cell left a big gap between the logo and the text, making them feel like two separate columns instead of one unit.

This PR replaces the `<table>`/`<tr>`/`<td>` structure with a simpler `<img align="left">` float + `<br clear="left">` pattern. No borders, tight logo-to-text spacing, and the comment template is updated so future sponsors follow the same pattern (floated logo + blurb + clear-left break).

Before (current):
- table with two cells, 140px icon column, visible cell borders

After (this PR):
- floated logo, text wraps immediately to its right, clear-left break ends the block