### PR TITLE
fix: remove managed files when MODRINTH_PROJECTS is empty

### DIFF
--- a/docs/mods-and-plugins/modrinth.md
+++ b/docs/mods-and-plugins/modrinth.md
@@ -80,7 +80,7 @@ Where:
 
 !!! note "Auto-removal"
 
-    Entries that are removed from the `MODRINTH_PROJECTS` list will be automatically removed from the `mods` or `plugins` directory. This is useful for removing mods/plugins that are no longer needed. An empty `MODRINTH_PROJECTS` list will remove all mods/plugins.
+    Entries that are removed from the `MODRINTH_PROJECTS` list will be automatically removed from the `mods` or `plugins` directory. This is useful for removing mods/plugins that are no longer needed. Setting `MODRINTH_PROJECTS` to an empty string removes all previously managed project-files, the same as `CURSEFORGE_FILES`.
 
 !!! note "Disable processing"
 

--- a/scripts/start-setupModpack
+++ b/scripts/start-setupModpack
@@ -306,14 +306,22 @@ function handleModrinthProjects() {
       loader="${TYPE,,}"
     fi
 
-    mc-image-helper modrinth \
-      --output-directory=/data \
-      --world-directory="${LEVEL:-world}" \
-      --projects="${MODRINTH_PROJECTS}" \
-      --game-version="${VERSION}" \
-      --loader="$loader" \
-      --download-dependencies="$MODRINTH_DOWNLOAD_DEPENDENCIES" \
+    args=(
+      --output-directory=/data
+      --world-directory="${LEVEL:-world}"
+      --game-version="${VERSION}"
+      --loader="$loader"
+      --download-dependencies="$MODRINTH_DOWNLOAD_DEPENDENCIES"
       --allowed-version-type="$MODRINTH_PROJECTS_DEFAULT_VERSION_TYPE"
+    )
+    # An empty list still invokes the helper so previously managed files are
+    # removed, matching CURSEFORGE_FILES. Comment the variable out to skip.
+    if [[ -n "${MODRINTH_PROJECTS}" ]]; then
+      args+=(--projects="${MODRINTH_PROJECTS}")
+    else
+      log "MODRINTH_PROJECTS is empty; removing previously managed project files"
+    fi
+    mc-image-helper modrinth "${args[@]}"
   fi
 }
 

--- a/tests/setuponlytests/modrinth-empty-projects/docker-compose.yml
+++ b/tests/setuponlytests/modrinth-empty-projects/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  mc:
+    image: ${IMAGE_TO_TEST:-itzg/minecraft-server}
+    environment:
+      EULA: "true"
+      SETUP_ONLY: "true"
+      TYPE: CUSTOM
+      CUSTOM_SERVER: /servers/fake.jar
+      VERSION: 1.21.4
+      MODRINTH_LOADER: paper
+      # Empty string must still run the helper so previously managed files are removed
+      MODRINTH_PROJECTS: ""
+    volumes:
+      - ./data:/data
+      - ./fake.jar:/servers/fake.jar

--- a/tests/setuponlytests/modrinth-empty-projects/prepare.sh
+++ b/tests/setuponlytests/modrinth-empty-projects/prepare.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -euo pipefail
+
+rm -rf data
+mkdir -p data/plugins
+printf 'managed-plugin\n' > data/plugins/tabtps-spigot-1.3.26.jar
+cat > data/.modrinth-manifest.json <<'EOF'
+{"@type":"me.itzg.helpers.modrinth.ModrinthManifest","timestamp":"2026-01-01T00:00:00Z","files":["plugins/tabtps-spigot-1.3.26.jar"],"projects":["tabtps"]}
+EOF

--- a/tests/setuponlytests/modrinth-empty-projects/verify.sh
+++ b/tests/setuponlytests/modrinth-empty-projects/verify.sh
@@ -1,0 +1,2 @@
+mc-image-helper assert fileNotExists "plugins/tabtps-spigot-1.3.26.jar"
+mc-image-helper assert fileNotExists ".modrinth-manifest.json"

--- a/tests/setuponlytests/test.sh
+++ b/tests/setuponlytests/test.sh
@@ -41,6 +41,10 @@ setupOnlyMinecraftTest(){
     fi
   fi
 
+  if [ -f prepare.sh ]; then
+    bash prepare.sh
+  fi
+
   # false positive since it's used in delta calculations below
   # shellcheck disable=SC2034
   start=$(date +%s)


### PR DESCRIPTION
Fixes #3339

Empty `MODRINTH_PROJECTS` now still invokes `mc-image-helper modrinth` so previously managed mods/plugins are removed, matching `CURSEFORGE_FILES`. Comment the variable out to skip processing.

## Test plan

- [x] `docker run -e MODRINTH_PROJECTS=tabtps` then `-e MODRINTH_PROJECTS=` removes `plugins/tabtps-*.jar`
- [x] Seeded `.modrinth-manifest.json` + dummy plugin, scripts mounted from this branch, empty `MODRINTH_PROJECTS` logs the new message and deletes both the jar and the manifest
- [x] `IMAGE_TO_TEST=itzg/minecraft-server:latest bash tests/setuponlytests/test.sh ./modrinth-empty-projects` — PASSED