### PR TITLE
Fail closed when CUSTOM_SERVER download returns an HTTP error

### DIFF
--- a/scripts/start-deployCustom
+++ b/scripts/start-deployCustom
@@ -16,8 +16,8 @@ if isURL "${CUSTOM_SERVER}"; then
     log "Using previously downloaded jar at ${SERVER}"
   else
    log "Downloading custom server jar from ${CUSTOM_SERVER} ..."
-   if ! curl -sSL -o "${SERVER}" "${CUSTOM_SERVER}"; then
-      log "Failed to download from ${CUSTOM_SERVER}"
+   if ! curl -fsSL -o "${SERVER}" "${CUSTOM_SERVER}"; then
+      logError "Failed to download from ${CUSTOM_SERVER}"
       exit 2
     fi
   fi


### PR DESCRIPTION
## Summary

- `TYPE=CUSTOM` downloaded `CUSTOM_SERVER` with `curl -sSL`, which treats 404 as success.
- The error body was then used as the server jar.
- Require `-f` and log the failure as an error.

## Test plan

- `bash -n scripts/start-deployCustom`
- Confirmed the download uses `curl -fsSL` and `logError`