### PR TITLE
build: update COPY stage image versions with Renovate

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -10,6 +10,16 @@
       "matchStrings": [
         "# renovate: datasource=(?<datasource>[a-z-]+?)(?: packageName=(?<packageName>.+?))?(?: versioning=(?<versioning>[a-z-]+))?\\s(?:ENV|ARG) .+?_VERSION=(?<currentValue>.+?)\\s"
       ]
+    },
+    {
+      "customType": "regex",
+      "description": "Update versioned images used by Dockerfile COPY --from instructions",
+      "managerFilePatterns": ["/^Dockerfile$/"],
+      "matchStrings": [
+        "COPY --from=(?<depName>[^:\\s]+):(?<currentValue>[^\\s]+)\\s"
+      ],
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "docker"
     }
   ],
   "labels": ["dependencies"]


### PR DESCRIPTION
Closes #4248.

Adds a narrow Renovate regex manager for versioned images in Dockerfile `COPY --from=` instructions. It extracts `tianon/gosu:1.19` as a Docker dependency without enabling the broader Dockerfile manager.

Validation:
- `renovate-config-validator renovate.json5`
- Renovate local extract dry run (detected `tianon/gosu` at `1.19` with Docker versioning)
- `git diff --check`
