### PR TITLE
Note java8 CurseForge installs need CF_API_KEY

### DIFF
--- a/docs/mods-and-plugins/curseforge-files.md
+++ b/docs/mods-and-plugins/curseforge-files.md
@@ -6,7 +6,7 @@ A specific file can be omitted from each reference to allow for auto-selecting t
 
 !!! info "CurseForge API key usage"
 
-    A CurseForge API key is _now_ included by this image; however, you can always supply your own instead. A CurseForge API key can be allocated and set with `CF_API_KEY` (or `CF_API_KEY_FILE`) [as described here](../types-and-platforms/mod-platforms/auto-curseforge.md#api-key).
+    A CurseForge API key is _now_ included by this image on Java 17 and newer; however, you can always supply your own instead. A CurseForge API key can be allocated and set with `CF_API_KEY` (or `CF_API_KEY_FILE`) [as described here](../types-and-platforms/mod-platforms/auto-curseforge.md#api-key). The `java8` image (and other pre-Java 17 tags) does not include a baked-in key; set `CF_API_KEY` yourself.
 
 ## Project-file references
 

--- a/docs/types-and-platforms/mod-platforms/auto-curseforge.md
+++ b/docs/types-and-platforms/mod-platforms/auto-curseforge.md
@@ -6,7 +6,9 @@ To manage a CurseForge modpack automatically with upgrade support, pinned or lat
 
 !!! info "CurseForge API key usage"
 
-    A CurseForge API key is _now_ included by this image; however, you can always supply your own instead. Go to their [developer console](https://console.curseforge.com/), generate an API key, and set the environment variable `CF_API_KEY`.
+    A CurseForge API key is _now_ included by this image on Java 17 and newer; however, you can always supply your own instead. Go to their [developer console](https://console.curseforge.com/), generate an API key, and set the environment variable `CF_API_KEY`.
+
+    The `java8` image (and other pre-Java 17 tags) does **not** include that key. Set `CF_API_KEY` yourself, or install the pack on a Java 17+ image first. See [Java 8](../../versions/java.md#java-8).
 
     When entering your API Key in a docker compose file you will need to escape any `$` character with a second `$`. Refer to [this compose file reference section](https://docs.docker.com/compose/compose-file/compose-file-v3/#variable-substitution) for more information.
 

--- a/docs/versions/java.md
+++ b/docs/versions/java.md
@@ -111,7 +111,11 @@ Caused by: org.spongepowered.asm.mixin.throwables.ClassMetadataNotFoundException
 
 #### Java 8
 
-For Forge versions less than 1.18, you _must_ use the `java8-multiarch` (or other java8) image tag.
+For Forge versions less than 1.18, you _must_ use the `java8` (or other java8) image tag.
+
+!!! warning "Java 8 is in maintenance mode"
+
+    The `java8` / `java8-jdk` tags, and other pre-Java 17 tags (`java11`, `java16`), pin an older `mc-image-helper` that predates the baked-in CurseForge API key. `AUTO_CURSEFORGE` and `CURSEFORGE_FILES` on those images require you to set `CF_API_KEY` yourself. Java 17+ images include a key and do not need this.
 
 In general, if you see the following line in a server startup failure, then it means you need to be using Java 8 instead of the latest image Java version:
 


### PR DESCRIPTION
Fixes #4226

Documents the existing Java 8 helper pin: pre-Java 17 images do not include the baked-in CurseForge API key, so `AUTO_CURSEFORGE` / `CURSEFORGE_FILES` need `CF_API_KEY`. Also notes that Java 8 is in maintenance mode, as discussed on the issue.

## Test plan

- [x] Cross-links from Auto CurseForge and CURSEFORGE_FILES docs to the Java 8 section
- [x] Java 8 section states the helper pin and the need to set `CF_API_KEY`