### PR TITLE
Restore the GraalVM image variants

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,10 +30,13 @@ jobs:
           - java25
           - java25-alpine
           - java25-jdk
+          - java25-graalvm
           - java21
           - java21-alpine
+          - java21-graalvm
           - java21-jdk
           - java17
+          - java17-graalvm
           - java16
           - java11
           - java8
@@ -54,6 +57,10 @@ jobs:
             baseImage: eclipse-temurin:25
             platforms: linux/amd64,linux/arm64
             mcVersion: latest
+          - variant: java25-graalvm
+            baseImage: container-registry.oracle.com/graalvm/jdk:25-ol10
+            platforms: linux/amd64,linux/arm64
+            mcVersion: latest
         # JAVA 21:
           - variant: java21
             baseImage: eclipse-temurin:21-jre
@@ -67,11 +74,19 @@ jobs:
             baseImage: eclipse-temurin:21-jre-alpine
             platforms: linux/amd64,linux/arm64
             mcVersion: 1.21.11
+          - variant: java21-graalvm
+            baseImage: container-registry.oracle.com/graalvm/jdk:21-ol10
+            platforms: linux/amd64,linux/arm64
+            mcVersion: 1.21.11
         # JAVA 17:
           - variant: java17
             # jammy doesn't work until minecraft updates to https://github.com/netty/netty/issues/12343
             baseImage: eclipse-temurin:17-jre-focal
             platforms: linux/amd64,linux/arm/v7,linux/arm64
+            mcVersion: 1.20.4
+          - variant: java17-graalvm
+            baseImage: container-registry.oracle.com/graalvm/jdk:17-ol10
+            platforms: linux/amd64,linux/arm64
             mcVersion: 1.20.4
         # JAVA 16
           - variant: java16

--- a/.github/workflows/verify-pr.yml
+++ b/.github/workflows/verify-pr.yml
@@ -75,6 +75,9 @@ jobs:
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4.2.0
+
       - name: Confirm multi-arch build
         uses: docker/build-push-action@v7
         with:

--- a/.github/workflows/verify-pr.yml
+++ b/.github/workflows/verify-pr.yml
@@ -24,6 +24,7 @@ jobs:
         variant:
           - java25
           - java25-alpine
+          - java25-graalvm
           - java17
           - java8
         include:
@@ -39,6 +40,11 @@ jobs:
             mcVersion: latest
             # For GLIBC_2.34 support (and Alpine)
             knockdRepoOrg: Metalcape/knock
+          - variant: java25-graalvm
+            # stay aligned with build.yml
+            baseImage: container-registry.oracle.com/graalvm/jdk:25-ol10
+            platforms: linux/amd64,linux/arm64
+            mcVersion: latest
         # JAVA 17:
           - variant: java17
             # jammy doesn't work until minecraft updates to https://github.com/netty/netty/issues/12343

--- a/build/ol/install-packages.sh
+++ b/build/ol/install-packages.sh
@@ -66,16 +66,12 @@ fi
 # Clean up DNF when done
 dnf clean all
 
-cat <<EOF > /usr/local/sbin/knockd
-#!/bin/sh
-
-echo "Auto-pause (using knockd) is currently unavailable on graalvm image variants"
-echo "Consider using a different image variant https://docker-minecraft-server.readthedocs.io/en/latest/versions/java/"
-echo "or mc-router's auto scale up/down feature https://github.com/itzg/mc-router#docker-auto-scale-updown"
-exit 2
-EOF
-chmod 755 /usr/local/sbin/knockd
-# TODO restore retrieval from https://github.com/Metalcape/knock when tar's "Cannot open: Invalid argument" is solved
+# Download and install patched knockd
+curl -fsSL -o /tmp/knock.tar.gz https://github.com/Metalcape/knock/releases/download/0.8.1/knock-0.8.1-$TARGET.tar.gz
+tar -xf /tmp/knock.tar.gz -C /usr/local/ && rm /tmp/knock.tar.gz
+ln -s /usr/local/sbin/knockd /usr/sbin/knockd
+ls -l /usr/local/sbin/knockd
+setcap cap_net_raw=ep /usr/local/sbin/knockd
 
 # Set git credentials globally
 cat <<EOF >> /etc/gitconfig

--- a/build/ol/setup-user.sh
+++ b/build/ol/setup-user.sh
@@ -1,2 +1,6 @@
+#!/bin/sh
+
+set -e
+
 groupadd --gid 1000 minecraft
 useradd --system --shell /bin/false --uid 1000 -g minecraft --home /data minecraft

