### PR TITLE
Remove EMI from Modrinth exclusions

### DIFF
--- a/files/modrinth-exclude-include.json
+++ b/files/modrinth-exclude-include.json
@@ -39,8 +39,6 @@
     "distraction_free_recipes",
     "drippyloadingscreen",
     "eating-animation",
-    "emi",
-    "emi_loot",
     "emi_trade",
     "emiffect",
     "emitrades",


### PR DESCRIPTION
Since Minecraft 1.21, EMI needs to be installed on both the client and server for:
- Recipe syncing
- Recipe tree view
- Item drop rates

EMI Loot also needs to be installed server-side for loot tables and item drop rates