### PR TITLE
packwiz: re-load LOAD_ENV_FROM_FILE after the installer runs

### DIFF
--- a/docs/mods-and-plugins/packwiz.md
+++ b/docs/mods-and-plugins/packwiz.md
@@ -13,6 +13,8 @@ docker run -d --pull=always \
 
 packwiz modpack definitions are processed before other mod definitions (`MODPACK`, `MODS`, etc.) to allow for additional processing/overrides you may want to perform (in case of mods not available via Modrinth/CurseForge, or you do not maintain the pack).
 
+If the pack ships a `.env` file that you reference with `LOAD_ENV_FROM_FILE`, that file is re-loaded immediately after the packwiz installer runs, so the freshly downloaded values are applied to the remaining startup stages. Note that `TYPE` and `VERSION` are resolved earlier (before the deploy is dispatched), so a pack-provided `.env` cannot change those from within packwiz; use `LOAD_ENV_FROM_GENERIC_PACK` or `LOAD_ENV_FROM_ARCHIVE` for those.
+
 !!! note 
 
     packwiz is pre-configured to only download server mods. If client-side mods are downloaded and cause issues, check your pack.toml configuration, and make sure any client-only mods are not set to `"both"`, but rather `"client"` for the side configuration item.

--- a/scripts/start-setupModpack
+++ b/scripts/start-setupModpack
@@ -50,6 +50,16 @@ function handlePackwiz() {
       logError "Failed to run packwiz installer"
       exit 1
     fi
+
+    # packwiz may have just downloaded/updated the env file referenced by
+    # LOAD_ENV_FROM_FILE. The initial load in start-configuration happened
+    # before this point, so re-load it now to pick up the pack's values for
+    # the remaining setup stages (server.properties, JVM args, etc.).
+    if [[ ${LOAD_ENV_FROM_FILE:-} ]]; then
+      if ! loadEnvFromFile "${LOAD_ENV_FROM_FILE}"; then
+        exit 1
+      fi
+    fi
   fi
 }
 


### PR DESCRIPTION
Fixes #4074.

When `PACKWIZ_URL` and `LOAD_ENV_FROM_FILE` are both set, the container sources the env file before packwiz writes it. `start-configuration` loads it during the configuration stage, before the deploy is dispatched. The packwiz installer runs later, in `start-setupModpack`, and writes pack files into `/data`, including any `.env` the pack ships. By that point the container has already sourced the previous file, or no file at all on a first run, so the pack's values never reach the rest of startup.

The fix re-runs `loadEnvFromFile` inside `handlePackwiz` once the installer succeeds, guarded on `LOAD_ENV_FROM_FILE` being set. `start-setupModpack` already sources `start-utils`, so the helper is in scope. The early load stays where it is, so `TYPE` and `VERSION` still resolve before the deploy is dispatched.

What changed:
- `scripts/start-setupModpack`: re-load the env file after the packwiz installer runs.
- `docs/mods-and-plugins/packwiz.md`: document the re-load, and note that `TYPE` and `VERSION` resolve earlier, so a pack `.env` can't set them (use `LOAD_ENV_FROM_GENERIC_PACK` or `LOAD_ENV_FROM_ARCHIVE` for that).

Behaviour only changes when both `PACKWIZ_URL` and `LOAD_ENV_FROM_FILE` are set. Existing setups behave the same.

To reproduce: serve a packwiz pack with a root `.env` (for example `MOTD=from-packwiz`), then run with `EULA=TRUE TYPE=FABRIC PACKWIZ_URL=... LOAD_ENV_FROM_FILE=/data/.env` on a clean `/data`. The resulting `server.properties` shows `motd=from-packwiz`; without this change it stays at the default. Updating the served `.env` and restarting picks up the new value.