--- a/docs/versions/java.md
+++ b/docs/versions/java.md
@@ -17,10 +17,13 @@ where `<tag>` refers to the first column of this table:
 | java25        | 25           | Ubuntu | Hotspot     | amd64, arm64, riscv64 |      |
 | java25-alpine | 25           | Alpine | Hotspot     | amd64, arm64          |      |
 | java25-jdk    | 25           | Ubuntu | Hotspot+JDK | amd64, arm64          |      |
+| java25-graalvm | 25          | Oracle | Oracle GraalVM | amd64, arm64       | (2)(3) |
 | java21        | 21           | Ubuntu | Hotspot     | amd64, arm64          |      |
 | java21-jdk    | 21           | Ubuntu | Hotspot+JDK | amd64, arm64          |      |
 | java21-alpine | 21           | Alpine | Hotspot     | amd64, arm64          |      |
+| java21-graalvm | 21          | Oracle | Oracle GraalVM | amd64, arm64       | (2)(3) |
 | java17        | 17           | Ubuntu | Hotspot     | amd64, arm64, armv7   |      |
+| java17-graalvm | 17          | Oracle | Oracle GraalVM | amd64, arm64       | (2)(3) |
 | java16        | 16           | Ubuntu | Hotspot     | amd64, arm64, armv7   | (1)  |
 | java11        | 11           | Ubuntu | Hotspot     | amd64, arm64, armv7   |      |
 | java8         | 8            | Ubuntu | Hotspot     | amd64, arm64, armv7   |      |
@@ -28,6 +31,8 @@ where `<tag>` refers to the first column of this table:
 Notes
 
 1. This version of Java is [recommended for PaperMC 1.16.5](https://docs.papermc.io/paper/getting-started/#requirements)
+2. Based on the [Oracle GraalVM images](https://blogs.oracle.com/java/post/new-oracle-graalvm-container-images), which as of JDK 17, are now under the [GraalVM Free License](https://blogs.oracle.com/java/post/graalvm-free-license) incorporating what used to be known as the GraalVM Enterprise.
+3. Due to these images using Oracle Linux, (which is based on Red Hat Enterprise Linux) Forge Installer will not work due to its use of zlib-ng. Use other images for initial installation and Forge version upgrade.
 
 !!! example "Example using java8"
 
@@ -121,7 +126,6 @@ Forge also doesn't support openj9 JVM implementation.
 
 The following image tags have been deprecated and are no longer receiving updates:
 
-- java25-graalvm, java21-graalvm, java17-graalvm
 - adopt13
 - adopt14
 - adopt15


### PR DESCRIPTION
You said in #4203 that you would be interested in putting these back if the builds work again, so here is the change with what I have to support that.

The three variants are re-added to the matrix with their original base images, the docs table and its two notes are restored, and the knockd retrieval that #3893 stubbed out is put back. That last one is included because the images published before the variants were dropped still contain the real `knockd` binary — restoring the variants without it would be the first GraalVM images to ship the stub, and would silently take auto-pause away from anyone using it on those tags.

Builds pass on my fork for all three variants, amd64 and arm64: https://github.com/OowhitecatoO/docker-minecraft-server/actions/runs/30679759114. The `tar: Cannot open: Invalid argument` failure behind #3899 did not reappear, including with the knockd retrieval restored: https://github.com/OowhitecatoO/docker-minecraft-server/actions/runs/30649087679.

I did not restore `java8-graalvm-ce`. It is the only one on the community edition from ghcr rather than Oracle GraalVM, and it looked like it had been left behind long before this.

Separately, I have been through what upstream MeowIce has changed since those flags were copied into the image, and will send a small PR for that on its own.

<details><summary>Details, if useful</summary>

What I can and cannot claim about the build failure: I could not find out why it failed in January, only that it does not fail now. The runs above are on current `master` with the matrix trimmed to the GraalVM variants and the test step skipped, so that the multi-arch build step is reached quickly; nothing else in the build path is modified. If it turns out to have been intermittent, this brings it back.

Beyond the CI builds I also ran the images: two real modded servers, NeoForge 1.21.1 on a locally built `java25-graalvm` and Forge 1.19.2 on `java21-graalvm`, both migrated from the frozen published images with no configuration change. Both reached `Done`, passed the health check and answered RCON. Locally built images report Oracle GraalVM 21.0.12 and 25.0.4, against 21.0.9 and 25.0.1 in the last published ones, so the base image tags have kept moving while nothing was rebuilding them.

Docs changes: the three rows go back into the tag table with the two notes they used to carry — the Oracle GraalVM licence note, and the one about Forge Installer not working on Oracle Linux because of zlib-ng — and the tags come out of the deprecated list.

</details>
