### PR TITLE
Add warning for missing .gtnh-version file when using SKIP_GTNH_UPDATE_CHECK

### DIFF
--- a/scripts/start-deployGTNH
+++ b/scripts/start-deployGTNH
@@ -312,6 +312,9 @@ function handleGTNH() {
     fi
   else
     log "SKIP_GTNH_UPDATE_CHECK=$SKIP_GTNH_UPDATE_CHECK ... Skipping GTNH Update/Install"
+    if [[ ! -f /data/.gtnh-version ]]; then
+      logWarning "No .gtnh-version file detected! There might not be a valid GTNH server installation in /data. Please ensure that the server files are present or set SKIP_GTNH_UPDATE_CHECK=false to allow the script to download and install the server files."
+    fi
   fi
 }
 


### PR DESCRIPTION
In reference to #4227 this pr aims to add a warning message if no `.gtnh-version` file is found, indicating that no server files are installed. It can only be triggered if `SKIP_GTNH_UPDATE_CHECK=true`. 