### PR TITLE
Detect Fabric FTB App packs from run.sh

### DIFF
--- a/scripts/start-deployFTBA
+++ b/scripts/start-deployFTBA
@@ -140,9 +140,9 @@ if [[ $SERVER = run.sh ]]; then
   elif grep -q forge "$SERVER"; then
     export FAMILY=FORGE
     export TYPE=FORGE
-  elif grep -q fabric run.s; then
-      export FAMILY=FABRIC
-      export TYPE=FABRIC
+  elif grep -q fabric "$SERVER"; then
+    export FAMILY=FABRIC
+    export TYPE=FABRIC
   else
     logError "Unrecognized loader type in $SERVER"
     cat "$SERVER"


### PR DESCRIPTION
## Summary

- FTB App `run.sh` loader detection greps `$SERVER` for neoforge/forge, but grepped `run.s` for fabric.
- Fabric packs that boot via `run.sh` were reported as an unrecognized loader type.

## Test plan

- `bash -n scripts/start-deployFTBA`
- Confirmed the fabric branch now greps `"$SERVER"`, matching the other two loaders