### PR TITLE
Stop startup when a MODPACK zip cannot be extracted

### DIFF
--- a/scripts/start-setupModpack
+++ b/scripts/start-setupModpack
@@ -77,11 +77,13 @@ if [[ "$MODPACK" ]]; then
     mkdir -p "$PLUGINS_OUT_DIR"
     if ! unzip -o -d "$PLUGINS_OUT_DIR" /tmp/modpack.zip; then
       logError "Failed to unzip the modpack from ${MODPACK}"
+      exit 2
     fi
   else
     mkdir -p "$MODS_OUT_DIR"
     if ! unzip -o -d "$MODS_OUT_DIR" /tmp/modpack.zip; then
       logError "Failed to unzip the modpack from ${MODPACK}"
+      exit 2
     fi
   fi
   rm -f /tmp/modpack.zip


### PR DESCRIPTION
## Summary

- `handleModpackZip` logged unzip failures inside `if !`, which bypasses `set -e`.
- The zip was then deleted and setup continued without the mods/plugins.

## Test plan

- `bash -n scripts/start-setupModpack`
- Confirmed both unzip failure branches now `exit 2`