### PR TITLE
pin gosu, fail closed on BuildTools download, reject zip slip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ ARG KNOCKD_REPO_ORG=Metalcape/knock
 RUN --mount=target=/build,source=build \
     TARGET=${TARGETARCH}${TARGETVARIANT} \
     /build/run.sh install-packages
-COPY --from=tianon/gosu /gosu /usr/local/bin/
+COPY --from=tianon/gosu:1.19 /gosu /usr/local/bin/
 
 RUN --mount=target=/build,source=build \
     /build/run.sh setup-user

--- a/scripts/start-deployBukkitSpigot
+++ b/scripts/start-deployBukkitSpigot
@@ -43,7 +43,7 @@ function buildSpigotFromSource {
   fi
 
   logn ''
-  curl -sSL -o ${tempDir}/BuildTools.jar https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar && \
+  curl -fsSL -o "${tempDir}/BuildTools.jar" https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar && \
     java $jvmOpts -jar ${tempDir}/BuildTools.jar --rev "$VERSION" 2>&1 |tee ${spigotBuildLog}| while read l; do echo -n .; done; log "done"
 
   case ${TYPE^^} in

--- a/scripts/start-utils
+++ b/scripts/start-utils
@@ -579,6 +579,10 @@ function extract() {
 
   case "${type}" in
   application/zip)
+    if unzip -Z1 "${src}" | grep -qE '(^/)|(^\.\./)|(/\.\./)|(/\.\.$)'; then
+      logError "Refusing to extract $src because it contains path traversal entries"
+      return 1
+    fi
     unzip -o -q -d "${destDir}" "${src}" "$@"
     ;;
   application/x-tar | application/gzip | application/x-gzip | application/x-bzip2)

--- a/scripts/start-utils
+++ b/scripts/start-utils
@@ -586,9 +586,17 @@ function extract() {
     unzip -o -q -d "${destDir}" "${src}" "$@"
     ;;
   application/x-tar | application/gzip | application/x-gzip | application/x-bzip2)
+    if tar -tf "${src}" | grep -qE '(^/)|(^\.\./)|(/\.\./)|(/\.\.$)'; then
+      logError "Refusing to extract $src because it contains path traversal entries"
+      return 1
+    fi
     tar -C "${destDir}" -xf "${src}" "$@"
     ;;
   application/zstd | application/x-zstd)
+    if tar --use-compress-program=unzstd -tf "${src}" | grep -qE '(^/)|(^\.\./)|(/\.\./)|(/\.\.$)'; then
+      logError "Refusing to extract $src because it contains path traversal entries"
+      return 1
+    fi
     tar -C "${destDir}" --use-compress-program=unzstd -xf "${src}" "$@"
     ;;
   *)


### PR DESCRIPTION
## Summary

- `COPY --from=tianon/gosu` used an untagged `latest` image. Pin to `1.19`.
- Require a successful BuildTools download (`curl -fsSL`) before compiling Spigot.
- Refuse world/modpack archives whose entries contain path traversal (`../` or absolute paths) before extract. Applies to zip, tar/gz/bz2, and zstd.

## Test plan

- [x] `bash -n scripts/start-utils scripts/start-deployBukkitSpigot`
- [x] Confirmed `Dockerfile` copies `tianon/gosu:1.19`
- [x] Zip with `../evil.txt` and `/abs.txt` is rejected; clean `world/level.dat` zip extracts
- [x] Tar with `../evil.txt` is listed by `tar -tf` and rejected by the same regex; clean tar is allowed
- Full `tests/setuponlytests` Docker suite was not run here (no Docker daemon)