### PR TITLE
Add AutoStopper to related projects

### DIFF
--- a/docs/misc/related-projects.md
+++ b/docs/misc/related-projects.md
@@ -29,3 +29,7 @@ A tool that is bundled with this image to provide complex, re-usable preparation
 ### [itzg/rcon](https://github.com/itzg/docker-rcon-web-admin)
 
 An image that dockerizes [rcon-web-admin](https://github.com/rcon-web-admin/rcon-web-admin).
+
+### [AutoStopper](https://github.com/Criseda/AutoStopper)
+
+A Velocity plugin that stops idle backend servers and wakes them when players connect, with readiness-aware Docker lifecycle management.


### PR DESCRIPTION
Adds AutoStopper to the Related Projects page, as discussed in #4229.

### [AutoStopper](https://github.com/Criseda/AutoStopper)

A Velocity plugin that stops idle backend servers and wakes them when players connect, with readiness-aware Docker lifecycle management.

- Docs-only change; no behavior or configuration impact.
- Entry follows the existing format of the page.
