### PR TITLE
Added: riscv64 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,7 @@ jobs:
         # JAVA 25
           - variant: java25
             # NOTE: 25-jre is also Noble (currently), but this variant needs to be 25-jre-noble specifically to include riscv64
+            # Keep this aligned in verify-pr.yml also
             baseImage: eclipse-temurin:25-jre-noble
             platforms: linux/amd64,linux/arm64,linux/riscv64
             mcVersion: latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,7 @@ jobs:
       matrix:
         # NOTE: the "latest" variant is identified in the Docker meta step's 'latest' config
         variant:
+          - java26-noble
           - java25
           - java25-alpine
           - java25-jdk
@@ -38,6 +39,11 @@ jobs:
           - java8
           - java8-jdk
         include:
+        # JAVA 26
+          - variant: java26-noble
+            baseImage: eclipse-temurin:26-jre-noble
+            platforms: linux/amd64,linux/arm64,linux/riscv64
+            mcVersion: latest
         # JAVA 25
           - variant: java25
             baseImage: eclipse-temurin:25-jre

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,19 +41,15 @@ jobs:
         include:
         # JAVA 25
           - variant: java25
-            baseImage: eclipse-temurin:25-jre
-            platforms: linux/amd64,linux/arm64
-            mcVersion: latest
-          - variant: java25-alpine
-            baseImage: eclipse-temurin:25-jre-alpine
-            platforms: linux/amd64,linux/arm64
-            mcVersion: latest
-          - variant: java25-noble
             baseImage: eclipse-temurin:25-jre-noble
             platforms: linux/amd64,linux/arm64,linux/riscv64
             mcVersion: latest
           - variant: java25-jdk
             baseImage: eclipse-temurin:25
+            platforms: linux/amd64,linux/arm64
+            mcVersion: latest
+          - variant: java25-alpine
+            baseImage: eclipse-temurin:25-jre-alpine
             platforms: linux/amd64,linux/arm64
             mcVersion: latest
         # JAVA 21:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,9 +26,9 @@ jobs:
       matrix:
         # NOTE: the "latest" variant is identified in the Docker meta step's 'latest' config
         variant:
-          - java26-noble
           - java25
           - java25-alpine
+          - java25-noble
           - java25-jdk
           - java21
           - java21-alpine
@@ -39,11 +39,6 @@ jobs:
           - java8
           - java8-jdk
         include:
-        # JAVA 26
-          - variant: java26-noble
-            baseImage: eclipse-temurin:26-jre-noble
-            platforms: linux/amd64,linux/arm64,linux/riscv64
-            mcVersion: latest
         # JAVA 25
           - variant: java25
             baseImage: eclipse-temurin:25-jre
@@ -52,6 +47,10 @@ jobs:
           - variant: java25-alpine
             baseImage: eclipse-temurin:25-jre-alpine
             platforms: linux/amd64,linux/arm64
+            mcVersion: latest
+          - variant: java25-noble
+            baseImage: eclipse-temurin:25-jre-noble
+            platforms: linux/amd64,linux/arm64,linux/riscv64
             mcVersion: latest
           - variant: java25-jdk
             baseImage: eclipse-temurin:25

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,6 @@ jobs:
         variant:
           - java25
           - java25-alpine
-          - java25-noble
           - java25-jdk
           - java21
           - java21-alpine
@@ -41,6 +40,7 @@ jobs:
         include:
         # JAVA 25
           - variant: java25
+            # NOTE: 25-jre is also Noble (currently), but this variant needs to be 25-jre-noble specifically to include riscv64
             baseImage: eclipse-temurin:25-jre-noble
             platforms: linux/amd64,linux/arm64,linux/riscv64
             mcVersion: latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,12 +45,12 @@ jobs:
             baseImage: eclipse-temurin:25-jre-noble
             platforms: linux/amd64,linux/arm64,linux/riscv64
             mcVersion: latest
-          - variant: java25-jdk
-            baseImage: eclipse-temurin:25
-            platforms: linux/amd64,linux/arm64
-            mcVersion: latest
           - variant: java25-alpine
             baseImage: eclipse-temurin:25-jre-alpine
+            platforms: linux/amd64,linux/arm64
+            mcVersion: latest
+          - variant: java25-jdk
+            baseImage: eclipse-temurin:25
             platforms: linux/amd64,linux/arm64
             mcVersion: latest
         # JAVA 21:

--- a/.github/workflows/verify-pr.yml
+++ b/.github/workflows/verify-pr.yml
@@ -29,7 +29,8 @@ jobs:
         include:
         # JAVA 21/25:
           - variant: java25
-            baseImage: eclipse-temurin:25-jre
+            # stay aligned with build.yml
+            baseImage: eclipse-temurin:25-jre-noble
             platforms: linux/amd64,linux/arm64
             mcVersion: latest
           - variant: java25-alpine

--- a/build/ubuntu/install-packages.sh
+++ b/build/ubuntu/install-packages.sh
@@ -37,7 +37,7 @@ apt-get install -y \
 apt-get clean
 
 # Download and install patched knockd
