### PR TITLE
Use mc-image-helper to install vanilla Minecraft.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,27 +80,27 @@ jobs:
             platforms: linux/amd64,linux/arm/v7,linux/arm64
             mcVersion: 1.16.5
             # Pin version for pre-Java 17
-            mcHelperVersion: 1.51.3-java8
+            mcHelperVersion: 1.51.4-java8
         # JAVA 11
           - variant: java11
             baseImage: adoptopenjdk:11-jre-hotspot
             platforms: linux/amd64,linux/arm/v7,linux/arm64
             mcVersion: 1.16.4
             # Pin version for pre-Java 17
-            mcHelperVersion: 1.51.3-java8
+            mcHelperVersion: 1.51.4-java8
         # JAVA 8: NOTE: Unable to go past 8u312 because of Forge dependencies
           - variant: java8
             baseImage: eclipse-temurin:8u312-b07-jre-focal
             platforms: linux/amd64,linux/arm/v7,linux/arm64
             mcVersion: 1.12.2
             # Pin version for Java 8, also be sure to set in verify-pr.yml
-            mcHelperVersion: 1.51.3-java8
+            mcHelperVersion: 1.51.4-java8
           - variant: java8-jdk
             baseImage: eclipse-temurin:8u312-b07-jdk-focal
             platforms: linux/amd64,linux/arm64
             mcVersion: 1.12.2
             # Pin version for Java 8, also be sure to set in verify-pr.yml
-            mcHelperVersion: 1.51.3-java8
+            mcHelperVersion: 1.51.4-java8
     env:
       # Assume they line up, but when forked change to your Docker Hub username
       DOCKER_HUB_ORG: ${{ github.repository_owner }}

--- a/.github/workflows/verify-pr.yml
+++ b/.github/workflows/verify-pr.yml
@@ -47,6 +47,7 @@ jobs:
             mcVersion: 1.20.4
             # For GLIBC_2.34 support
             knockdRepoOrg: Metalcape/knock
+        # JAVA 8:
           - variant: java8
             baseImage: eclipse-temurin:8u312-b07-jre-focal
             platforms: linux/amd64
@@ -54,7 +55,7 @@ jobs:
             # For GLIBC_2.34 support
             knockdRepoOrg: Metalcape/knock
             # Pin version for Java 8, be sure to also set in build.yml
-            mcHelperVersion: 1.51.3-java8
+            mcHelperVersion: 1.51.4-java8
     env:
       IMAGE_TO_TEST: ${{ github.repository_owner }}/minecraft-server:test-${{ matrix.variant }}-${{ github.run_id }}
     runs-on: ubuntu-22.04

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ RUN easy-add --var os=${TARGETOS} --var arch=${TARGETARCH}${TARGETVARIANT} \
   --from ${GITHUB_BASEURL}/itzg/{{.app}}/releases/download/{{.version}}/{{.app}}_{{.version}}_{{.os}}_{{.arch}}.tar.gz
 
 # renovate: datasource=github-releases packageName=itzg/mc-image-helper versioning=loose
-ARG MC_HELPER_VERSION=1.61.2
+ARG MC_HELPER_VERSION=1.62.0
 ARG MC_HELPER_BASE_URL=${GITHUB_BASEURL}/itzg/mc-image-helper/releases/download/${MC_HELPER_VERSION}
 # used for cache busting local copy of mc-image-helper
 ARG MC_HELPER_REV=1

--- a/scripts/start-deployVanilla
+++ b/scripts/start-deployVanilla
@@ -25,6 +25,8 @@ fi
 
 applyResultsFile "${resultsFile}"
 
+log "Successfully setup vanilla Minecraft version $VERSION"
+
 isDebugging && ls -l
 export FAMILY=VANILLA
 exec "$(dirname "$0")/start-setupWorld" "$@"

--- a/scripts/start-deployVanilla
+++ b/scripts/start-deployVanilla
@@ -8,6 +8,7 @@ set -o pipefail
 resultsFile=/data/.install-vanilla.env
 
 args=(
+  --output-directory=/data
   --results-file="${resultsFile}"
   --version="${VERSION}"
 )

--- a/scripts/start-deployVanilla
+++ b/scripts/start-deployVanilla
@@ -5,51 +5,24 @@
 isDebugging && set -x
 set -o pipefail
 
-resolveVersion
-export SERVER="minecraft_server.${VERSION// /_}.jar"
+resultsFile=/data/.install-vanilla.env
 
-if [ ! -e "$SERVER" ] || [ -n "$FORCE_REDOWNLOAD" ]; then
-  debug "Finding version manifest for $VERSION"
-  versionManifestUrl=$(get 'https://launchermeta.mojang.com/mc/game/version_manifest.json' | jq --arg VERSION "$VERSION" --raw-output '[.versions[]|select(.id == $VERSION)][0].url')
-  result=$?
-  if [ $result != 0 ]; then
-    logError "Failed to obtain version manifest URL ($result)"
-    exit 1
-  fi
-  if [ "$versionManifestUrl" = "null" ]; then
-    logError "Couldn't find a matching manifest entry for $VERSION"
-    exit 1
-  fi
-  debug "Found version manifest at $versionManifestUrl"
+args=(
+  --results-file="${resultsFile}"
+  --version="${VERSION}"
+)
 
-  if ! serverDownloadUrl=$(get --json-path '$.downloads.server.url' "${versionManifestUrl}"); then
-    logError "Failed to obtain version manifest from $versionManifestUrl ($result)"
-    exit 1
-  elif [ "$serverDownloadUrl" = "null" ]; then
-    logError "There is not a server download for version $VERSION"
-    exit 1
-  fi
-
-  log "Downloading $VERSION server..."
-  debug "Downloading server from $serverDownloadUrl"
-  get -o "$SERVER" "$serverDownloadUrl"
-  result=$?
-  if [ $result != 0 ]; then
-    logError "Failed to download server from $serverDownloadUrl ($result)"
-    exit 1
-  fi
+if isTrue "${FORCE_REDOWNLOAD}"; then
+  log "Forcing re-install of Minecraft"
+  args+=(--force-reinstall)
 fi
-minecraftServerJarPath=/data/minecraft_server.jar
 
-if versionLessThan 1.6; then
-  if ! [[ -L $minecraftServerJarPath && $minecraftServerJarPath -ef "/data/$SERVER" ]]; then
-    rm -f $minecraftServerJarPath
-    ln -s "/data/$SERVER" $minecraftServerJarPath
-  fi
-  SERVER=minecraft_server.jar
-elif [[ -L $minecraftServerJarPath ]]; then
-  rm -f $minecraftServerJarPath
+if ! mc-image-helper install-vanilla "${args[@]}"; then
+  logError "Failed to install vanilla Minecraft version $VERSION"
+  exit 1
 fi
+
+applyResultsFile "${resultsFile}"
 
 isDebugging && ls -l
 export FAMILY=VANILLA


### PR DESCRIPTION
This is a prerequsitive for itzg/docker-minecraft-server#1818, and uses mc-image-helper for the vanilla install logic.

This PR will remain in draft until its prerequisite itzg/mc-image-helper#812 is merged.