### PR TITLE
Fix two Modrinth packs that fail to start due to excluded server-required mods

### DIFF
--- a/files/modrinth-exclude-include.json
+++ b/files/modrinth-exclude-include.json
@@ -48,7 +48,6 @@
     "fancymenu",
     "fast-ip-ping",
     "fastquit",
-    "FauxCustomEntityData",
     "feytweaks",
     "figura",
     "ForgeConfigScreens",
@@ -111,6 +110,9 @@
     "cobbleverse": {
       "excludes": [
         "cloth-config"
+      ],
+      "forceIncludes": [
+        "configurable"
       ]
     }
   }


### PR DESCRIPTION
Two Modrinth modpacks fail to start because the default exclude list drops a mod that Minecraft needs on the server. Both are one-line data fixes; no code changes.

I boot-tested both packs on a real server before and after, on `itzg/minecraft-server:java21-alpine`.

### 1. `FauxCustomEntityData` is server-required

Prominence II: Hasturian Era (`prominence-2-fabric` 4.0.1hf, Fabric 0.19.3 / MC 1.20.1) aborts at load:

```
Mod 'Open Parties PvP Support' (opacpvp) 1.0.0 requires any version of
faux-custom-entity-data, which is missing!
A potential solution has been determined, this may resolve your problem:
  - Install faux-custom-entity-data, any version.
net.fabricmc.loader.impl.FormattedException: Some of your mods are incompatible with the game or each other!
```

`FauxCustomEntityData-fabric-1.20.1-6.0.1.jar` is excluded by the `FauxCustomEntityData` entry in `globalExcludes`, but Modrinth declares [`faux-custom-entity-data`](https://modrinth.com/mod/faux-custom-entity-data) as **`server_side: required`**, and `opacpvp` hard-depends on it. Removing the entry lets the pack start.

### 2. `figura` matches `configurable` as a substring

COBBLEVERSE (`cobbleverse` 1.7.42, Fabric / MC 1.21.1) aborts at load:

```
Immediate reason: [HARD_DEP_NO_CANDIDATE neruina 3.3.3 {depends configurable @ [~3.5.2]},
                   ROOT_FORCELOAD_SINGLE neruina 3.3.3]
```

`mods/configurable-3.5.2+1.21.1-fabric.jar` is declared in `modrinth.index.json` with `env = {server: required, client: required}`, and it satisfies Neruina's `[3.5.2, 3.6-)`. It is never downloaded.

The cause is that `FileInclusionCalculator.shouldExcludeFile` matches entries as unanchored substrings of the file path, so the client-only entry `figura` matches `con`**`figura`**`ble-…jar`.

Measured rather than assumed:

- The pack manifest lists 168 files; the boot log has 145 `Downloaded` lines.
- Replaying the exclude list against the 24 missing paths matches **24/24 with no false positives or negatives** — 23 are intended client-only mods, 1 is `configurable`.
- `figura` is the **only** one of the entries that substring-matches that filename.
- There is no log line for the exclusion at any level, so this is silent.

I have scoped this PR to a `forceIncludes` for the affected pack, since that is the minimal safe fix and the pack already has an entry. The matching behaviour itself may be worth a separate look:

- The [schema](https://github.com/itzg/mc-image-helper?tab=readme-ov-file#excludeinclude-file-schema) documents these entries as "Mods by slug|id", but they are applied as substrings of the filename, so any entry that is a substring of another mod's name silently removes it.
- The obvious guard — never exclude a file the manifest marks `env.server: required` — unfortunately does not work. Across five popular packs I checked, *every* file is marked `env.server: required` (76/76, 112/112, 14/14, 129/129, 548/548), so that rule would disable the exclude list entirely. Modrinth's project-level `server_side` is the field that actually carries signal.

Happy to split this into two PRs, or to open a separate issue for the substring matching, if you'd prefer.
