### PR TITLE
fix quadlet example socket access

### DIFF
--- a/examples/podman-quadlets/README.md
+++ b/examples/podman-quadlets/README.md
@@ -37,6 +37,8 @@ ln -s ${XDG_CONFIG_HOME}/containers/systemd/mc@.service ${XDG_CONFIG_HOME}/conta
 
 If running rootless, be sure to enable lingering with `sudo loginctl enable-linger $USER`.
 
+`GroupAdd=0` when rootless the equivalent of the user's group id, not the hosts root.
+
 Also note that source IPs are currently lost due to how rootless podman handles custom networks.
 This should be fixed in a future podman release.[^3]
 

--- a/examples/podman-quadlets/mc-router.container
+++ b/examples/podman-quadlets/mc-router.container
@@ -6,6 +6,7 @@ Image=docker.io/itzg/mc-router
 ContainerName=%N
 AutoUpdate=registry
 UserNS=host
+GroupAdd=0
 Volume=%t/podman/podman.sock:/var/run/docker.sock:ro
 Network=minecraft.network
 PublishPort=25565:25565


### PR DESCRIPTION
Adds the group to support v1.46.0+
