### PR TITLE
fix: refuse GTNH skip-update when no server is installed

### DIFF
--- a/docs/types-and-platforms/mod-platforms/gtnh.md
+++ b/docs/types-and-platforms/mod-platforms/gtnh.md
@@ -14,7 +14,7 @@ Configuration options with defaults:
 
 As GTNH is a Minecraft 1.7.10 modpack, when using it your minecraft version is set to 1.7.10 by default. The [modpack version](https://www.gtnewhorizons.com/downloads/) can be selected by setting `GTNH_PACK_VERSION` to `latest`, `latest-beta` (formerly `latest-dev`) or any specific version number. `latest` will automatically select the latest full release version available and deploy the server with it (Note: this will also automatically update the server on startup). `latest-beta` does the same but selects the latest version marked as beta or RC (it won't select a full release version even if a newer exist). The third (and recommended) option is setting the server to a specific version like `2.8.1` to manage updates manually.
 
-> To actively prevent an update from happening you can set the environment variable `SKIP_GTNH_UPDATE_CHECK` to true this will prevent any update check from running, but will also prevent the server install from running, so just set it after the initial setup.
+> To freeze the installed pack version, set `SKIP_GTNH_UPDATE_CHECK` to true *after* the initial install. It skips both update checks and installs, so using it on an empty data directory will fail startup rather than launching without server files.
 
 ## Resource requirements
 

--- a/scripts/start-deployGTNH
+++ b/scripts/start-deployGTNH
@@ -313,7 +313,9 @@ function handleGTNH() {
   else
     log "SKIP_GTNH_UPDATE_CHECK=$SKIP_GTNH_UPDATE_CHECK ... Skipping GTNH Update/Install"
     if [[ ! -f /data/.gtnh-version ]]; then
-      logWarning "No .gtnh-version file detected! There might not be a valid GTNH server installation in /data. Please ensure that the server files are present or set SKIP_GTNH_UPDATE_CHECK=false to allow the script to download and install the server files."
+      logError "SKIP_GTNH_UPDATE_CHECK is true, but no GTNH server is installed in /data."
+      logError "Unset SKIP_GTNH_UPDATE_CHECK (or set it to false) for the initial install, then set it to true to freeze the installed version."
+      exit 1
     fi
   fi
 }


### PR DESCRIPTION
## Summary

- `SKIP_GTNH_UPDATE_CHECK=true` on a fresh volume skipped the install and continued.
- Java 17+ then failed with `Error: could not open java9args.txt` (#4227).
- Exit with a clear error instead of a warning and a broken launch.

## Test plan

- `bash -n scripts/start-deployGTNH`
- Confirmed the no-`.gtnh-version` path now `logError` + `exit 1`