### PR TITLE
Note ANSI-C Quoting bash in MOTD

### DIFF
--- a/docs/configuration/server-properties.md
+++ b/docs/configuration/server-properties.md
@@ -78,6 +78,12 @@ To produce a multi-line MOTD, embed a newline character as `\n` in the string, s
     -e MOTD="Line one\nLine two"
     ```
     
+    From bash shell
+    
+    ```
+    -e MOTD=$'Line one\nLine two'
+    ```
+    
     or within a compose file
     
     ```yaml


### PR DESCRIPTION
This clarify bash shell requirement for MOTD. This was already noted in the Custom server properties area but one (like me) won't come across it if you only need the MOTD option. 

https://github.com/itzg/docker-minecraft-server/blob/544382d5d60276f846113991585e69bb4f7077a3/docs/configuration/server-properties.md?plain=1#L429