-curl -fsSL -o /tmp/knock.tar.gz https://github.com/Metalcape/knock/releases/download/0.8.1/knock-0.8.1-$TARGET.tar.gz
+curl -fsSL -o /tmp/knock.tar.gz https://github.com/Opvolger/knock/releases/download/0.8.1/knock-0.8.1-$TARGET.tar.gz
 tar -xf /tmp/knock.tar.gz -C /usr/local/ && rm /tmp/knock.tar.gz
 ln -s /usr/local/sbin/knockd /usr/sbin/knockd
 setcap cap_net_raw=ep /usr/local/sbin/knockd

--- a/docs/versions/java.md
+++ b/docs/versions/java.md
@@ -10,20 +10,20 @@ or explicitly include the tag, such as
 
 where `<tag>` refers to the first column of this table:
 
-| Tag            | Java version | Linux  | JVM Type           | Architecture        | Note |
-|----------------|--------------|--------|--------------------|---------------------|------|
-| latest         | 25           | Ubuntu | Hotspot            | amd64, arm64        |      |
-| stable         | 25           | Ubuntu | Hotspot            | amd64, arm64        |      |
-| java25         | 25           | Ubuntu | Hotspot            | amd64, arm64        |      |
-| java25-alpine  | 25           | Alpine | Hotspot            | amd64, arm64        |      |
-| java25-jdk     | 25           | Ubuntu | Hotspot+JDK        | amd64, arm64        |      |
-| java21         | 21           | Ubuntu | Hotspot            | amd64, arm64        |      |
-| java21-jdk     | 21           | Ubuntu | Hotspot+JDK        | amd64, arm64        |      |
-| java21-alpine  | 21           | Alpine | Hotspot            | amd64, arm64        |      |
-| java17         | 17           | Ubuntu | Hotspot            | amd64, arm64, armv7 |      |
-| java16         | 16           | Ubuntu | Hotspot            | amd64, arm64, armv7 | (1)  |
-| java11         | 11           | Ubuntu | Hotspot            | amd64, arm64, armv7 |      |
-| java8          | 8            | Ubuntu | Hotspot            | amd64, arm64, armv7 |      |
+| Tag           | Java version | Linux  | JVM Type    | Architecture          | Note |
+|---------------|--------------|--------|-------------|-----------------------|------|
+| latest        | 25           | Ubuntu | Hotspot     | amd64, arm64, riscv64 |      |
+| stable        | 25           | Ubuntu | Hotspot     | amd64, arm64, riscv64 |      |
+| java25        | 25           | Ubuntu | Hotspot     | amd64, arm64, riscv64 |      |
+| java25-alpine | 25           | Alpine | Hotspot     | amd64, arm64          |      |
+| java25-jdk    | 25           | Ubuntu | Hotspot+JDK | amd64, arm64          |      |
+| java21        | 21           | Ubuntu | Hotspot     | amd64, arm64          |      |
+| java21-jdk    | 21           | Ubuntu | Hotspot+JDK | amd64, arm64          |      |
+| java21-alpine | 21           | Alpine | Hotspot     | amd64, arm64          |      |
+| java17        | 17           | Ubuntu | Hotspot     | amd64, arm64, armv7   |      |
+| java16        | 16           | Ubuntu | Hotspot     | amd64, arm64, armv7   | (1)  |
+| java11        | 11           | Ubuntu | Hotspot     | amd64, arm64, armv7   |      |
+| java8         | 8            | Ubuntu | Hotspot     | amd64, arm64, armv7   |      |
 
 Notes
 

--- a/images.json
+++ b/images.json
@@ -5,7 +5,7 @@
     "java": "25",
     "distribution": "ubuntu",
     "jvm": "hotspot",
-    "architectures": ["amd64", "arm64"],
+    "architectures": ["amd64", "arm64", "riscv64"],
     "lts": true
   },
   {
@@ -14,7 +14,7 @@
     "java": "25",
     "distribution": "ubuntu",
     "jvm": "hotspot",
-    "architectures": ["amd64", "arm64"],
+    "architectures": ["amd64", "arm64", "riscv64"],
     "lts": true
   },
   {
@@ -22,7 +22,7 @@
     "java": "25",
     "distribution": "ubuntu",
     "jvm": "hotspot",
-    "architectures": ["amd64", "arm64"]
+    "architectures": ["amd64", "arm64", "riscv64"]
   },
   {
     "tag": "java25-alpine",


### PR DESCRIPTION
- added java25-noble (has riscv64 support)
- cloned knock and build it for amd64/arm64/arm32/riscv64

My hardware was not fast enough; it could not keep up with generating. (StarFive VisionFive 2 Lite)

But there are now newer CPUs like the SpaceMit K3, which should not have any problems with this.

Test the code with this command:

```bash
docker buildx build --platform linux/amd64,linux/arm64,linux/riscv64 --build-arg BASE_IMAGE=eclipse-temurin:25-jre-noble --build-arg VERSION=latest --tag opvolger/minecraft-server:latest --push .
```