### PR TITLE
docs: Add docs for CurseForge regex filename matcher

### DIFF
--- a/docs/types-and-platforms/mod-platforms/auto-curseforge.md
+++ b/docs/types-and-platforms/mod-platforms/auto-curseforge.md
@@ -127,7 +127,6 @@ The following examples all refer to version 1.0.7 of ATM8:
 ```
 
 ```yaml
-  # Matches filenames containing "1.0.7"
   CF_SLUG: all-the-mods-8
   CF_FILENAME_MATCHER: 1.0.7
 ```
@@ -138,6 +137,13 @@ To use a regular expression instead, surround the pattern with `/` characters:
   # Matches filenames containing a 1.0.7 version
   CF_SLUG: all-the-mods-8
   CF_FILENAME_MATCHER: '/1\.0\.7/'
+```
+
+Regular expressions can use `^` to anchor a match to the beginning of the filename and `$` to anchor it to the end. The following matches an ATM8 filename that starts with `all-the-mods-8` and ends with `1.0.7.zip`:
+
+```yaml
+  CF_SLUG: all-the-mods-8
+  CF_FILENAME_MATCHER: '/^all-the-mods-8.*1\.0\.7\.zip$/'
 ```
 
 Pinning modpack version also pins the mod loader (to the version specified by the modpack). Mod loader version cannot be pinned independently of the modpack.

--- a/docs/types-and-platforms/mod-platforms/auto-curseforge.md
+++ b/docs/types-and-platforms/mod-platforms/auto-curseforge.md
@@ -109,7 +109,7 @@ The latest modpack file and its associated mod loader will be located and instal
 
 - Use `CF_PAGE_URL`, but include the full URL to a specific file
 - Set `CF_FILE_ID` to the numerical file ID
-- Specify a substring to match the desired filename with `CF_FILENAME_MATCHER`
+- Specify either a substring or a regex pattern surrounded with "/" to match the desired filename with `CF_FILENAME_MATCHER`
 
 The following shows where to get the URL to the specific file and also shows where the file ID is located:
 
@@ -127,8 +127,17 @@ The following examples all refer to version 1.0.7 of ATM8:
 ```
 
 ```yaml
+  # Matches filenames containing "1.0.7"
   CF_SLUG: all-the-mods-8
   CF_FILENAME_MATCHER: 1.0.7
+```
+
+To use a regular expression instead, surround the pattern with `/` characters:
+
+```yaml
+  # Matches filenames containing a 1.0.7 version
+  CF_SLUG: all-the-mods-8
+  CF_FILENAME_MATCHER: '/1\.0\.7/'
 ```
 
 Pinning modpack version also pins the mod loader (to the version specified by the modpack). Mod loader version cannot be pinned independently of the modpack.

--- a/docs/types-and-platforms/mod-platforms/auto-curseforge.md
+++ b/docs/types-and-platforms/mod-platforms/auto-curseforge.md
@@ -143,7 +143,7 @@ Regular expressions can use `^` to anchor a match to the beginning of the filena
 
 ```yaml
   CF_SLUG: all-the-mods-8
-  CF_FILENAME_MATCHER: '/^all-the-mods-8.*1\.0\.7\.zip$/'
+  CF_FILENAME_MATCHER: '/^All the Mods 8-1\.0\.7\.zip$/'
 ```
 
 Pinning modpack version also pins the mod loader (to the version specified by the modpack). Mod loader version cannot be pinned independently of the modpack.

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -611,7 +611,7 @@ This image maps known server properties as described in [this section](configura
         </tr>
         <tr>
             <td><code>CF_FILENAME_MATCHER</code></td>
-            <td>Specify a substring to match the desired filename</td>
+            <td>Specify either a substring or a regex pattern surrounded with "/" to match the desired filename</td>
             <td><code></code></td>
             <td>⬜️</td>
         </tr>


### PR DESCRIPTION
Documents support for matching curseforge filenames using regex patterns, added in itzg/mc-image-helper#823, updated in itzg/docker-minecraft-server#4222