### PR TITLE
build(deps): Bump mc-image-helper java8 to 1.51.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,13 +86,13 @@ jobs:
             platforms: linux/amd64,linux/arm/v7,linux/arm64
             mcVersion: 1.12.2
             # Pin version for Java 8
-            mcHelperVersion: 1.51.1
+            mcHelperVersion: 1.51.2
           - variant: java8-jdk
             baseImage: eclipse-temurin:8u312-b07-jdk-focal
             platforms: linux/amd64,linux/arm64
             mcVersion: 1.12.2
             # Pin version for Java 8
-            mcHelperVersion: 1.51.1
+            mcHelperVersion: 1.51.2
     env:
       IMAGE_TO_TEST: "${{ github.repository_owner }}/minecraft-server:test-${{ matrix.variant }}-${{ github.run_id }}"
       HAS_IMAGE_REPO_ACCESS: ${{ secrets.DOCKER_USER != '' && secrets.DOCKER_PASSWORD != '' }}


### PR DESCRIPTION
Bump mc-image-helper Java8 branch to release [1.51.2](https://github.com/itzg/mc-image-helper/releases/tag/1.51.2)