### PR TITLE
Honor cd failure when starting a CurseForge pack

### DIFF
--- a/scripts/start-finalExec
+++ b/scripts/start-finalExec
@@ -500,7 +500,7 @@ fi
 if [[ ${TYPE} == "CURSEFORGE" && "${SERVER}" ]]; then
   copyFilesForCurseForge
 
-  cd "${FTB_DIR}" || (logError "Can't go into ${FTB_DIR}"; exit 1)
+  cd "${FTB_DIR}" || { logError "Can't go into ${FTB_DIR}"; exit 1; }
   log "Starting CurseForge server in ${FTB_DIR}..."
   if isTrue "${DEBUG_EXEC}"; then
     set -x
@@ -541,7 +541,7 @@ fi
     fi
   fi
 
-  cd "${FTB_DIR}" || (logError "Can't go into ${FTB_DIR}"; exit 1)
+  cd "${FTB_DIR}" || { logError "Can't go into ${FTB_DIR}"; exit 1; }
   log "Running FTB ${FTB_SERVER_START} in ${FTB_DIR} ..."
 
   finalArgs="${FTB_SERVER_START}"

--- a/scripts/start-finalExec
+++ b/scripts/start-finalExec
@@ -500,7 +500,10 @@ fi
 if [[ ${TYPE} == "CURSEFORGE" && "${SERVER}" ]]; then
   copyFilesForCurseForge
 
-  cd "${FTB_DIR}" || { logError "Can't go into ${FTB_DIR}"; exit 1; }
+  if ! cd "${FTB_DIR}"; then
+    logError "Can't go into ${FTB_DIR}"
+    exit 1
+  fi
   log "Starting CurseForge server in ${FTB_DIR}..."
   if isTrue "${DEBUG_EXEC}"; then
     set -x

--- a/scripts/start-finalExec
+++ b/scripts/start-finalExec
@@ -544,7 +544,10 @@ fi
     fi
   fi
 
-  cd "${FTB_DIR}" || { logError "Can't go into ${FTB_DIR}"; exit 1; }
+  if ! cd "${FTB_DIR}"; then
+    logError "Can't go into ${FTB_DIR}"
+    exit 1
+  fi
   log "Running FTB ${FTB_SERVER_START} in ${FTB_DIR} ..."
 
   finalArgs="${FTB_SERVER_START}"


### PR DESCRIPTION
## Summary

- `cd \"\${FTB_DIR}\" || (logError ...; exit 1)` runs `exit` in a subshell.
- A missing `FTB_DIR` did not stop the parent script, which could then exec the server from `/data`.

## Test plan

- `bash -n scripts/start-finalExec`
- Confirmed both CurseForge `cd` sites now use `{ logError ...; exit 1; }`