### PR TITLE
Document Java profile names for user management

### DIFF
--- a/docs/configuration/server-properties.md
+++ b/docs/configuration/server-properties.md
@@ -168,7 +168,9 @@ To [enforce the whitelist changes immediately](https://minecraft.wiki/w/Server.p
 
 !!! tip "Changing user API provider"
 
-    The usernames provided for whitelist and ops processing are resolved using either [PlayerDB](https://playerdb.co/) or [Mojang's API](https://wiki.vg/Mojang_API#Username_to_UUID). The default uses PlayerDB, but can be changed by setting the environment variable `USER_API_PROVIDER` to "mojang". Sometimes one or the other service can become overloaded, which is why there is the ability to switch providers.
+    When specifying usernames for whitelist and ops processing, use Minecraft: Java Edition profile names, not Xbox gamertags. They can differ even when they belong to the same Microsoft account. A player can review or change their Java profile name on the [Minecraft profile page](https://www.minecraft.net/en-us/msaprofile/mygames/editprofile).
+
+    Usernames are resolved using either [PlayerDB](https://playerdb.co/) or [Mojang's API](https://wiki.vg/Mojang_API#Username_to_UUID). The default uses PlayerDB, but can be changed by setting the environment variable `USER_API_PROVIDER` to "mojang". Sometimes one or the other service can become overloaded, which is why there is the ability to switch providers.
 
 
 ### Op/Administrator Players


### PR DESCRIPTION
Closes #3460

Clarifies that username-based whitelist and operator entries for the Java Edition server must use the player’s Java profile name rather than an Xbox gamertag, and links to the Minecraft profile page where users can verify it.

Validation: built the documentation with the repository-pinned Zensical dependencies using `zensical build --strict` (no issues found).