### PR TITLE
feat: docker env-file handling

### DIFF
--- a/scripts/mc-motd-fix.sh
+++ b/scripts/mc-motd-fix.sh
@@ -1,0 +1,5 @@
+#!/bin/env bash
+
+export MOTD="${MOTD//\\n/$'\n'}"
+exec /image/scripts/start "$@"
+

--- a/scripts/mc-motd-fix.sh
+++ b/scripts/mc-motd-fix.sh
@@ -1,5 +1,0 @@
-#!/bin/env bash
-
-export MOTD="${MOTD//\\n/$'\n'}"
-exec /image/scripts/start "$@"
-

--- a/scripts/start-setupServerProperties
+++ b/scripts/start-setupServerProperties
@@ -30,7 +30,8 @@ function customizeServerProps {
     fi
   elif [[ "${DOCKER_RUN_ENV_FILE:-false,,}"  = "true" ]]; then
      if [[ -v MOTD ]]; then
-       MOTD="$(printf '%b' "$MOTD")"
+       # Replace literal '\n' with a real newline
+       MOTD="${MOTD//\\n/$'\n'}"
      fi
   fi
 

--- a/scripts/start-setupServerProperties
+++ b/scripts/start-setupServerProperties
@@ -28,6 +28,10 @@ function customizeServerProps {
       # shellcheck disable=SC2089
       MOTD="{\"text\":\"${MOTD}\"}"
     fi
+  elif [[ "${DOCKER_RUN_ENV_FILE:-false,,}"  = "true" ]]; then
+     if [[ -v MOTD ]]; then
+       MOTD="$(printf '%b' "$MOTD")"
+     fi
   fi
 
   if [[ -v MODE ]]; then


### PR DESCRIPTION
This helps fix dockers `--env-files` from being double slashed