### PR TITLE
Fix Fantasy MC Fabric failing to start due to excluded server-required mods

### DIFF
--- a/files/cf-exclude-include.json
+++ b/files/cf-exclude-include.json
@@ -187,6 +187,9 @@
     "create-arcane-engineering": {
       "forceIncludes": ["just-enough-resources-jer"]
     },
+    "fantasy-minecraft-fabric": {
+      "forceIncludes": ["simply-tooltips", "icon-leading-tooltip"]
+    },
     "ftb-stoneblock-4": {
       "forceIncludes": [
         "particular-reforged",


### PR DESCRIPTION
[Fantasy MC Fabric](https://www.curseforge.com/minecraft/modpacks/fantasy-minecraft-fabric) (`fantasy-minecraft-fabric`, 1.87M downloads) fails to start on `Fantasy MC [1.21.1]-0.3.3 [BETA]` (532141:8471683). One-line data fix; no code changes.

I boot-tested on `itzg/minecraft-server:java21-alpine` (revision `9100b32`, current master at time of testing), before and after, on clean volumes.

### Symptom

```
[main/ERROR]: Incompatible mods found!
 - Mod 'Show Me Your Build' (showmeyourbuild) 1.0.4 requires any version of icon-leading-tooltip, which is missing!
 - Mod 'Simply Bows' (simplybows) 0.1.2 requires any version of simplytooltips, which is missing!
 - Mod 'Simply More' (simplymore) 1.2.3 requires version 0.1.3 or later of simplytooltips, which is missing!
 - Mod 'Simply Swords' (simplyswords) 1.63.0-1.21.1 requires any version of simplytooltips, which is missing!
```

Both libraries are in the manifest, `required: true`, `allowModDistribution: true`. Neither is in `globalExcludes`. They are dropped by `isServerMod` in `CurseForgeInstaller`, because their CurseForge files carry the `Client` entry under `sortableGameVersions` (`gameVersionTypeId` 75208).

### The two cases are different, and only one is a mis-tag

I checked `fabric.mod.json` inside each jar rather than assuming:

| mod | declared `environment` | CurseForge `Client` tag |
|---|---|---|
| `simplytooltips` | `"*"` | **wrong** |
| `icon-leading-tooltip` | `"client"` | accurate |

- **`simplytooltips` is genuinely server-side.** It declares `environment: "*"`, has a `main` entrypoint, and on the fixed boot it loads and initialises on the dedicated server (`SimplyTooltips config loaded: simplytooltips:config`). It is the classic incorrectly-tagged-as-client-only case. Its three dependents — `simplyswords`, `simplymore`, `simplybows` — all declare `environment: "*"` themselves.
- **`icon-leading-tooltip` really is client-only**, so its tag is correct. But `showmeyourbuild` declares `environment: "*"` and hard-`depends` on it, and `rpg-systems` (also `"*"`) hard-depends on `showmeyourbuild`. Fabric needs the jar present to resolve, then env-disables it — it does not appear in the loaded-mod list on the server, so force-including it is inert at runtime and only satisfies resolution.

So the fix is not "ship two client mods on a server". It is one genuine mis-tag plus one upstream mod declaring a client-only hard dependency without marking itself client-only.

### Measured

| | before | after |
|---|---|---|
| mod files downloaded | 357 | 359 |
| unmet hard dependencies | 4 | 0 |
| result | `exit 1` | `Done (21.544s)`, RCON responsive, 516 mods loaded |

The `+2` is exactly the two jars; nothing else changed. Verified both via `CF_FORCE_INCLUDE_MODS` and via this patched `cf-exclude-include.json` mounted with `CF_EXCLUDE_INCLUDE_FILE` — identical outcome, so the entry is what does the work.

The `Incompatible mods found!` block also contains a line about `c2me-opts-natives-math` requiring Java 25. That one resolves itself: it is an optional JIJ module, and once the genuinely-missing dependencies are supplied Fabric solves without it and boots on Java 21 (its 17 sibling `c2me` submodules load normally). It is co-reported in the solver's unsatisfiable set, not a separate blocker — no Java 25 needed.

### Possibly worth a separate look

The two exclusion paths log asymmetrically. The configured path logs at `INFO`:

```java
log.info("Excluding mod file '{}' ({}) due to configuration", ...)
```

while the `Client`-tag path logs at `debug`:

```java
log.debug("Skipping {} since it is a client mod", cfFile.getFileName());
```

On this pack the silent path dropped **38** mods and the logged path **29**, so the larger and more surprising of the two is invisible at default log level. Reconciling the manifest against the boot log was the only way to find which files went missing. Happy to open a separate PR raising that one line to `info` if you think it is worth it.
