### PR TITLE
Revert "Switch to permissions for auto-release workflow (#4163)"

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -8,11 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     # If forked, changed to your username to enable auto-releases
     if: github.repository_owner == 'itzg'
-    permissions:
-      # allow for creating releases/tags
-      contents: write
     steps:
       - uses: zenengeo/github-auto-release-action@main
         with:
           stable-duration: 3d
-          force-duration: 14d  
+          force-duration: 14d
+          token: '${{ secrets.GH_TOKEN }}'
+

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -13,5 +13,8 @@ jobs:
         with:
           stable-duration: 3d
           force-duration: 14d
+          # It is important to use a token other than the workflow allocated GITHUB_TOKEN,
+          # since actions prevent loops by disallowing recursive workflow triggers with that token.
+          # In this case, the created tag needs to trigger the "Build and Publish" workflow.
           token: '${{ secrets.GH_TOKEN }}'
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,7 @@ on:
       - "zensical.toml"
       - ".readthedocs.yaml"
       - "renovate.json5"
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
Reverts #4163 and adds docs so I won't do it again

> By default, actions executed using the standard repository token (GITHUB_TOKEN) cannot trigger other workflow runs. If your auto-release workflow creates a release or pushes a tag using the implicit GITHUB_TOKEN, GitHub explicitly drops any subsequent webhook events (like a push to a tag) that would normally trigger other actions.