### PR TITLE
Enable compact object headers on Java 24+

### DIFF
--- a/scripts/start-finalExec
+++ b/scripts/start-finalExec
@@ -347,6 +347,11 @@ if isTrue "${USE_MEOWICE_FLAGS}"; then
   else
     log "cpu not x86_64, disabling architecture specific flags"
   fi
+  if [[ $java_major_version -gt 23 ]]; then
+    JVM_XX_OPTS="${JVM_XX_OPTS}
+    -XX:+UseCompactObjectHeaders
+    "
+  fi
 fi
 
 if isTrue "${USE_MEOWICE_GRAALVM_FLAGS}"; then


### PR DESCRIPTION
This is the small follow-up I mentioned in #4205. Upstream MeowIce has added `-XX:+UseCompactObjectHeaders` since the flag set was copied into the image, and of everything that changed it is the one worth picking up on its own.

It is gated on Java 24 or newer because the option does not exist before that, and an unrecognised `-XX:` option is fatal — emitting it unconditionally would stop `USE_MEOWICE_FLAGS` from starting on the java17 and java21 images. Upstream now says its flags target Java 25+, but the image applies MeowIce's set from 17 upwards, so the gate has to live here.

The other differences from upstream are less clear-cut, so I have left the rest of the set alone.

<details><summary>Details, if useful</summary>

What it does: JEP 450 folds the class pointer into the mark word, so an object header is 8 bytes instead of 12 plus padding. Allocating 5,000,000 `new Object()` into a reachable array in a 2G heap:

| | heap used after a full GC |
|---|---|
| `-XX:-UseCompactObjectHeaders` | 99 MB |
| `-XX:+UseCompactObjectHeaders` | 61 MB |

The 5M-element `Object[]` accounts for about 19 MiB of that on both sides, so the objects themselves go from roughly 16 bytes to 8.

Version compatibility:

| Java | flag |
|---|---|
| 17, 21 | does not exist — fatal |
| 24 | `{experimental}`, default false |
| 25 | `{product}`, default false |

On 24 it has to be preceded by `-XX:+UnlockExperimentalVMOptions`, which the block already emits well before this point.

Verified by generating the flag set with `USE_MEOWICE_FLAGS` and starting a JVM with it on each version:

| image | `UseCompactObjectHeaders` emitted | `java -version` |
|---|---|---|
| `eclipse-temurin:17-jre` | no | rc=0 |
| `eclipse-temurin:21-jre-noble` | no | rc=0 |
| `eclipse-temurin:24-jre` | yes | rc=0 |
| `eclipse-temurin:25-jre-noble` | yes | rc=0 |

</details>
