### PR TITLE
Add purpur support for ServerLibraryCleaner

### DIFF
--- a/docs/configuration/misc-options.md
+++ b/docs/configuration/misc-options.md
@@ -26,7 +26,10 @@ docker run -d --pull=always \
 
 By default, supported server types remove stale server libraries during installation by setting `CLEAN_SERVER_LIBRARIES` to `true`. Set `CLEAN_SERVER_LIBRARIES` to `false` to disable this cleanup if it causes unexpected behavior.
 
-Currently, library cleanup is supported by `TYPE=PAPER`. Other server jar types are not yet supported.
+Currently, library cleanup is supported by
+
+- `TYPE=PAPER`
+- `TYPE=PURPUR`
 
 ## Running as alternate user/group ID
 

--- a/scripts/start-deployPurpur
+++ b/scripts/start-deployPurpur
@@ -5,6 +5,7 @@ IFS=$'\n\t'
 : "${PURPUR_BUILD:=LATEST}"
 : "${PURPUR_DOWNLOAD_URL:=}"
 : "${PURPUR_CONFIG_REPO:=}"
+: "${CLEAN_SERVER_LIBRARIES:=true}"
 
 # shellcheck source=start-utils
 . "$(dirname "$0")/start-utils"
@@ -13,10 +14,15 @@ isDebugging && set -x
 resultsFile=/data/.purpur.env
 
 if [[ $PURPUR_DOWNLOAD_URL ]]; then
-  if ! mc-image-helper install-purpur \
-    --output-directory=/data \
-    --results-file="$resultsFile" \
-    --url="${PURPUR_DOWNLOAD_URL}"; then
+  args=(
+    --output-directory=/data
+    --results-file="$resultsFile"
+    --url="${PURPUR_DOWNLOAD_URL}"
+  )
+  if isTrue "$CLEAN_SERVER_LIBRARIES"; then
+    args+=(--clean-libraries)
+  fi
+  if ! mc-image-helper install-purpur "${args[@]}"; then
       logError "Failed to download from custom Purpur URL"
       exit 1
   fi
@@ -28,6 +34,9 @@ else
   )
   if [[ $PURPUR_BUILD ]]; then
     args+=(--build="$PURPUR_BUILD")
+  fi
+  if isTrue "$CLEAN_SERVER_LIBRARIES"; then
+    args+=(--clean-libraries)
   fi
   if ! mc-image-helper install-purpur "${args[@]}"; then
       logError "Failed to download Purpur"


### PR DESCRIPTION
Adds support for the ServerLibraryCleaner, implemented in itzg/mc-image-helper#748. Mimics implementation in #4046 by adding a variable, `$CLEAN_SERVER_LIBRARIES` which defaults to true.

Updated documentation to list support for `TYPE=PURPUR`