### PR TITLE
Pin java11 and java16 to java8 branch of mc-image-helper

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,11 +75,15 @@ jobs:
             baseImage: adoptopenjdk:16-jre-hotspot
             platforms: linux/amd64,linux/arm/v7,linux/arm64
             mcVersion: 1.16.5
+            # Pin version for pre-Java 17
+            mcHelperVersion: 1.51.3-java8
         # JAVA 11
           - variant: java11
             baseImage: adoptopenjdk:11-jre-hotspot
             platforms: linux/amd64,linux/arm/v7,linux/arm64
             mcVersion: 1.16.4
+            # Pin version for pre-Java 17
+            mcHelperVersion: 1.51.3-java8
         # JAVA 8: NOTE: Unable to go past 8u312 because of Forge dependencies
           - variant: java8
             baseImage: eclipse-temurin:8u312-b07-jre-focal


### PR DESCRIPTION
The mainline of mc-image-helper nows needs to be built with Java 17. As such, image versions running lower java versions need to be pinned to the branch-releases built with Java 8

Also for #4038