### PR TITLE
Fixed extra appended "s" in STOP_SERVER_DELAY_COMMAND

### DIFF
--- a/scripts/start-finalExec
+++ b/scripts/start-finalExec
@@ -491,7 +491,7 @@ if [[ ${STOP_SERVER_ANNOUNCE_DELAY} ]]; then
   mcServerRunnerArgs+=(--stop-server-announce-delay "${STOP_SERVER_ANNOUNCE_DELAY}s")
 fi
 if [[ ${STOP_SERVER_DELAY_COMMAND} ]]; then
-  mcServerRunnerArgs+=(--stop-server-delay-command "${STOP_SERVER_DELAY_COMMAND}s")
+  mcServerRunnerArgs+=(--stop-server-delay-command "${STOP_SERVER_DELAY_COMMAND}")
 fi
 if isTrue "${ENABLE_SSH}"; then
   mcServerRunnerArgs+=(--remote-console)


### PR DESCRIPTION
Extra appended "s" in STOP_SERVER_DELAY_COMMAND` appends to command message

itzg/minecraft-server:latest

"S" appended to final log, "Server shutting downs"
```
mc-1  | 2026-08-20T00:10:13.358Z        INFO    mc-server-runner        gracefully stopping server...
mc-1  | 2026-08-20T00:10:13.359Z        INFO    mc-server-runner        Sending shutdown command to Minecraft server
mc-1  | [00:10:13] [RCON Listener #1/INFO]: Thread RCON Client /0:0:0:0:0:0:0:1 started
mc-1  | [00:10:13] [Server thread/INFO]: [Not Secure] [Rcon] Server shutting downs
shutting down
```

Local build
```
# Local Build
mc-1  | 2026-08-19T23:50:30.803Z        INFO    mc-server-runner        gracefully stopping server...
mc-1  | 2026-08-19T23:50:30.803Z        INFO    mc-server-runner        Sending shutdown command to Minecraft server
mc-1  | [23:50:30] [RCON Listener #1/INFO]: Thread RCON Client /0:0:0:0:0:0:0:1 started
mc-1  | [23:50:30] [Server thread/INFO]: [Not Secure] [Rcon] Server shutting down
shutting down
```

refs: #4241