### PR TITLE
Prune CurseForge libraries/mods using relative find paths

### DIFF
--- a/scripts/start-deployCF
+++ b/scripts/start-deployCF
@@ -127,7 +127,7 @@ if ! isTrue "${USE_MODPACK_START_SCRIPT:-true}"; then
     echo "${FTB_SERVER_MOD}" > $installMarker
   fi
 
-  SERVER=$(find "${FTB_BASE_DIR}" -maxdepth 2 -type f \( -path "/libraries/*" -o -path "/mods/*" \) -prune -o -name "forge*.jar" -not -name "forge*installer.jar" -print)
+  SERVER=$(find "${FTB_BASE_DIR}" -maxdepth 2 -type f \( -path "*/libraries/*" -o -path "*/mods/*" \) -prune -o -name "forge*.jar" -not -name "forge*installer.jar" -print)
   if [[ -z "${SERVER}" || ! -f "${SERVER}" ]]; then
     logError "Unable to locate installed forge server jar"
     isDebugging && find "${FTB_BASE_DIR}" -name "forge*.jar"
@@ -200,7 +200,7 @@ if [[ ! $startScript ]]; then
   # no, then look for a forge jar to run
 
   # Allow up to 2 levels since some modpacks have a top-level directory named for the modpack
-  forgeJar=$(find "${FTB_BASE_DIR}" -maxdepth 2 -type f \( -path "/libraries/*" -o -path "/mods/*" \) -prune -o -name "forge*.jar" -not -name "forge*installer.jar" -print)
+  forgeJar=$(find "${FTB_BASE_DIR}" -maxdepth 2 -type f \( -path "*/libraries/*" -o -path "*/mods/*" \) -prune -o -name "forge*.jar" -not -name "forge*installer.jar" -print)
   if [[ "$forgeJar" ]]; then
     FTB_BASE_DIR=$(dirname "${forgeJar}")
     export FTB_BASE_DIR


### PR DESCRIPTION
## Summary

- Two `find` callers used `-path /libraries/*` / `-path /mods/*`, which only match those absolute locations.
- Jars under the pack'\''s own `libraries/` or `mods/` were therefore not pruned.
- The other finder in the same script already used `*/libraries/*`; align the remaining two.

## Test plan

- `bash -n scripts/start-deployCF`
- Confirmed both remaining finds now prune `*/libraries/*` and `*/mods/*`