### PR TITLE
Exclude e4mc and e4mc-retro from modpacks

### DIFF
--- a/files/cf-exclude-include.json
+++ b/files/cf-exclude-include.json
@@ -49,6 +49,8 @@
     "dynamiclights-reforged",
     "easiervillagertrading",
     "effective-forge",
+	"e4mc",
+	"e4mc-retro",
     "embeddium",
     "embeddium-extension",
     "embeddium-extras",

--- a/files/modrinth-exclude-include.json
+++ b/files/modrinth-exclude-include.json
@@ -36,6 +36,8 @@
     "DisableCustomWorldsAdvice",
     "distraction_free_recipes",
     "drippyloadingscreen",
+	"e4mc",
+	"e4mc-retro",
     "eating-animation",
     "emi_trade",
     "emiffect",


### PR DESCRIPTION
Both e4mc and e4mc-retro will crash the server if they are used. Some private modpacks may include them as well, this should avoid any issues with whoever accidentally includes them.