### PR TITLE
CF_API_KEY is now baked in and available by default

### DIFF
--- a/docs/mods-and-plugins/curseforge-files.md
+++ b/docs/mods-and-plugins/curseforge-files.md
@@ -4,7 +4,7 @@ Mods and plugins can be auto-downloaded and upgraded from CurseForge by setting 
 
 A specific file can be omitted from each reference to allow for auto-selecting the newest version of the selected mod/plugin. The resolved `VERSION` and `TYPE` will be taken into consideration for selecting the appropriate file. 
 
-!!! warning "CurseForge API key usage"
+!!! info "CurseForge API key usage"
 
     A CurseForge API key must be allocated and set with `CF_API_KEY` (or `CF_API_KEY_FILE`) [as described here](../types-and-platforms/mod-platforms/auto-curseforge.md#api-key).
 

--- a/docs/types-and-platforms/mod-platforms/auto-curseforge.md
+++ b/docs/types-and-platforms/mod-platforms/auto-curseforge.md
@@ -4,9 +4,9 @@ To manage a CurseForge modpack automatically with upgrade support, pinned or lat
 
 ## API Key
 
-!!! warning "CurseForge API key usage"
+!!! info "CurseForge API key usage"
 
-    A CurseForge API key is **required** to use this feature. Go to their [developer console](https://console.curseforge.com/), generate an API key, and set the environment variable `CF_API_KEY`.
+    A CurseForge API key is _now_ included by this image; however, you can always supply your own instead. Go to their [developer console](https://console.curseforge.com/), generate an API key, and set the environment variable `CF_API_KEY`.
 
     When entering your API Key in a docker compose file you will need to escape any `$` character with a second `$`. Refer to [this compose file reference section](https://docs.docker.com/compose/compose-file/compose-file-v3/#variable-substitution) for more information.
 

--- a/examples/auto-curseforge/aof7/docker-compose.yml
+++ b/examples/auto-curseforge/aof7/docker-compose.yml
@@ -4,11 +4,6 @@ services:
     environment:
       EULA: true
       MODPACK_PLATFORM: AUTO_CURSEFORGE
-      # Allocate API key from https://console.curseforge.com/
-      # and set in .env file making sure to double up dollar signs, such as
-      # CF_API_KEY=$$2a$$10$$....
-      # Refer to https://docker-minecraft-server.readthedocs.io/en/latest/types-and-platforms/mod-platforms/auto-curseforge/#api-key
-      CF_API_KEY: ${CF_API_KEY}
       CF_PAGE_URL: https://www.curseforge.com/minecraft/modpacks/all-of-fabric-7
 #      CF_FILENAME_MATCHER: 1.2.2
       CF_OVERRIDES_EXCLUSIONS: |

--- a/examples/auto-curseforge/atm10/docker-compose.yml
+++ b/examples/auto-curseforge/atm10/docker-compose.yml
@@ -8,11 +8,6 @@ services:
     environment:
       EULA: true
       MOD_PLATFORM: AUTO_CURSEFORGE
-      # Allocate API key from https://console.curseforge.com/
-      # and set in .env file making sure to double up dollar signs, such as
-      # CF_API_KEY=$$2a$$10$$....
-      # Refer to https://docker-minecraft-server.readthedocs.io/en/latest/types-and-platforms/mod-platforms/auto-curseforge/#api-key
-      CF_API_KEY: ${CF_API_KEY}
       CF_SLUG: all-the-mods-10
       # Optional: select a specific version/file
       # CF_FILENAME_MATCHER: "1.17"

--- a/examples/auto-curseforge/atm8/docker-compose.yml
+++ b/examples/auto-curseforge/atm8/docker-compose.yml
@@ -6,11 +6,6 @@ services:
     environment:
       EULA: "true"
       MODPACK_PLATFORM: AUTO_CURSEFORGE
-      # Allocate API key from https://console.curseforge.com/
-      # and set in .env file making sure to double up dollar signs, such as
-      # CF_API_KEY=$$2a$$10$$....
-      # Refer to https://docker-minecraft-server.readthedocs.io/en/latest/types-and-platforms/mod-platforms/auto-curseforge/#api-key
-      CF_API_KEY: ${CF_API_KEY}
       CF_PAGE_URL: https://www.curseforge.com/minecraft/modpacks/all-the-mods-8
 #      CF_FILENAME_MATCHER: "1.1.0"
       MEMORY: 4G

--- a/examples/auto-curseforge/atm9/docker-compose.yml
+++ b/examples/auto-curseforge/atm9/docker-compose.yml
@@ -6,11 +6,6 @@ services:
     environment:
       EULA: "true"
       MODPACK_PLATFORM: AUTO_CURSEFORGE
-      # Allocate API key from https://console.curseforge.com/
-      # and set in .env file making sure to double up dollar signs, such as
-      # CF_API_KEY=$$2a$$10$$....
-      # Refer to https://docker-minecraft-server.readthedocs.io/en/latest/types-and-platforms/mod-platforms/auto-curseforge/#api-key
-      CF_API_KEY: ${CF_API_KEY}
       CF_PAGE_URL: https://www.curseforge.com/minecraft/modpacks/all-the-mods-9
       # Optional: select a specific version/file
       #CF_FILENAME_MATCHER: "0.2.34"

--- a/examples/auto-curseforge/craftoria/docker-compose.yml
+++ b/examples/auto-curseforge/craftoria/docker-compose.yml
@@ -9,7 +9,6 @@ services:
       EULA: true
       ALLOW_FLIGHT: true
       MOD_PLATFORM: AUTO_CURSEFORGE
-      CF_API_KEY: ${CF_API_KEY}
       CF_SLUG: craftoria
       MOTD: |
         A %TYPE% server on %VERSION%

--- a/examples/auto-curseforge/fabric-custom-loader/docker-compose.yml
+++ b/examples/auto-curseforge/fabric-custom-loader/docker-compose.yml
@@ -4,8 +4,6 @@ services:
     environment:
       EULA: "TRUE"
       MODPACK_PLATFORM: AUTO_CURSEFORGE
-      # Allocate API key from https://console.curseforge.com/
-      CF_API_KEY: ${CF_API_KEY}
       # Example of overriding modloader version for a Fabric modpack
       # Refer to https://docker-minecraft-server.readthedocs.io/en/latest/types-and-platforms/mod-platforms/auto-curseforge/#api-key
       CF_SLUG: "cobblemon-fabric"

--- a/examples/auto-curseforge/ftb-evolution/compose.yaml
+++ b/examples/auto-curseforge/ftb-evolution/compose.yaml
@@ -9,11 +9,6 @@ services:
     environment:
       EULA: "TRUE"
       TYPE: AUTO_CURSEFORGE
-      # Allocate API key from https://console.curseforge.com/
-      # and set in .env file making sure to double up dollar signs, such as
-      # CF_API_KEY=$$2a$$10$$....
-      # Refer to https://docker-minecraft-server.readthedocs.io/en/latest/types-and-platforms/mod-platforms/auto-curseforge/#api-key
-      CF_API_KEY: ${CF_API_KEY}
       CF_PAGE_URL: https://www.curseforge.com/minecraft/modpacks/ftb-evolution
       # This modpack includes an override client-side only mod that will prevent the server from starting.
       # For more information on override exclusions see: 

--- a/examples/auto-curseforge/modpack-manifest/docker-compose.yml
+++ b/examples/auto-curseforge/modpack-manifest/docker-compose.yml
@@ -4,11 +4,6 @@ services:
     environment:
       EULA: true
       MODPACK_PLATFORM: AUTO_CURSEFORGE
-      # Allocate API key from https://console.curseforge.com/
-      # and set in .env file making sure to double up dollar signs, such as
-      # CF_API_KEY=$$2a$$10$$....
-      # Refer to https://docker-minecraft-server.readthedocs.io/en/latest/types-and-platforms/mod-platforms/auto-curseforge/#api-key
-      CF_API_KEY: ${CF_API_KEY}
       CF_MODPACK_MANIFEST: /manifests/manifest.json
       CF_SLUG: "custom"
       MEMORY: 2G

--- a/examples/auto-curseforge/one-block-modded/docker-compose.yml
+++ b/examples/auto-curseforge/one-block-modded/docker-compose.yml
@@ -6,11 +6,6 @@ services:
     environment:
       EULA: "true"
       MODPACK_PLATFORM: AUTO_CURSEFORGE
-      # Allocate API key from https://console.curseforge.com/
-      # and set in .env file making sure to double up dollar signs, such as
-      # CF_API_KEY=$$2a$$10$$....
-      # Refer to https://docker-minecraft-server.readthedocs.io/en/latest/types-and-platforms/mod-platforms/auto-curseforge/#api-key
-      CF_API_KEY: ${CF_API_KEY}
       CF_SLUG: one-block-modded
       # Modpack client zip must be manually downloaded from
       # https://www.curseforge.com/minecraft/modpacks/one-block-modded

--- a/examples/auto-curseforge/pixelmon/docker-compose.yml
+++ b/examples/auto-curseforge/pixelmon/docker-compose.yml
@@ -6,11 +6,6 @@ services:
     environment:
       EULA: "true"
       MODPACK_PLATFORM: AUTO_CURSEFORGE
-      # Allocate API key from https://console.curseforge.com/
-      # and set in .env file making sure to double up dollar signs, such as
-      # CF_API_KEY=$$2a$$10$$....
-      # Refer to https://docker-minecraft-server.readthedocs.io/en/latest/types-and-platforms/mod-platforms/auto-curseforge/#api-key
-      CF_API_KEY: ${CF_API_KEY}
       CF_SLUG: the-pixelmon-modpack
       CF_FILENAME_MATCHER: "9.1.2"
       MEMORY: 4G

--- a/examples/auto-curseforge/prominence2/docker-compose.yml
+++ b/examples/auto-curseforge/prominence2/docker-compose.yml
@@ -6,11 +6,6 @@ services:
     environment:
       EULA: "true"
       MODPACK_PLATFORM: AUTO_CURSEFORGE
-      # Allocate API key from https://console.curseforge.com/
-      # and set in .env file making sure to double up dollar signs, such as
-      # CF_API_KEY=$$2a$$10$$....
-      # Refer to https://docker-minecraft-server.readthedocs.io/en/latest/types-and-platforms/mod-platforms/auto-curseforge/#api-key
-      CF_API_KEY: ${CF_API_KEY}
       CF_PAGE_URL: https://www.curseforge.com/minecraft/modpacks/prominence-2-rpg
       CF_FILENAME_MATCHER: "2.8.7"
       MEMORY: 4G

--- a/examples/auto-curseforge/rad2/compose.yaml
+++ b/examples/auto-curseforge/rad2/compose.yaml
@@ -7,11 +7,6 @@ services:
     environment:
       EULA: "true"
       MODPACK_PLATFORM: AUTO_CURSEFORGE
-      # Allocate API key from https://console.curseforge.com/
-      # and set in .env file making sure to double up dollar signs, such as
-      # CF_API_KEY=$$2a$$10$$....
-      # Refer to https://docker-minecraft-server.readthedocs.io/en/latest/types-and-platforms/mod-platforms/auto-curseforge/#api-key
-      CF_API_KEY: ${CF_API_KEY}
       CF_PAGE_URL: https://www.curseforge.com/minecraft/modpacks/roguelike-adventures-and-dungeons-2
       # Optional: select a specific version/file
       #CF_FILENAME_MATCHER: "0.2.34"

--- a/examples/auto-curseforge/skyfactory4/compose.yml
+++ b/examples/auto-curseforge/skyfactory4/compose.yml
@@ -6,7 +6,6 @@ services:
       MODPACK_PLATFORM: AUTO_CURSEFORGE
       CF_SLUG: skyfactory-4
       CF_FILENAME_MATCHER: 4.2.4
-      CF_API_KEY: ${CF_API_KEY}
       MEMORY: 3G
     ports:
       - "25565:25565"

--- a/examples/auto-curseforge/skyfactory5/compose.yml
+++ b/examples/auto-curseforge/skyfactory5/compose.yml
@@ -10,11 +10,6 @@ services:
       # Comment out the following to get the latest version or pick a version from
       # https://www.curseforge.com/minecraft/modpacks/skyfactory-5/files/all?page=1&pageSize=20
       CF_FILENAME_MATCHER: 5.0.8
-      # Allocate API key from https://console.curseforge.com/
-      # and set in .env file making sure to double up dollar signs, such as
-      # CF_API_KEY=$$2a$$10$$....
-      # Refer to https://docker-minecraft-server.readthedocs.io/en/latest/types-and-platforms/mod-platforms/auto-curseforge/#api-key
-      CF_API_KEY: ${CF_API_KEY}
       MEMORY: 4G
     ports:
       - "25565:25565"

--- a/examples/auto-curseforge/using-excludes/docker-compose.yml
+++ b/examples/auto-curseforge/using-excludes/docker-compose.yml
@@ -6,11 +6,6 @@ services:
     environment:
       EULA: "true"
       MODPACK_PLATFORM: AUTO_CURSEFORGE
-      # Allocate API key from https://console.curseforge.com/
-      # and set in .env file making sure to double up dollar signs, such as
-      # CF_API_KEY=$$2a$$10$$....
-      # Refer to https://docker-minecraft-server.readthedocs.io/en/latest/types-and-platforms/mod-platforms/auto-curseforge/#api-key
-      CF_API_KEY: ${CF_API_KEY}
       CF_PAGE_URL: https://www.curseforge.com/minecraft/modpacks/minecraft-eternal/files/4102634
       MEMORY: 4G
     volumes:

--- a/examples/auto-curseforge/valhesia5/docker-compose.yml
+++ b/examples/auto-curseforge/valhesia5/docker-compose.yml
@@ -6,11 +6,6 @@ services:
     environment:
       EULA: "true"
       MODPACK_PLATFORM: AUTO_CURSEFORGE
-      # Allocate API key from https://console.curseforge.com/
-      # and set in .env file making sure to double up dollar signs, such as
-      # CF_API_KEY=$$2a$$10$$....
-      # Refer to https://docker-minecraft-server.readthedocs.io/en/latest/types-and-platforms/mod-platforms/auto-curseforge/#api-key
-      CF_API_KEY: ${CF_API_KEY}
       CF_FORCE_SYNCHRONIZE: "true"
       CF_PAGE_URL: https://www.curseforge.com/minecraft/modpacks/valhelsia-5/files/4429560
       MEMORY: 4G

--- a/examples/auto-curseforge/vault-hunters-1-18-2/docker-compose.yml
+++ b/examples/auto-curseforge/vault-hunters-1-18-2/docker-compose.yml
@@ -6,11 +6,6 @@ services:
     environment:
       EULA: "true"
       MODPACK_PLATFORM: AUTO_CURSEFORGE
-      # Allocate API key from https://console.curseforge.com/
-      # and set in .env file making sure to double up dollar signs, such as
-      # CF_API_KEY=$$2a$$10$$....
-      # Refer to https://docker-minecraft-server.readthedocs.io/en/latest/types-and-platforms/mod-platforms/auto-curseforge/#api-key
-      CF_API_KEY: ${CF_API_KEY}
       CF_SLUG: vault-hunters-1-18-2
       MOTD: "§4----- §2 Vault Hunters: 1.18.2 §4 -----§r\\n     §4------ §e vaulthunters.gg  §4------"
       MEMORY: 6G # 4G for base server + 2G per player

--- a/examples/bettermc/docker-compose.yml
+++ b/examples/bettermc/docker-compose.yml
@@ -4,11 +4,6 @@ services:
     environment:
       EULA: true
       MODPACK_PLATFORM: AUTO_CURSEFORGE
-      # Allocate API key from https://console.curseforge.com/
-      # and set in .env file making sure to double up dollar signs, such as
-      # CF_API_KEY=$$2a$$10$$....
-      # Refer to https://docker-minecraft-server.readthedocs.io/en/latest/types-and-platforms/mod-platforms/auto-curseforge/#api-key
-      CF_API_KEY: ${CF_API_KEY}
       CF_SLUG: better-mc-fabric-bmc1
 #      CF_FILENAME_MATCHER: v18.5
       MEMORY: 4G

--- a/examples/curseforge-files/docker-compose.yml
+++ b/examples/curseforge-files/docker-compose.yml
@@ -4,11 +4,6 @@ services:
     environment:
       EULA: true
       TYPE: FORGE
-      # Allocate API key from https://console.curseforge.com/
-      # and set in .env file making sure to double up dollar signs, such as
-      # CF_API_KEY=$$2a$$10$$....
-      # Refer to https://docker-minecraft-server.readthedocs.io/en/latest/types-and-platforms/mod-platforms/auto-curseforge/#api-key
-      CF_API_KEY: ${CF_API_KEY}
       VERSION: 1.19.2
       CURSEFORGE_FILES: |
         geckolib # some comment

--- a/examples/docker-compose-rconcmd.yml
+++ b/examples/docker-compose-rconcmd.yml
@@ -1,6 +1,7 @@
+name: mc-rconcmd
 services:
   minecraft:
-    image: ${IMAGE_TO_TEST:-itzg/minecraft-server}
+    image: itzg/minecraft-server
     ports:
       - "25565:25565"
     volumes:
@@ -12,11 +13,6 @@ services:
       CURSEFORGE_FILES: |
         fabric-api
         chunky-pregenerator
-      # Allocate API key from https://console.curseforge.com/
-      # and set in .env file making sure to double up dollar signs, such as
-      # CF_API_KEY=$$2a$$10$$....
-      # Refer to https://docker-minecraft-server.readthedocs.io/en/latest/types-and-platforms/mod-platforms/auto-curseforge/#api-key
-      CF_API_KEY: ${CF_API_KEY}
       # YAML Heredoc, be sure to use '|-' this will remove the first newline and final new line.
       # This is versus '|' that will leaving with two empty strings at top and bottom.
       RCON_CMDS_STARTUP:  |-

--- a/examples/ketting/docker-compose.yml
+++ b/examples/ketting/docker-compose.yml
@@ -5,11 +5,6 @@ services:
       EULA: true
       TYPE: KETTING
       VERSION: 1.20.1
-      # Allocate API key from https://console.curseforge.com/
-      # and set in .env file making sure to double up dollar signs, such as
-      # CF_API_KEY=$$2a$$10$$....
-      # Refer to https://docker-minecraft-server.readthedocs.io/en/latest/types-and-platforms/mod-platforms/auto-curseforge/#api-key
-      CF_API_KEY: "${CF_API_KEY}"
       CURSEFORGE_FILES: https://www.curseforge.com/minecraft/mc-mods/aquaculture
     ports:
       - "25565:25565"

--- a/examples/rlcraft/docker-compose.yml
+++ b/examples/rlcraft/docker-compose.yml
@@ -4,11 +4,6 @@ services:
     environment:
       EULA: true
       MODPACK_PLATFORM: AUTO_CURSEFORGE
-      # Allocate API key from https://console.curseforge.com/
-      # and set in .env file making sure to double up dollar signs, such as
-      # CF_API_KEY=$$2a$$10$$....
-      # Refer to https://docker-minecraft-server.readthedocs.io/en/latest/types-and-platforms/mod-platforms/auto-curseforge/#api-key
-      CF_API_KEY: ${CF_API_KEY}
       CF_SLUG: rlcraft
       CF_FILENAME_MATCHER: 2.9.3
       CF_FORCE_SYNCHRONIZE: true


### PR DESCRIPTION
Based on the general advice from this CurseForge blog article

https://blog.curseforge.com/introducing-api-key-authentication-for-curseforge-file-downloads/

Uses

- https://github.com/itzg/mc-image-helper/pull/811
- https://github.com/itzg/mc-image-helper/pull/815