### PR TITLE
Added PREFER_IPv6 to simplify Java setup for IPv6 addresses and stack

### DIFF
--- a/docs/configuration/misc-options.md
+++ b/docs/configuration/misc-options.md
@@ -179,6 +179,10 @@ such as:
 
 You may configure the use of an HTTP/HTTPS proxy by passing the proxy's "host:port" via the environment variable `PROXY`. In [the example compose file](https://github.com/itzg/docker-minecraft-server/blob/master/examples/proxied/compose.yml) it references a Squid proxy. The host and port can be separately passed via the environment variables `PROXY_HOST` and `PROXY_PORT`. A `|` delimited list of hosts to exclude from proxying can be passed via `PROXY_NON_PROXY_HOSTS`.
 
+## Prefer IPv6 Addresses and Stack
+
+The image can be configured to prefer IPv6 addresses and stack by setting the environment variable `PREFER_IPV6` to "true". This will ensure the Java properties `java.net.preferIPv6Addresses` and `java.net.preferIPv6Stack` are set accordingly for mc-image-helper and the Minecraft server process.
+
 ## Using "noconsole" option
 
 Some older versions (pre-1.14) of Spigot required `--noconsole` to be passed when detaching stdin, which can be done by setting `-e CONSOLE=FALSE`.

--- a/scripts/start-configuration
+++ b/scripts/start-configuration
@@ -7,6 +7,7 @@ IFS=$'\n\t'
 
 : "${EULA:=}"
 : "${PROXY:=}"
+: "${PREFER_IPV6:=false}"
 : "${ENABLE_AUTOPAUSE:=false}"
 : "${ENABLE_AUTOSTOP:=false}"
 : "${RCON_CMDS_STARTUP:=}"
@@ -27,6 +28,13 @@ export MEMORY INIT_MEMORY MAX_MEMORY
 shopt -s nullglob
 
 isDebugging && set -x
+
+if isTrue "$PREFER_IPV6"; then
+  MC_IMAGE_HELPER_OPTS+="-Djava.net.preferIPv6Addresses=true -Djava.net.preferIPv6Stack=true"
+  export MC_IMAGE_HELPER_OPTS
+  JVM_DD_OPTS+="java.net.preferIPv6Addresses=true java.net.preferIPv6Stack=true"
+  export JVM_DD_OPTS
+fi
 
 if (( $(mc-image-helper java-release) >= 17 )); then
   MC_IMAGE_HELPER_OPTS+=" --enable-native-access=ALL-UNNAMED"


### PR DESCRIPTION
Also helped to test https://github.com/itzg/mc-router/issues/574