### PR TITLE
Remove redundant CF_API_KEY_FILE handling

### DIFF
--- a/scripts/start-deployAutoCF
+++ b/scripts/start-deployAutoCF
@@ -22,21 +22,10 @@ set -eu
 : "${CF_DOWNLOADS_REPO=$([ -d /downloads ] && echo '/downloads' || echo '')}"
 : "${CF_MODPACK_MANIFEST:=}"
 : "${CF_API_CACHE_DEFAULT_TTL:=}" # as ISO-8601 duration, such as P2D or PT12H
-: "${CF_API_KEY_FILE:=}" # Path to file containing CurseForge API key
 : "${CF_MOD_LOADER_VERSION:=}" # Override mod loader version
 : "${CF_USE_HTTP2:=false}" # CF downloads are faster with HTTP 1.1
 
 resultsFile=/data/.install-curseforge.env
-
-if [[ -n ${CF_API_KEY_FILE} ]]; then
-  if [[ -r "${CF_API_KEY_FILE}" ]]; then
-    CF_API_KEY="$(cat "${CF_API_KEY_FILE}")"
-    export CF_API_KEY
-  else
-    logError "CF_API_KEY_FILE is not readable: ${CF_API_KEY_FILE}"
-    exit 1
-  fi
-fi
 
 isDebugging && set -x
 

--- a/scripts/start-setupModpack
+++ b/scripts/start-setupModpack
@@ -9,22 +9,11 @@ set -e -o pipefail
 : "${PLUGINS_FILE:=}"
 : "${REMOVE_OLD_MODS_DEPTH:=1} "
 : "${REMOVE_OLD_MODS_INCLUDE:=*.jar,*-version.json}"
-: "${CF_API_KEY_FILE:=}" # Path to file containing CurseForge API key
 : "${CF_USE_HTTP2:=false}" # CF downloads are faster with HTTP 1.1
 : "${MODRINTH_LOADER:=}"
 
 # shellcheck source=start-utils
 . "$(dirname "$0")/start-utils"
-
-if [[ -n ${CF_API_KEY_FILE} ]]; then
-  if [[ -r "${CF_API_KEY_FILE}" ]]; then
-    CF_API_KEY="$(cat "${CF_API_KEY_FILE}")"
-    export CF_API_KEY
-  else
-    logError "CF_API_KEY_FILE is not readable: ${CF_API_KEY_FILE}"
-    exit 1
-  fi
-fi
 
 isDebugging && set -x
 


### PR DESCRIPTION
Closes #4218

mc-image-helper now loads the CurseForge API key from `CF_API_KEY_FILE` itself.
Remove the duplicate file reading, export, and error handling from
`start-deployAutoCF` and `start-setupModpack` so that behavior has one owner.

Validation:

- `bash -n scripts/start-deployAutoCF scripts/start-setupModpack`
- confirmed neither script retains a `CF_API_KEY_FILE` reference
- `git diff --check`

I could not run the Docker-based `auto_curseforge_file` setup scenario locally
because this environment has no Docker daemon or CurseForge credential.

AI assistance: OpenAI Codex helped prepare and review this narrow deletion. I
reviewed the complete diff and validation evidence and take responsibility for
the contribution.