### PR TITLE
Stop figura exclude from matching configurable jars

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ RUN easy-add --var os=${TARGETOS} --var arch=${TARGETARCH}${TARGETVARIANT} \
   --from ${GITHUB_BASEURL}/itzg/{{.app}}/releases/download/{{.version}}/{{.app}}_{{.version}}_{{.os}}_{{.arch}}.tar.gz
 
 # renovate: datasource=github-releases packageName=itzg/mc-image-helper versioning=loose
-ARG MC_HELPER_VERSION=1.66.1
+ARG MC_HELPER_VERSION=1.67.0
 ARG MC_HELPER_BASE_URL=${GITHUB_BASEURL}/itzg/mc-image-helper/releases/download/${MC_HELPER_VERSION}
 # used for cache busting local copy of mc-image-helper
 ARG MC_HELPER_REV=1

--- a/docs/types-and-platforms/mod-platforms/modrinth-modpacks.md
+++ b/docs/types-and-platforms/mod-platforms/modrinth-modpacks.md
@@ -50,9 +50,7 @@ Some mods, such as [MCInstance Loader](https://modrinth.com/mod/mcinstance-loade
 
 ## Excluding files
 
-To exclude client mods that are incorrectly declared by the modpack as server-compatible, set `MODRINTH_EXCLUDE_FILES` to a comma or newline delimited list of partial file names to exclude. You may need to set `MODRINTH_FORCE_SYNCHRONIZE` to "true" while iterating on a compatible set of mods to use.
-
-Each entry is matched as a case-insensitive substring of the file path. Short names can collide with other mods — for example `figura` also matches `configurable-*.jar`. Prefer a more distinctive fragment such as `figura-`. Entries wrapped in slashes, such as `/(^|/)figura-/`, are treated as regex when using mc-image-helper 1.67 or later.
+To exclude client mods that are incorrectly declared by the modpack as server-compatible, set `MODRINTH_EXCLUDE_FILES` to a comma or newline delimited list of file name matchers. Each entry is a case-insensitive substring of the file path, or a regular expression if surrounded with `/` (same convention as [`CF_FILENAME_MATCHER`](auto-curseforge.md#pinning-modpack-and-mod-loader-versions)). You may need to set `MODRINTH_FORCE_SYNCHRONIZE` to "true" while iterating on a compatible set of mods to use.
 
 !!! example
 
@@ -66,7 +64,7 @@ Each entry is matched as a case-insensitive substring of the file path. Short na
 
 ## Force-include files
 
-To force include client mods, set `MODRINTH_FORCE_INCLUDE_FILES` to a comma or newline delimited list of partial file names. You may need to set `MODRINTH_FORCE_SYNCHRONIZE` to "true" while iterating on a compatible set of mods to use.
+To force include client mods, set `MODRINTH_FORCE_INCLUDE_FILES` to a comma or newline delimited list of file name matchers using the same substring or `/regex/` rules as `MODRINTH_EXCLUDE_FILES`. You may need to set `MODRINTH_FORCE_SYNCHRONIZE` to "true" while iterating on a compatible set of mods to use.
 
 !!! example
 

--- a/docs/types-and-platforms/mod-platforms/modrinth-modpacks.md
+++ b/docs/types-and-platforms/mod-platforms/modrinth-modpacks.md
@@ -52,6 +52,8 @@ Some mods, such as [MCInstance Loader](https://modrinth.com/mod/mcinstance-loade
 
 To exclude client mods that are incorrectly declared by the modpack as server-compatible, set `MODRINTH_EXCLUDE_FILES` to a comma or newline delimited list of partial file names to exclude. You may need to set `MODRINTH_FORCE_SYNCHRONIZE` to "true" while iterating on a compatible set of mods to use.
 
+Each entry is matched as a case-insensitive substring of the file path. Short names can collide with other mods — for example `figura` also matches `configurable-*.jar`. Prefer a more distinctive fragment such as `figura-`. Entries wrapped in slashes, such as `/(^|/)figura-/`, are treated as regex when using mc-image-helper 1.67 or later.
+
 !!! example
 
     In a Compose file:

--- a/files/modrinth-exclude-include.json
+++ b/files/modrinth-exclude-include.json
@@ -49,7 +49,7 @@
     "fast-ip-ping",
     "fastquit",
     "feytweaks",
-    "figura",
+    "figura-",
     "ForgeConfigScreens",
     "GeckoLibIrisCompat",
     "gpumemleakfix",

--- a/files/modrinth-exclude-include.json
+++ b/files/modrinth-exclude-include.json
@@ -49,7 +49,7 @@
     "fast-ip-ping",
     "fastquit",
     "feytweaks",
-    "figura-",
+    "/(^|/)figura-/",
     "ForgeConfigScreens",
     "GeckoLibIrisCompat",
     "gpumemleakfix",
@@ -110,9 +110,6 @@
     "cobbleverse": {
       "excludes": [
         "cloth-config"
-      ],
-      "forceIncludes": [
-        "configurable"
       ]
     }
   }


### PR DESCRIPTION
Fixes #4234

Default Modrinth exclude entries are unanchored path substrings, so `figura` also matched `configurable-*.jar` and dropped a server-required mod. The global exclude is now `/(^|/)figura-/`, using the slash-delimited regex matcher from mc-image-helper 1.67.

The cobbleverse `configurable` force-include is removed; it only existed to cover that collision. Helper is bumped 1.66.1 → 1.67.0 so the regex is actually evaluated.

## Test plan

- [x] `/(^|/)figura-/` matches `mods/figura-0.1.5+1.21.jar`
- [x] `/(^|/)figura-/` does not match `mods/configurable-3.5.2+1.21.1-fabric.jar`
- [x] No other `globalExcludes` entry matches that configurable filename