### PR TITLE
Fix GraalVM flag selection when USE_MEOWICE_FLAGS is not set

### DIFF
--- a/scripts/start-finalExec
+++ b/scripts/start-finalExec
@@ -213,8 +213,11 @@ fi
 : "${USE_MEOWICE_FLAGS:=false}"
 : "${USE_MEOWICE_GRAALVM_FLAGS:=false}"
 
-if isTrue "${USE_MEOWICE_FLAGS}"; then
+if isTrue "${USE_MEOWICE_FLAGS}" || isTrue "${USE_MEOWICE_GRAALVM_FLAGS}"; then
   java_major_version=$(mc-image-helper java-release)
+fi
+
+if isTrue "${USE_MEOWICE_FLAGS}"; then
   if [[ $java_major_version -gt 16 ]]; then
     log "Java version $java_major_version using MeowIce's flags for Java 17+"
   else


### PR DESCRIPTION
Fixes #3881.

Setting `USE_MEOWICE_GRAALVM_FLAGS=true` without also setting `USE_MEOWICE_FLAGS` makes the JVM exit at startup on any GraalVM 25 image: `Error parsing Graal options: Could not find option OptWriteMotion`. This reproduces on the currently published `java25-graalvm` tag, so it is not tied to the variants being rebuilt.

`java_major_version` is assigned at `start-finalExec:217`, inside the `USE_MEOWICE_FLAGS` guard, but it is read at `:350` inside the `USE_MEOWICE_GRAALVM_FLAGS` block. With only the latter set the variable is never assigned, and since an unset value compares as `0`, `[[ $java_major_version -gt 23 ]]` is false and the pre-Java-24 flag set is emitted — including `-Dgraal.OptWriteMotion=true`, which GraalVM removed in 25 and whose parser treats an unknown option as fatal.

This assigns the version when either flag is set. The other three combinations emit exactly the same command line as before.

<details><summary>Details, if useful</summary>

`-Dgraal.OptWriteMotion=true` passed to `java -version` directly:

| image | result |
| --- | --- |
| Oracle GraalVM 21.0.12 | starts, exit 0 |
| Oracle GraalVM 25.0.4 | `Could not find option OptWriteMotion`, `A fatal exception has occurred`, exit 1 |
| `itzg/minecraft-server:java25-graalvm` as published (25.0.1) | same, exit 1 |

Which branch each combination takes, checked with `SETUP_ONLY=true` on a GraalVM 25 image and reading the printed `SETUP_ONLY: java ...` line:

| `USE_MEOWICE_FLAGS` | `USE_MEOWICE_GRAALVM_FLAGS` | branch | `OptWriteMotion` emitted |
| --- | --- | --- | --- |
| unset | unset | block skipped | no |
| set | unset | block skipped | no |
| unset | set | `Using MeowIce's flags for Graalvm` | **yes** — the failure |
| set | set | `Java 24 or higher detected` | no |

With this change the third row becomes `Java 24 or higher detected` and stops emitting the option; the other three rows are unchanged, which I checked by diffing the printed command lines. The modern flag set on its own was also run against GraalVM 25.0.4 to confirm it starts cleanly.

Verification used the script mount from the development docs — `-v .../start-finalExec:/image/scripts/start-finalExec:ro` — rather than rebuilding, and `bash -n` passes on the modified script.

Choosing `USE_MEOWICE_FLAGS || USE_MEOWICE_GRAALVM_FLAGS` rather than hoisting the assignment unconditionally keeps `mc-image-helper java-release` from running on every start for the majority of users who set neither.

</details>
