### PR TITLE
fix: drop extra brace in Forge/NeoForge FORCE_REINSTALL defaults

### DIFF
--- a/scripts/start-deployForge
+++ b/scripts/start-deployForge
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 : "${FORGE_VERSION:=${FORGEVERSION:-RECOMMENDED}}"
-: "${FORGE_FORCE_REINSTALL:=false}}"
+: "${FORGE_FORCE_REINSTALL:=false}"
 
 # shellcheck source=start-utils
 . "${SCRIPTS:-$(dirname "$0")}/start-utils"

--- a/scripts/start-deployNeoForge
+++ b/scripts/start-deployNeoForge
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 : "${NEOFORGE_VERSION:=latest}"
-: "${NEOFORGE_FORCE_REINSTALL:=false}}"
+: "${NEOFORGE_FORCE_REINSTALL:=false}"
 : "${NEOFORGE_INSTALLER:=}"
 
 # shellcheck source=start-utils


### PR DESCRIPTION
## Summary

- `: "${FORGE_FORCE_REINSTALL:=false}}"` (and the NeoForge copy) assigned the string `false}` when the variable was unset.
- That value is passed through as `--force-reinstall=false}`.

## Test plan

- `bash -n scripts/start-deployForge scripts/start-deployNeoForge`
- Confirmed the default assignment is now `false` in both scripts