### PR TITLE
autopause: warn when the status ping fails instead of silently never pausing

### DIFF
--- a/files/auto/autopause-fcns.sh
+++ b/files/auto/autopause-fcns.sh
@@ -34,8 +34,22 @@ mc_server_listening() {
   mc-monitor status $(use_proxy) --host "${SERVER_HOST:-localhost}" --port "$SERVER_PORT" $(use_server_list_ping) --timeout 10s >&/dev/null
 }
 
+# Tracks consecutive status-ping failures so the warning below can be rate
+# limited instead of repeating every AUTOPAUSE_PERIOD. Held in a file rather
+# than a variable because java_clients_connections is called through command
+# substitution, so it runs in a subshell and any variable it sets is lost.
+autopause_ping_failures_file="${AUTOPAUSE_PING_FAILURE_STATE:-/tmp/.autopause-status-ping-failures}"
+
+autopause_ping_failures() {
+  local count
+  count=$(cat "${autopause_ping_failures_file}" 2>/dev/null)
+  [[ ${count} =~ ^[0-9]+$ ]] || count=0
+  echo "${count}"
+}
+
 java_clients_connections() {
   local connections
+  local failures
   if java_running; then
     if ! connections=$(mc-monitor status \
         --host "${SERVER_HOST:-localhost}" \
@@ -46,6 +60,22 @@ java_clients_connections() {
       # consider it a non-zero player count if the ping fails
       # otherwise a laggy server with players connected could get paused
       connections=1
+
+      # A failing ping is indistinguishable from "a player is connected", so a
+      # ping that fails permanently means the server never pauses and nothing
+      # ever says why. Warn on the first failure, then every 30th.
+      # Logged to stderr because this function returns its value on stdout.
+      failures=$(( $(autopause_ping_failures) + 1 ))
+      echo "${failures}" > "${autopause_ping_failures_file}"
+      if [[ ${failures} -eq 1 ]] || [[ $((failures % 30)) -eq 0 ]]; then
+        logAutopause "Status ping to ${SERVER_HOST:-localhost}:${SERVER_PORT} failed (${failures} consecutive). Assuming players are connected, so the server will not pause. If this persists while nobody is online, something is blocking the status ping." >&2
+      fi
+    else
+      failures=$(autopause_ping_failures)
+      if [[ ${failures} -gt 0 ]]; then
+        logAutopause "Status ping recovered after ${failures} consecutive failures." >&2
+        rm -f "${autopause_ping_failures_file}"
+      fi
     fi
   else
     connections=0


### PR DESCRIPTION
## Problem

`java_clients_connections` treats a failed status ping as one connected player:

```bash
if ! connections=$(mc-monitor status ... --show-player-count); then
  # consider it a non-zero player count if the ping fails
  # otherwise a laggy server with players connected could get paused
  connections=1
fi
```

That fail-safe is correct for a *transient* failure — pausing a laggy server with players on it would be much worse than staying awake. But it assumes the failure is transient. When the ping fails *permanently*, the server can never observe zero players: the state machine parks in `E` ("Client connected - waiting for disconnect") and never pauses, and nothing is logged to say why.

The symptom is a server that silently never sleeps, which is indistinguishable from "someone is always playing" unless you check the JVM's process state by hand.

## How I hit it

A modpack shipping the [Connectivity](https://www.curseforge.com/minecraft/mc-mods/connectivity) mod, which is bundled in many large Forge packs. Its `malformedtraffic` filter blacklists a source after repeated packet sequences that never complete a login — which is exactly what a server-list-ping health check looks like at the packet level, repeated every `AUTOPAUSE_PERIOD` forever. About three minutes into every boot:

```
[Netty Epoll Server IO #2/WARN] [com.connectivity.Connectivity/]:
Ignoring further traffic from: 0:0:0:0:0:0:0:1%0 for repeated malformed traffic.
```

From then on the ping from loopback got no response, so `connections=1` on every cycle. Concretely:

```
07:00:35  server boots
07:03:35  Connectivity blacklists ::1
17:51:32  last player leaves
18:08:00  still running, 21% CPU, 9GB RSS, nobody online
```

`AUTOPAUSE_TIMEOUT_EST` is 180s, so it was 16 minutes overdue. Checking the rotated logs, that same block had fired on **every boot going back to mid-July** — the server had not paused once in three weeks, and there was no indication anywhere. I only found it because I was investigating something unrelated and happened to look at `ps`.

This isn't specific to that mod. Anything that makes the status ping fail persistently produces the same silent non-pausing, and the existing issues for Geyser (#1046), playit.gg (#3433), proxied servers (#3315) and non-default `SERVER_PORT` (#2666) all share the shape: autopause's detection assumption breaks under some networking arrangement, and it's hard to tell from the outside.

## Change

Warn on the first failure and every 30th after that, and log once on recovery.

Two implementation details worth calling out, since both are why this logging didn't already exist:

- **stderr, not stdout.** `logAutopause` writes to stdout, and `java_clients_connections` returns its value via stdout capture, so a naive log line would corrupt the player count. Verified the function still returns a bare integer.
- **File-backed counter.** The function is called through command substitution, so it runs in a subshell and a shell variable would reset on every call — the first version of this patch logged on *every* failure for exactly that reason. The path is overridable via `AUTOPAUSE_PING_FAILURE_STATE`.

## Testing

Harness stubbing `mc-monitor`, `java_running` and `logAutopause`, asserting the stdout contract and the rate limiting:

```
PASS  1st failure: stdout is bare '1'
PASS  1st failure: warns once
PASS  failures 2-29: stdout still '1'
PASS  failures 2-29: stays silent
PASS  30th failure: warns again
PASS  recovery: stdout is player count '2'
PASS  recovery: logs once
PASS  recovery reports count
PASS  steady state: no spam
PASS  steady state: stdout '2'
PASS  java stopped: stdout '0'
```

Happy to adjust the thresholds, wording, or drop the recovery message if you'd rather keep it minimal.
