### PR TITLE
paper: Fix boolean flag always return true

### DIFF
--- a/scripts/start-deployPaper
+++ b/scripts/start-deployPaper
@@ -24,7 +24,7 @@ elif [[ $PAPER_DOWNLOAD_URL ]]; then
     --url="$PAPER_DOWNLOAD_URL"
   )
 
-  if [[ $CLEAN_SERVER_LIBRARIES ]]; then
+  if isTrue $CLEAN_SERVER_LIBRARIES; then
     args+=(--clean-libraries)
   fi
 
@@ -45,7 +45,7 @@ else
     args+=(--build="$PAPER_BUILD")
   fi
 
-  if [[ $CLEAN_SERVER_LIBRARIES ]]; then
+  if isTrue $CLEAN_SERVER_LIBRARIES; then
     args+=(--clean-libraries)
   fi
 


### PR DESCRIPTION
Bug in the `scripts/start-deployPaper` script

When checking if we pass the `--clean-libraries` flag, we check if the var `$CLEAN_SERVER_LIBRARIES` is set

Previously this was checked by

```bash
if [[ $CLEAN_SERVER_LIBRARIES ]]; then
  args+=(--clean-libraries)
fi
```

However performing the test operator `[[` on a variable will only return false if the variable is empty, not if it is "false". e.g.

```bash
[[ true ]]  # true
[[ false ]] # true
[[ "" ]].   # false
```

Fix replaces test operator with `isTrue $CLEAN_SERVER_LIBRARIES`, utilising isTrue function from `scripts/start-utils`