### PR TITLE
fix(exclude): exclude ImmersiveDamageIndicators from server mods

### DIFF
--- a/files/cf-exclude-include.json
+++ b/files/cf-exclude-include.json
@@ -82,6 +82,7 @@
     "iceberg",
     "ignitioncoil",
     "illager-raid-music",
+    "immersive-damage-indicators",
     "inmisaddon",
     "iris-flywheel-compat",
     "irisshaders",

--- a/files/modrinth-exclude-include.json
+++ b/files/modrinth-exclude-include.json
@@ -56,7 +56,7 @@
     "gpumemleakfix",
     "Highlighter",
     "ImmediatelyFast",
-    "immersive-damage-indicators",
+    "immersivedamageindicators",
     "indium",
     "inventory-profiles-next",
     "iris",

--- a/files/modrinth-exclude-include.json
+++ b/files/modrinth-exclude-include.json
@@ -56,6 +56,7 @@
     "gpumemleakfix",
     "Highlighter",
     "ImmediatelyFast",
+    "immersive-damage-indicators",
     "indium",
     "inventory-profiles-next",
     "iris",


### PR DESCRIPTION
Mod is clientside only.