### PR TITLE
fix deadlink for autostop example

### DIFF
--- a/docs/misc/autopause-autostop/autostop.md
+++ b/docs/misc/autopause-autostop/autostop.md
@@ -8,7 +8,7 @@ An option to stop the server after a specified time has been added for niche app
 
 A `.skip-stop` file can be created in the `/data` directory to make the server skip autostopping, for as long as the file is present. The autostop timer will also be reset.
 
-A starting, example compose file has been provided in [examples/docker-compose-autostop.yml](https://github.com/itzg/docker-minecraft-server/blob/master/examples/docker-compose-autostop.yml).
+A starting, example compose file has been provided in [examples/autostop/compose.yml](https://github.com/itzg/docker-minecraft-server/blob/master/examples/autostop/compose.yml).
 
 Enable the Autostop functionality by setting:
 


### PR DESCRIPTION
Deadlink for autostop pointing to older revision ./examples/docker-compose-autostop.yml