### PR TITLE
Fix GTNH versions.json parsing

### DIFF
--- a/scripts/start-deployGTNH
+++ b/scripts/start-deployGTNH
@@ -14,7 +14,7 @@ function getGTNHdownloadPath(){
   if [ "$GTNH_PACK_VERSION" == "latest-dev" ]; then
     if ! release_object="$(
       curl -fsSL "https://downloads.gtnewhorizons.com/versions.json" \
-        | jq -r '.versions|to_entries|sort_by(.value.releaseDate)|map(select(.value.title=="Beta release"))|.[-1]'
+        | jq -r '(.versions // .)|to_entries|sort_by(.value.releaseDate)|map(select(.value.title=="Beta release"))|.[-1]'
       )"; then logError "Failed to retrieve release from https://downloads.gtnewhorizons.com/versions.json"
       exit 1
     fi
@@ -23,7 +23,7 @@ function getGTNHdownloadPath(){
   elif [ "$GTNH_PACK_VERSION" == "latest" ]; then
     if ! release_object="$(
       curl -fsSL "https://downloads.gtnewhorizons.com/versions.json" \
-        | jq -r '.versions|to_entries|sort_by(.value.releaseDate)|map(select(.value.title=="Stable release"))|.[-1]'
+        | jq -r '(.versions // .)|to_entries|sort_by(.value.releaseDate)|map(select(.value.title=="Stable release"))|.[-1]'
       )"; then logError "Failed to retrieve release from https://downloads.gtnewhorizons.com/versions.json"
       exit 1
     fi
@@ -32,7 +32,7 @@ function getGTNHdownloadPath(){
   else
     if ! release_object="$(
       curl -fsSL "https://downloads.gtnewhorizons.com/versions.json" \
-        | jq -r --arg USRIN "$GTNH_PACK_VERSION" '.versions|to_entries|sort_by(.value.releaseDate)|map(select(.key==$USRIN))|.[]'
+        | jq -r --arg USRIN "$GTNH_PACK_VERSION" '(.versions // .)|to_entries|sort_by(.value.releaseDate)|map(select(.key==$USRIN))|.[]'
       )"; then logError "Failed to retrieve release from https://downloads.gtnewhorizons.com/versions.json"
       exit 1
     fi


### PR DESCRIPTION
GTNH's `versions.json` file does not have a top level `versions` key (e.g. `{ "versions": { ... } }`), or at least not that I can see in the current version or revision history [here](https://github.com/GTNewHorizons/GTNewHorizons.github.io/commits/6bc04eb0594042c76429771d116d5f974bfbfbb4/public/versions.json).

However, the current script assumes it does.

This change uses `(.versions // .)` for the parsing so both formats are supported.

Fixes https://github.com/itzg/docker-minecraft-server/issues/4145