### PR TITLE
Add missing HARDCORE environment variable to variables docs

### DIFF
--- a/docs/variables.md
+++ b/docs/variables.md
@@ -205,6 +205,12 @@ alternatively, you can mount: <code>/etc/localtime:/etc/localtime:ro
             <td>⬜️</td>
         </tr>
         <tr>
+            <td><code>HARDCORE</code></td>
+            <td>Enable hardcore mode. Set to <code>true</code> or <code>false</code>. This maps to the Minecraft server property <code>hardcore</code>.</td>
+            <td><code>false</code></td>
+            <td>⬜️</td>
+        </tr>
+        <tr>
             <td><code>ICON</code></td>
             <td>The url or file path for the icon image to use for the server. It will be downloaded, scaled, and converted to the proper format.</td>
             <td><code></code></td>


### PR DESCRIPTION
This PR adds the HARDCORE environment variable to the reference at variables.md, next to the similar DIFFICULTY setting.

I was visiting the docs to check whether hardcore was available as a variable and ended up blindly scrolling past the warning that the page may be outdated ...

This change documents the variable so that others can discover it more easily when looking for the corresponding server setting.