### PR TITLE
Use http/1.1 for CurseForge

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.sh text eol=lf
+scripts/** text eol=lf

--- a/scripts/start-deployAutoCF
+++ b/scripts/start-deployAutoCF
@@ -24,6 +24,7 @@ set -eu
 : "${CF_API_CACHE_DEFAULT_TTL:=}" # as ISO-8601 duration, such as P2D or PT12H
 : "${CF_API_KEY_FILE:=}" # Path to file containing CurseForge API key
 : "${CF_MOD_LOADER_VERSION:=}" # Override mod loader version
+: "${CF_USE_HTTP2:=false}" # CF downloads are faster with HTTP 1.1
 
 resultsFile=/data/.install-curseforge.env
 
@@ -46,6 +47,7 @@ args=(
   --force-synchronize="$CF_FORCE_SYNCHRONIZE"
   --force-reinstall-modloader="$CF_FORCE_REINSTALL_MODLOADER"
   --overrides-skip-existing="$CF_OVERRIDES_SKIP_EXISTING"
+  --use-http2="$CF_USE_HTTP2"
 )
 setArg() {
   arg="${1?}"

--- a/scripts/start-setupModpack
+++ b/scripts/start-setupModpack
@@ -10,6 +10,7 @@ set -e -o pipefail
 : "${REMOVE_OLD_MODS_DEPTH:=1} "
 : "${REMOVE_OLD_MODS_INCLUDE:=*.jar,*-version.json}"
 : "${CF_API_KEY_FILE:=}" # Path to file containing CurseForge API key
+: "${CF_USE_HTTP2:=false}" # CF downloads are faster with HTTP 1.1
 : "${MODRINTH_LOADER:=}"
 
 # shellcheck source=start-utils
@@ -296,7 +297,9 @@ function handleModrinthProjects() {
 }
 
 function handleCurseForgeFiles() {
-  args=()
+  args=(
+    --use-http2="$CF_USE_HTTP2"
+  )
   if usesMods && ! usesPlugins; then
     args+=(--default-category mc-mods)
   elif usesPlugins && ! usesMods; then


### PR DESCRIPTION
There is about a 34% slowdown using http/2 🤷‍♂️

Added env var `CF_USE_HTTP2` that defaults to "false"